### PR TITLE
Change Micro GW default bind address to 0.0.0.0

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/gateway/listeners/api_gateway_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/listeners/api_gateway_listener.bal
@@ -217,7 +217,8 @@ function initiateGatewayConfigurations(EndpointConfiguration config) {
     if(!config.isSecured) {
         config.port = getConfigIntValue(LISTENER_CONF_INSTANCE_ID, LISTENER_CONF_HTTP_PORT, 9090);
     }
-    config.host = getConfigValue(LISTENER_CONF_INSTANCE_ID, LISTENER_CONF_HOST,"localhost");
+    // default should bind to 0.0.0.0, not localhost. Else will not work in dockerized environments.
+    config.host = getConfigValue(LISTENER_CONF_INSTANCE_ID, LISTENER_CONF_HOST, "0.0.0.0");
     intitateKeyManagerConfigurations();
     initGatewayCaches();
     initiateThrottleConfigs();

--- a/distribution/product/resources/conf/micro-gw.conf
+++ b/distribution/product/resources/conf/micro-gw.conf
@@ -1,5 +1,5 @@
 [listenerConfig]
-host="localhost"
+host="0.0.0.0"
 httpPort=9090
 httpsPort=9095
 keyStore.path="${ballerina.home}/bre/security/ballerinaKeystore.p12"


### PR DESCRIPTION
## Purpose
> Currently mg binds to localhost by default. This will not work in Docker and K8s environments. Should bind to 0.0.0.0 by default.