### PR TITLE
Adding hashing based change detection funtionality

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/Main.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/Main.java
@@ -31,6 +31,8 @@ import org.wso2.apimgt.gateway.cli.codegen.CodeGenerationContext;
 import org.wso2.apimgt.gateway.cli.codegen.CodeGenerator;
 import org.wso2.apimgt.gateway.cli.codegen.ThrottlePolicyGenerator;
 import org.wso2.apimgt.gateway.cli.config.TOMLConfigParser;
+import org.wso2.apimgt.gateway.cli.exception.HashingException;
+import org.wso2.apimgt.gateway.cli.hashing.HashUtils;
 import org.wso2.apimgt.gateway.cli.model.config.Config;
 import org.wso2.apimgt.gateway.cli.model.config.ContainerConfig;
 import org.wso2.apimgt.gateway.cli.constants.GatewayCliConstants;
@@ -348,6 +350,12 @@ public class Main {
                 policyGenerator.generate(GatewayCmdUtils.getLabelSrcDirectoryPath(projectRoot, label) + File.separator
                         + GatewayCliConstants.POLICY_DIR, applicationPolicies, subscriptionPolicies);
                 codeGenerator.generate(projectRoot, label, apis, true);
+                try {
+                    boolean changesDetected = HashUtils.detectChanges(apis, subscriptionPolicies, applicationPolicies);
+                    System.out.println("Changes -- "+ changesDetected);
+                } catch (HashingException e) {
+                    outStream.println("Error while checking for changes of resources. Skipping no-change detection..");
+                }
                 InitHandler.initialize(Paths.get(GatewayCmdUtils
                         .getLabelDirectoryPath(projectRoot, label)), null, new ArrayList<SrcFile>(), null);
             } catch (IOException | BallerinaServiceGenException e) {

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/Main.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/Main.java
@@ -350,14 +350,19 @@ public class Main {
                 policyGenerator.generate(GatewayCmdUtils.getLabelSrcDirectoryPath(projectRoot, label) + File.separator
                         + GatewayCliConstants.POLICY_DIR, applicationPolicies, subscriptionPolicies);
                 codeGenerator.generate(projectRoot, label, apis, true);
-                try {
-                    boolean changesDetected = HashUtils.detectChanges(apis, subscriptionPolicies, applicationPolicies);
-                    System.out.println("Changes -- "+ changesDetected);
-                } catch (HashingException e) {
-                    outStream.println("Error while checking for changes of resources. Skipping no-change detection..");
-                }
+                //Initializing the ballerina label project and creating .bal folder. 
                 InitHandler.initialize(Paths.get(GatewayCmdUtils
                         .getLabelDirectoryPath(projectRoot, label)), null, new ArrayList<SrcFile>(), null);
+                try {
+                    boolean changesDetected = HashUtils.detectChanges(apis, subscriptionPolicies, applicationPolicies);
+                    if (!changesDetected) {
+                        outStream.println("No changes from upstream.");
+                        Runtime.getRuntime().exit(GatewayCliConstants.EXIT_CODE_NOT_MODIFIED);
+                    }
+                } catch (HashingException e) {
+                    outStream.println("Error while checking for changes of resources. Skipping no-change detection..");
+                    Runtime.getRuntime().exit(1);
+                }
             } catch (IOException | BallerinaServiceGenException e) {
                 outStream.println("Error while generating ballerina source");
                 e.printStackTrace();

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
@@ -26,6 +26,8 @@ import io.swagger.parser.SwaggerParser;
 import org.wso2.apimgt.gateway.cli.constants.GatewayCliConstants;
 import org.wso2.apimgt.gateway.cli.constants.GeneratorConstants;
 import org.wso2.apimgt.gateway.cli.exception.BallerinaServiceGenException;
+import org.wso2.apimgt.gateway.cli.exception.HashingException;
+import org.wso2.apimgt.gateway.cli.hashing.HashUtils;
 import org.wso2.apimgt.gateway.cli.model.rest.ext.ExtendedAPI;
 import org.wso2.apimgt.gateway.cli.model.template.GenSrcFile;
 import org.wso2.apimgt.gateway.cli.model.template.service.BallerinaService;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
@@ -31,6 +31,7 @@ public class GatewayCliConstants {
     public static final String LABEL_CONFIG_FILE_NAME = "label-config.toml";
     public static final String TEMP_DIR_NAME = "temp";
     public static final String PROJECT_ROOT_HOLDER_FILE_NAME = "workspace.txt";
+    public static final String RESOURCE_HASH_HOLDER_FILE_NAME = "hashes.json";
     public static final String DEFAULT_MAIN_CONFIG_FILE_NAME = "default-config.toml";
     public static final String DEFAULT_LABEL_CONFIG_FILE_NAME = "default-label-config.toml";
     public static final String CLI_HOME = "cli.home";

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
@@ -57,4 +57,6 @@ public class GatewayCliConstants {
     public static final String K8S_SERVICE = "-rest-";
     public static final String LABEL_PLACEHOLDER = "${label}";
     public static final String CHARSET_UTF8 = "UTF-8";
+
+    public static final int EXIT_CODE_NOT_MODIFIED = 34;
 }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/HashingConstants.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/HashingConstants.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.apimgt.gateway.cli.constants;
+
+/**
+ * Constants used for hashing
+ */
+public class HashingConstants {
+
+    public static final String HASH_SEPARATOR = "::";
+    public static final String HASH_ALGORITHM = "MD5";
+    public static final int BASE_16 = 16;
+}

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/exception/HashingException.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/exception/HashingException.java
@@ -17,12 +17,12 @@
  */
 package org.wso2.apimgt.gateway.cli.exception;
 
+/**
+ * Hashing Exception class
+ * 
+ */
 public class HashingException extends Exception {
     public HashingException(String message, Throwable e) {
         super(message, e);
-    }
-
-    public HashingException(String message) {
-        super(message);
     }
 }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/exception/HashingException.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/exception/HashingException.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.apimgt.gateway.cli.exception;
+
+public class HashingException extends Exception {
+    public HashingException(String message, Throwable e) {
+        super(message, e);
+    }
+
+    public HashingException(String message) {
+        super(message);
+    }
+}

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/hashing/Hash.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/hashing/Hash.java
@@ -20,6 +20,9 @@ package org.wso2.apimgt.gateway.cli.hashing;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+/**
+ * Annotation used to mark fields of APIs/Policies that will be used for hash generation
+ */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Hash {
     

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/hashing/Hash.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/hashing/Hash.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.apimgt.gateway.cli.hashing;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Hash {
+    
+}

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/hashing/HashUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/hashing/HashUtils.java
@@ -1,0 +1,207 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.apimgt.gateway.cli.hashing;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
+import org.wso2.apimgt.gateway.cli.constants.GatewayCliConstants;
+import org.wso2.apimgt.gateway.cli.constants.HashingConstants;
+import org.wso2.apimgt.gateway.cli.exception.HashingException;
+import org.wso2.apimgt.gateway.cli.model.rest.ext.ExtendedAPI;
+import org.wso2.apimgt.gateway.cli.model.rest.policy.ApplicationThrottlePolicyDTO;
+import org.wso2.apimgt.gateway.cli.model.rest.policy.SubscriptionThrottlePolicyDTO;
+import org.wso2.apimgt.gateway.cli.model.rest.policy.ThrottlePolicyDTO;
+import org.wso2.apimgt.gateway.cli.model.template.policy.ThrottlePolicy;
+import org.wso2.apimgt.gateway.cli.utils.GatewayCmdUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+
+public class HashUtils {
+
+    public static boolean detectChanges(List<ExtendedAPI> apis,
+            List<SubscriptionThrottlePolicyDTO> subscriptionPolicies,
+            List<ApplicationThrottlePolicyDTO> appPolicies) throws HashingException {
+        boolean hasChanges = true;
+        Map<String, String> allHashesMap = new HashMap<>();
+        Map<String, String> apiHashesMap = getMapOfHashesForAPIs(apis);
+        Map<String, String> appPolicyHashesMap = getMapOfHashesForAppPolicies(appPolicies);
+        Map<String, String> subsPolicyHashesMap = getMapOfHashesForSubpolicies(subscriptionPolicies);
+
+        allHashesMap.putAll(apiHashesMap);
+        allHashesMap.putAll(appPolicyHashesMap);
+        allHashesMap.putAll(subsPolicyHashesMap);
+
+        try {
+            Map<String, String> storedHashes = loadStoredResourceHashes();
+            if (equalMaps(storedHashes, allHashesMap)) {
+                hasChanges = false;
+            } else {
+                storeResourceHashes(allHashesMap);
+            }
+        } catch (IOException e) {
+            throw new HashingException("Error while resource change detection", e);
+        }
+        return hasChanges;
+    }
+
+    private static Map<String, String> loadStoredResourceHashes() throws IOException {
+        String content = GatewayCmdUtils.loadStoredResourceHashes();
+        Map<String, String> hashes = new HashMap<>();
+        if (StringUtils.isNotEmpty(content)) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            hashes = objectMapper.readValue(content, Map.class);
+        }
+        return hashes;
+    }
+
+    private static void storeResourceHashes(Map<String, String> hashesMap) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        String stringifiedHashes = mapper.writeValueAsString(hashesMap);
+        GatewayCmdUtils.storeResourceHashesFileContent(stringifiedHashes);
+    }
+
+    private static Map<String, String> getMapOfHashesForAPIs(List<ExtendedAPI> apis) throws HashingException {
+        Map<String, String> hashes = new HashMap<>();
+        if (apis != null) {
+            for (ExtendedAPI api : apis) {
+                String hash = getAnnotatedHash(api);
+                System.out.println(api.getName() + " -- " + hash);
+                hashes.put(api.getId(), hash);
+            }
+        }
+        return hashes;
+    }
+
+    private static Map<String, String> getMapOfHashesForAppPolicies(List<ApplicationThrottlePolicyDTO> policies)
+            throws HashingException {
+        Map<String, String> hashes = new HashMap<>();
+        if (policies != null) {
+            for (ApplicationThrottlePolicyDTO throttlePolicy : policies) {
+                String hash = getAnnotatedHash(throttlePolicy);
+                System.out.println(throttlePolicy.getDisplayName() + " -- " + hash);
+                hashes.put(throttlePolicy.getPolicyId(), hash);
+            }
+        }
+        return hashes;
+    }
+
+    private static Map<String, String> getMapOfHashesForSubpolicies(List<SubscriptionThrottlePolicyDTO> policies)
+            throws HashingException {
+        Map<String, String> hashes = new HashMap<>();
+        if (policies != null) {
+            for (SubscriptionThrottlePolicyDTO throttlePolicy : policies) {
+                String hash = getAnnotatedHash(throttlePolicy);
+                System.out.println(throttlePolicy.getDisplayName() + " -- " + hash);
+                hashes.put(throttlePolicy.getPolicyId(), hash);
+            }
+        }
+        return hashes;
+    }
+    
+    private static String getAnnotatedHash(Object obj) throws HashingException {
+        ObjectMapper mapper = new ObjectMapper();
+        TreeSet<String> sortedSet = new TreeSet<>();
+        for (Method method : obj.getClass().getMethods()) {
+            if (method.isAnnotationPresent(Hash.class)) {
+                try {
+                    Object value = method.invoke(obj);
+                    String stringifiedField = mapper.writeValueAsString(value);
+                    sortedSet.add(method.getName() + HashingConstants.HASH_SEPARATOR + stringifiedField);
+                } catch (JsonProcessingException | IllegalAccessException | InvocationTargetException e) {
+                    throw new HashingException("Error while generating hash for " + obj, e);
+                }
+            }
+        }
+        StringBuilder builder = new StringBuilder();
+        for (String entry : sortedSet) {
+            builder.append(entry);
+            builder.append(HashingConstants.HASH_SEPARATOR);
+        }
+        String val = builder.toString();
+        return getMD5Hex(val);
+    }
+
+    /**
+     * Iterate through the given maps and check if they are both having equal entries 
+     * 
+     * @param map1 First map
+     * @param map2 Second map
+     * @return true if both maps are having equal entries 
+     */
+    private static boolean equalMaps(Map<String, String> map1, Map<String, String> map2) {
+        if (map1 == null || map2 == null) {
+            return false;
+        }
+        if (map1.keySet().size() != map2.keySet().size()) {
+            return false;
+        }
+
+        for (String map1Key : map1.keySet()) {
+            if (map1.get(map1Key) == null || !map1.get(map1Key).equals(map2.get(map1Key))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Calculates the MD5 hash for a given String
+     * 
+     * @param inputString input string
+     * @return calculated md5 hash value
+     * @throws HashingException error while calculating the md5 hash value
+     */
+    private static String getMD5Hex(final String inputString) throws HashingException {
+        MessageDigest md;
+        byte[] digest;
+        try {
+            md = MessageDigest.getInstance(HashingConstants.HASH_ALGORITHM);
+            md.update(inputString.getBytes());
+            digest = md.digest();
+        } catch (NoSuchAlgorithmException e) {
+            throw new HashingException("Error getting md5 hash of " + inputString, e);
+        }
+        return convertByteToHex(digest);
+    }
+
+
+    /**
+     * Convert the given byte array to a hex string
+     * 
+     * @param byteData byte array
+     * @return converted hex string for the byte array
+     */
+    private static String convertByteToHex(byte[] byteData) {
+        StringBuilder sb = new StringBuilder();
+        for (byte aByteData : byteData) {
+            sb.append(Integer.toString((aByteData & 0xff) + 0x100, HashingConstants.BASE_16).substring(1));
+        }
+
+        return sb.toString();
+    }
+}

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/hashing/HashUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/hashing/HashUtils.java
@@ -37,6 +37,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 
+/**
+ * Utility class used for hashing functionality
+ * 
+ */
 public class HashUtils {
 
     /**

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/APIDetailedDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/APIDetailedDTO.java
@@ -155,6 +155,7 @@ public class APIDetailedDTO extends APIInfoDTO {
     /**
      * The transport to be set. Accepted values are HTTP, WS
      **/
+    @Hash
     @JsonProperty("type")
     public TypeEnum getType() {
         return type;
@@ -195,6 +196,7 @@ public class APIDetailedDTO extends APIInfoDTO {
     /**
      * The subscription tiers selected for the particular APIDetailedDTO
      **/
+    @Hash
     @JsonProperty("tiers")
     public List<String> getTiers() {
         return tiers;
@@ -263,7 +265,7 @@ public class APIDetailedDTO extends APIInfoDTO {
         this.visibleTenants = visibleTenants;
     }
 
-
+    @Hash
     @JsonProperty("endpointConfig")
     public String getEndpointConfig() {
         return endpointConfig;
@@ -273,7 +275,7 @@ public class APIDetailedDTO extends APIInfoDTO {
         this.endpointConfig = endpointConfig;
     }
 
-
+    @Hash
     @JsonProperty("endpointSecurity")
     public APIEndpointSecurityDTO getEndpointSecurity() {
         return endpointSecurity;
@@ -410,6 +412,7 @@ public class APIDetailedDTO extends APIInfoDTO {
     /**
      * * The authorization header of the API
      **/
+    @Hash
     @JsonProperty("authorizationHeader")
     public String getAuthorizationHeader() {
         return authorizationHeader;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/APIDetailedDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/APIDetailedDTO.java
@@ -18,6 +18,7 @@ package org.wso2.apimgt.gateway.cli.model.rest;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.wso2.apimgt.gateway.cli.hashing.Hash;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -87,6 +88,7 @@ public class APIDetailedDTO extends APIInfoDTO {
     /**
      * Swagger definition of the APIDetailedDTO which contains details about URI templates and scopes\n
      **/
+    @Hash
     @JsonProperty("apiDefinition")
     public String getApiDefinition() {
         return apiDefinition;
@@ -109,7 +111,7 @@ public class APIDetailedDTO extends APIInfoDTO {
         this.wsdlUri = wsdlUri;
     }
 
-
+    @Hash
     @JsonProperty("responseCaching")
     public String getResponseCaching() {
         return responseCaching;
@@ -119,7 +121,7 @@ public class APIDetailedDTO extends APIInfoDTO {
         this.responseCaching = responseCaching;
     }
 
-
+    @Hash
     @JsonProperty("cacheTimeout")
     public Integer getCacheTimeout() {
         return cacheTimeout;
@@ -139,7 +141,7 @@ public class APIDetailedDTO extends APIInfoDTO {
         this.destinationStatsEnabled = destinationStatsEnabled;
     }
 
-
+    @Hash
     @JsonProperty("isDefaultVersion")
     public Boolean getIsDefaultVersion() {
         return isDefaultVersion;
@@ -166,6 +168,7 @@ public class APIDetailedDTO extends APIInfoDTO {
     /**
      * Supported transports for the APIDetailedDTO (http and/or https).\n
      **/
+    @Hash
     @JsonProperty("transport")
     public List<String> getTransport() {
         return transport;
@@ -394,6 +397,7 @@ public class APIDetailedDTO extends APIInfoDTO {
         this.businessInformation = businessInformation;
     }
 
+    @Hash
     @JsonProperty("corsConfiguration")
     public APICorsConfigurationDTO getCorsConfiguration() {
         return corsConfiguration;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/APIInfoDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/APIInfoDTO.java
@@ -16,6 +16,7 @@
 package org.wso2.apimgt.gateway.cli.model.rest;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.wso2.apimgt.gateway.cli.hashing.Hash;
 
 public class APIInfoDTO {
 
@@ -44,6 +45,7 @@ public class APIInfoDTO {
     /**
      * Name of the APIDetailedDTO
      **/
+    @Hash
     @JsonProperty("name")
     public String getName() {
         return name;
@@ -68,6 +70,7 @@ public class APIInfoDTO {
     /**
      * A string that represents the context of the user's request
      **/
+    @Hash
     @JsonProperty("context")
     public String getContext() {
         return context;
@@ -80,6 +83,7 @@ public class APIInfoDTO {
     /**
      * The version of the APIDetailedDTO
      **/
+    @Hash
     @JsonProperty("version")
     public String getVersion() {
         return version;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/ext/ExtendedAPI.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/ext/ExtendedAPI.java
@@ -18,6 +18,10 @@ package org.wso2.apimgt.gateway.cli.model.rest.ext;
 import org.wso2.apimgt.gateway.cli.model.rest.APIDetailedDTO;
 import org.wso2.apimgt.gateway.cli.model.rest.EndpointConfig;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 public class ExtendedAPI extends APIDetailedDTO {
     private EndpointConfig endpointConfigRepresentation = null;
 

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/ext/ExtendedAPI.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/ext/ExtendedAPI.java
@@ -18,10 +18,6 @@ package org.wso2.apimgt.gateway.cli.model.rest.ext;
 import org.wso2.apimgt.gateway.cli.model.rest.APIDetailedDTO;
 import org.wso2.apimgt.gateway.cli.model.rest.EndpointConfig;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
 public class ExtendedAPI extends APIDetailedDTO {
     private EndpointConfig endpointConfigRepresentation = null;
 

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/policy/ApplicationThrottlePolicyDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/policy/ApplicationThrottlePolicyDTO.java
@@ -16,11 +16,13 @@
 package org.wso2.apimgt.gateway.cli.model.rest.policy;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.wso2.apimgt.gateway.cli.hashing.Hash;
 
 public class ApplicationThrottlePolicyDTO extends ThrottlePolicyDTO {
 
     private ThrottleLimitDTO defaultLimit = null;
 
+    @Hash
     @JsonProperty("defaultLimit")
     public ThrottleLimitDTO getDefaultLimit() {
         return defaultLimit;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/policy/SubscriptionThrottlePolicyDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/policy/SubscriptionThrottlePolicyDTO.java
@@ -16,6 +16,7 @@
 package org.wso2.apimgt.gateway.cli.model.rest.policy;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.wso2.apimgt.gateway.cli.hashing.Hash;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,6 +30,7 @@ public class SubscriptionThrottlePolicyDTO extends ThrottlePolicyDTO {
     private Boolean stopOnQuotaReach = false;
     private String billingPlan = null;
 
+    @Hash
     @JsonProperty("defaultLimit")
     public ThrottleLimitDTO getDefaultLimit() {
         return defaultLimit;
@@ -82,6 +84,7 @@ public class SubscriptionThrottlePolicyDTO extends ThrottlePolicyDTO {
      * This indicates the action to be taken when a user goes beyond the allocated quota. If checked, the user's
      * requests will be dropped. If unchecked, the requests will be allowed to pass through.\n
      **/
+    @Hash
     @JsonProperty("stopOnQuotaReach")
     public Boolean getStopOnQuotaReach() {
         return stopOnQuotaReach;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/policy/ThrottlePolicyDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/policy/ThrottlePolicyDTO.java
@@ -17,6 +17,7 @@ package org.wso2.apimgt.gateway.cli.model.rest.policy;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
+import org.wso2.apimgt.gateway.cli.hashing.Hash;
 
 import javax.validation.constraints.NotNull;
 
@@ -47,6 +48,7 @@ public class ThrottlePolicyDTO {
     /**
      * Name of policy
      **/
+    @Hash
     @JsonProperty("policyName")
     public String getPolicyName() {
         return policyName;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -355,6 +355,12 @@ public class GatewayCmdUtils {
         createFolderIfNotExist(distExec);
     }
 
+    /**
+     * Load the stored resource hash content from the CLI temp folder
+     * 
+     * @return stored resource hash content from the CLI temp folder
+     * @throws IOException error while loading stored resource hash content
+     */
     public static String loadStoredResourceHashes() throws IOException {
         String resourceHashFileLocation = getResourceHashHolderFileLocation();
         String content = null;
@@ -364,6 +370,12 @@ public class GatewayCmdUtils {
         return content;
     }
 
+    /**
+     * Saves the resource hash content to the CLI temp folder
+     * 
+     * @param content resource hash content
+     * @throws IOException error while saving resource hash content
+     */
     public static void storeResourceHashesFileContent(String content) throws IOException {
         String tempDirPath = getTempFolderLocation();
         createFolderIfNotExist(tempDirPath);

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -250,7 +250,7 @@ public class GatewayCmdUtils {
      * Get temp folder location
      * @return temp folder location
      */
-    public static String getTempFolderLocation() {
+    private static String getTempFolderLocation() {
         return getCLIHome() + File.separator + GatewayCliConstants.TEMP_DIR_NAME;
     }
 

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -37,6 +37,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
+import java.util.Map;
 
 public class GatewayCmdUtils {
 
@@ -181,14 +183,8 @@ public class GatewayCmdUtils {
         if (!pathFile.exists()) {
             pathFile.createNewFile();
         }
-        FileWriter writer = null;
         //Write Content
-        try {
-            writer = new FileWriter(pathFile);
-            writer.write(workspacePath);
-        } finally {
-            writer.close();
-        }
+        writeContent(workspacePath, pathFile);
     }
 
     /**
@@ -254,7 +250,7 @@ public class GatewayCmdUtils {
      * Get temp folder location
      * @return temp folder location
      */
-    private static String getTempFolderLocation() {
+    public static String getTempFolderLocation() {
         return getCLIHome() + File.separator + GatewayCliConstants.TEMP_DIR_NAME;
     }
 
@@ -357,6 +353,38 @@ public class GatewayCmdUtils {
         //path : {label}/target/distribution/micro-gw-{label}/exec
         String distExec = distMicroGWPath + File. separator + GatewayCliConstants.GW_DIST_EXEC;
         createFolderIfNotExist(distExec);
+    }
+
+    public static String loadStoredResourceHashes() throws IOException {
+        String resourceHashFileLocation = getResourceHashHolderFileLocation();
+        String content = null;
+        if (new File(resourceHashFileLocation).exists()) {
+            content = GatewayCmdUtils.readFileAsString(resourceHashFileLocation, false);
+        }
+        return content;
+    }
+
+    public static void storeResourceHashesFileContent(String content) throws IOException {
+        String tempDirPath = getTempFolderLocation();
+        createFolderIfNotExist(tempDirPath);
+
+        String resourceHashesFileLocation = getResourceHashHolderFileLocation();
+        File pathFile = new File(resourceHashesFileLocation);
+        if (!pathFile.exists()) {
+            pathFile.createNewFile();
+        }
+        //Write Content
+        writeContent(content, pathFile);
+    }
+    
+    /**
+     * Get resource hash holder file path
+     *
+     * @return resource hash holder file path
+     */
+    private static String getResourceHashHolderFileLocation() {
+        return GatewayCmdUtils.getTempFolderLocation() + File.separator
+                + GatewayCliConstants.RESOURCE_HASH_HOLDER_FILE_NAME;
     }
 
     /**
@@ -601,6 +629,25 @@ public class GatewayCmdUtils {
     }
 
     /**
+     * Write content to a specified file
+     * 
+     * @param content content to be written
+     * @param file file object initialized with path
+     * @throws IOException error while writing content to file
+     */
+    private static void writeContent(String content, File file) throws IOException {
+        FileWriter writer = null;
+        try {
+            writer = new FileWriter(file);
+            writer.write(content);
+        } finally {
+            if (writer != null) {
+                writer.close();
+            }
+        }
+    }
+
+    /**
      * Create initial label configuration
      * @param root workspace location
      * @param label label name
@@ -611,17 +658,9 @@ public class GatewayCmdUtils {
         File file = new File(mainConfig);
         if (!file.exists()) {
             file.createNewFile();
-            FileWriter writer = null;
             //Write Content
             String defaultConfig = readFileAsString(GatewayCliConstants.DEFAULT_LABEL_CONFIG_FILE_NAME, true);
-            try {
-                writer = new FileWriter(file);
-                writer.write(defaultConfig);
-            } finally {
-                if (writer != null) {
-                    writer.close();
-                }
-            }
+            writeContent(defaultConfig, file);
         }
     }
 


### PR DESCRIPTION
## Purpose
First time running the setup command, the tool will run normally.
```
$ micro-gw setup -l internal --path /home/malintha/wso2apim/cur/c4mgw/malintha

BALLERINA_HOME environment variable is set to /home/malintha/wso2apim/cur/c4mgw/wso2am-micro-gw-2.5.0-SNAPSHOT/lib/platform
MICROGW_TOOLKIT_HOME environment variable is set to /home/malintha/wso2apim/cur/c4mgw/wso2am-micro-gw-2.5.0-SNAPSHOT
Enter Password: 
```

The exit code for this state will be 0.

```
$ echo $?
0
```

Second time running the command the tool will compare the hashes generated for the previous API/Policy requests. If the server gives the same response for the required attributes the tool notifies the user that there is no change from upstream.

```
$ micro-gw setup -l internal --path /home/malintha/wso2apim/cur/c4mgw/malintha

BALLERINA_HOME environment variable is set to /home/malintha/wso2apim/cur/c4mgw/wso2am-micro-gw-2.5.0-SNAPSHOT/lib/platform
MICROGW_TOOLKIT_HOME environment variable is set to /home/malintha/wso2apim/cur/c4mgw/wso2am-micro-gw-2.5.0-SNAPSHOT
Enter Password: 

No changes from upstream.
```

The exit code for this state will be 34.

```
$ echo $?
34
```

## Approach
The required fields to hash are annotated using `@Hash` annotation. Values of those fields are concatenated to generate the hashes for each resource.

The hashes are stored in `<CLI-HOME>/temp/hashes.json`. It has the format `<resource uuid> : <hash>`.
A sample generated file:

```

{  
   "1897e822-1594-443b-bc0e-7ebdbade4db3":"bf027623927e5f2c8e68eebf15b72dbf",
   "cecab69a-2472-4a44-87f7-59a4a26094b7":"35ac52b9e6a9e00745bf04770131b40d",
   "221dc303-12a3-4b65-9336-464bab4d1e40":"0d8dad3fbee27d9d7726e6a8658c5dd8",
   "e6c34a8d-25e6-4851-9352-caaf1dc9ccfa":"c43f2b188e86eb4fd38019717b84ccdd"
}
```