### PR TITLE
Add cors annotations and auth header configurable

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/codegen/model/BallerinaService.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/codegen/model/BallerinaService.java
@@ -33,6 +33,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Wrapper for {@link Swagger}.
@@ -160,6 +161,9 @@ public class BallerinaService implements BallerinaSwaggerObject<BallerinaService
         key = key.replaceAll("/", "_");
         key = key.replaceAll("\\{", "_");
         key = key.replaceAll("}", "_");
+        if (key.contains("*")) {
+            key = key.replaceAll("\\*", UUID.randomUUID().toString().replaceAll("-", "_"));
+        }
         return key;
     }
 

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/codegen/service/APIServiceImpl.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/codegen/service/APIServiceImpl.java
@@ -52,7 +52,7 @@ public class APIServiceImpl implements APIService {
                 apiListDTO = mapper.readValue(responseStr, APIListDTO.class);
                 for (ExtendedAPI api : apiListDTO.getList()) {
                     String endpointConfig = api.getEndpointConfig();
-                    api.setEndpointConfigRepresentation(getEndpointConfig(endpointConfig)); 
+                    api.setEndpointConfigRepresentation(getEndpointConfig(endpointConfig));
                 }
             } else {
                 throw new RuntimeException("Error occurred while getting token. Status code: " + responseCode);

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/codegen/service/bean/APIDetailedDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/codegen/service/bean/APIDetailedDTO.java
@@ -105,6 +105,9 @@ public class APIDetailedDTO extends APIInfoDTO {
 
   private APICorsConfigurationDTO corsConfiguration = null;
 
+
+  private String authorizationHeader = null;
+
   /**
    * Swagger definition of the APIDetailedDTO which contains details about URI templates and scopes\n
    **/
@@ -441,6 +444,16 @@ public class APIDetailedDTO extends APIInfoDTO {
   }
   public void setCorsConfiguration(APICorsConfigurationDTO corsConfiguration) {
     this.corsConfiguration = corsConfiguration;
+  }
+
+  /**
+   ** The authorization header of the API
+   **/
+  @ApiModelProperty(value = "The authorization header to be set")
+  @JsonProperty("authorizationHeader")
+  public String getAuthorizationHeader() { return authorizationHeader; }
+  public void setAuthorizationHeader(String authorizationHeader) {
+      this.authorizationHeader = authorizationHeader;
   }
 
 

--- a/components/micro-gateway-cli/src/main/resources/templates/mock/service.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/mock/service.mustache
@@ -35,12 +35,18 @@ endpoint http:Client {{qualifiedServiceName}}_EP {
     authConfig:{
         authProviders:["oauth2"],
         authentication:{enabled:true}
-    }
+    },
+    cors: {
+            allowOrigins: [{{#api.corsConfiguration.accessControlAllowOrigins}}"{{.}}"{{#unless @last}},{{/unless}}{{/api.corsConfiguration.accessControlAllowOrigins}}],
+            allowCredentials: {{api.corsConfiguration.accessControlAllowCredentials}},
+            allowHeaders: [{{#api.corsConfiguration.accessControlAllowHeaders}}"{{.}}"{{#unless @last}},{{/unless}}{{/api.corsConfiguration.accessControlAllowHeaders}}]
+        }
 }
 
 @gateway:API {
     name:"{{api.name}}",
-    apiVersion: "{{api.version}}"
+    apiVersion: "{{api.version}}" {{#if api.authorizationHeader}},
+    authorizationHeader : "{{api.authorizationHeader}}" {{/if}}
 }
 service<http:Service> {{cut qualifiedServiceName " "}} bind apiListener,apiSecureListener {
 {{#paths}}{{#value}}{{#operations}}{{#value}}

--- a/components/micro-gateway-core/src/main/ballerina/gateway/annotation.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/annotation.bal
@@ -27,9 +27,11 @@ public annotation <resource> RateLimit TierConfiguration;
 @Description {value:"Configuration used for api version annotation"}
 @Field {value:"name: Name of the API"}
 @Field {value:"apiVersion: version specified for the API"}
+@Field {value:"authorizationHeader: authorization header specified for the API"}
 public type APIConfiguration {
     string apiVersion;
     string name;
+    string authorizationHeader;
 
 };
 

--- a/components/micro-gateway-core/src/main/ballerina/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/constants/constants.bal
@@ -138,6 +138,8 @@
 @final public string LISTENER_CONF_KEY_STORE_PASSWORD = "keyStore.password";
 @Description { value: "The port which exposes /token,/revoke, /authorize and etc endpoints"}
 @final public string TOKEN_LISTENER_PORT = "tokenListenerPort";
+@Description { value: "The authoization header config name"}
+@final public string AUTH_HEADER_NAME = "authorizationHeader";
 @Description { value: "Set of filters to be enabled"}
 @final public string FILTERS = "filters";
 

--- a/components/micro-gateway-core/src/main/ballerina/gateway/filters/authn_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/filters/authn_filter.bal
@@ -52,13 +52,14 @@ public type AuthnFilter object {
         boolean isAuthorized;
         if (isSecured) {
             string authHeader;
-            if(request.hasHeader(AUTH_HEADER)) {
-                authHeader = request.getHeader(AUTH_HEADER);
+            string authHeaderName = getAuthorizationHeader(reflect:getServiceAnnotations(context.serviceType));
+            if (request.hasHeader(authHeaderName)) {
+                authHeader = request.getHeader(authHeaderName);
             } else {
                 log:printError("No authorization header was provided");
                 return createFilterResult(false, 401, "No authorization header was provided");
             }
-            string providerId = getAuthenticationProviderType(request.getHeader(AUTH_HEADER));
+            string providerId = getAuthenticationProviderType(request.getHeader(authHeaderName));
             // if auth providers are there, use those to authenticate
             if(providerId != AUTH_SCHEME_OAUTH2) {
                 string[] providerIds = [providerId];

--- a/components/micro-gateway-core/src/main/ballerina/gateway/utils/utils.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/utils/utils.bal
@@ -346,3 +346,13 @@ public function setErrorMessageToFilterContext(http:FilterContext context, int e
     context.attributes[ERROR_MESSAGE] = errorMessage;
     context.attributes[ERROR_DESCRIPTION] = getFailureMessageDetailDescription(errorCode, errorMessage);
 }
+
+public function getAuthorizationHeader(reflect:annotationData[] annData) returns string {
+    APIConfiguration apiConfig = getAPIDetailsFromServiceAnnotation(annData);
+    string authHeader = apiConfig.authorizationHeader;
+    if (authHeader == "") {
+        authHeader = getConfigValue(LISTENER_CONF_INSTANCE_ID, AUTH_HEADER_NAME, AUTHORIZATION_HEADER);
+    }
+    return authHeader;
+
+}

--- a/distribution/product/resources/conf/micro-gw.conf
+++ b/distribution/product/resources/conf/micro-gw.conf
@@ -5,6 +5,7 @@ httpsPort=9095
 keyStore.path="${ballerina.home}/bre/security/ballerinaKeystore.p12"
 keyStore.password="ballerina"
 tokenListenerPort=9096
+authorizationHeader="Authorization"
 
 [filters]
 AUTHN_FILTER=true


### PR DESCRIPTION
## Purpose
- Added CORS annotations to generated ballerina services
- Get authorization header from API , if not from the config file

## Goals
- Micro gateway apis should be able to restricted with CORS headers and , user should be able to specify any header to provide the access token
