### PR TITLE
 Restructure project generation root location

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/Main.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/Main.java
@@ -37,6 +37,7 @@ import java.util.Optional;
 public class Main {
     private static final String JC_UNKNOWN_OPTION_PREFIX = "Unknown option:";
     private static final String JC_EXPECTED_A_VALUE_AFTER_PARAMETER_PREFIX = "Expected a value after parameter";
+    private static final String INTERNAL_ERROR_MESSAGE = "Internal error occurred while executing command.";
     private static final String MICRO_GW = "micro-gw";
 
     private static PrintStream outStream = System.err;
@@ -49,20 +50,20 @@ public class Main {
             optionalInvokedCmd.ifPresent(GatewayLauncherCmd::execute);
         } catch (CliLauncherException e) {
             outStream.println(e.getMessages());
-            logger.error("Error occurred while executing command", e);
+            logger.error("micro-gw: Error occurred while executing command.", e);
             Runtime.getRuntime().exit(1);
         } catch (CLIInternalException e) {
-            outStream.println(e.getMessage());
-            logger.error("Internal error occurred when setup.", e);
-            Runtime.getRuntime().exit(1);
-        } catch (CLIRuntimeException e) {
-            outStream.println(e.getTerminalMsg());
+            outStream.println("micro-gw: " + INTERNAL_ERROR_MESSAGE);
             logger.error(e.getMessage(), e);
             Runtime.getRuntime().exit(1);
+        } catch (CLIRuntimeException e) {
+            outStream.println("micro-gw: " + e.getTerminalMsg());
+            logger.error(e.getMessage(), e);
+            Runtime.getRuntime().exit(e.getExitCode());
         } catch (Exception e) {
             //Use generic exception to catch all the runtime exception
-            outStream.println("Internal error occurred when setup.");
-            logger.error("Internal error occurred when setup.", e);
+            outStream.println("micro-gw: " + INTERNAL_ERROR_MESSAGE);
+            logger.error(INTERNAL_ERROR_MESSAGE, e);
             Runtime.getRuntime().exit(1);
         }
     }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
@@ -301,6 +301,7 @@ public class SetupCmd implements GatewayLauncherCmd {
             GatewayCmdUtils.saveConfig(newConfig, configPath);
         }
 
+        outStream.println("Setting up project " + projectName + " successful.");
         //There should not be any logic after this system exit
         if (!changesDetected) {
             outStream.println(

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
@@ -364,7 +364,6 @@ public class SetupCmd implements GatewayLauncherCmd {
 
     private static void init(String workspace, String projectName, String configPath) {
         try {
-            GatewayCmdUtils.createWorkspaceStructure(workspace);
             GatewayCmdUtils.createProjectStructure(workspace, projectName);
             GatewayCmdUtils.createLabelConfig(workspace, projectName);
 

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
@@ -24,9 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public class GatewayCliConstants {
-    public static final String MAIN_DIRECTORY_NAME = "micro-gw-resources";
     public static final String CONF_DIRECTORY_NAME = "conf";
-    public static final String PROJECTS_DIRECTORY_NAME = "projects";
     public static final String PROJECTS_SRC_DIRECTORY_NAME = "src";
     public static final String PROJECTS_LOGS_DIRECTORY_NAME = "logs";
     public static final String ACCESS_LOG_FILE = "access_logs";

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/exception/CLIInternalException.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/exception/CLIInternalException.java
@@ -24,10 +24,6 @@ public class CLIInternalException extends RuntimeException {
     private final static int DEFAULT_EXIT_CODE = 1;
     private int exitCode;
 
-    public CLIInternalException() {
-        super();
-    }
-
     public CLIInternalException(String message) {
         this(message, DEFAULT_EXIT_CODE);
     }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/oauth/OAuthServiceImpl.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/oauth/OAuthServiceImpl.java
@@ -66,12 +66,10 @@ public class OAuthServiceImpl implements OAuthService {
                 JsonNode rootNode = mapper.readTree(responseStr);
                 return rootNode.path(TokenManagementConstants.ACCESS_TOKEN).asText();
             } else {
-                logger.error("Error occurred while getting token. Status code: {} ", responseCode);
-                throw new CLIInternalException();
+                throw new CLIInternalException("Error occurred while getting token. Status code: " + responseCode);
             }
         } catch (IOException e) {
-            logger.error("Error occurred while communicate with token endpoint {}", tokenEndpoint, e);
-            throw new CLIInternalException();
+            throw new CLIInternalException("Error occurred while communicate with token endpoint " + tokenEndpoint, e);
         } finally {
             if (urlConn != null) {
                 urlConn.disconnect();

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -232,15 +232,6 @@ public class GatewayCmdUtils {
     }
 
     /**
-     * Get workspace root holder file path
-     *
-     * @return workspace root holder file path
-     */
-    private static String getProjectRootHolderFileLocation() {
-        return getTempFolderLocation() + File.separator + GatewayCliConstants.PROJECT_ROOT_HOLDER_FILE_NAME;
-    }
-
-    /**
      * Get temp folder location
      *
      * @return temp folder location
@@ -250,27 +241,13 @@ public class GatewayCmdUtils {
     }
 
     /**
-     * Create the main structure of the project for all the labels
-     *
-     * @param workspace location to the workspace
-     */
-    public static void createWorkspaceStructure(String workspace) {
-        String mainResourceDirPath =
-                workspace + File.separator + GatewayCliConstants.MAIN_DIRECTORY_NAME + File.separator
-                        + GatewayCliConstants.PROJECTS_DIRECTORY_NAME;
-        createFoldersIfNotExist(mainResourceDirPath);
-    }
-
-    /**
      * Create a project structure for a particular label.
      *
      * @param workspace   project root location
      * @param projectName name of the project
      */
     public static void createProjectStructure(String workspace, String projectName) {
-        String mainProjectDir = workspace + File.separator + GatewayCliConstants.MAIN_DIRECTORY_NAME + File.separator
-                + GatewayCliConstants.PROJECTS_DIRECTORY_NAME;
-        File projectDir = createFolderIfNotExist(mainProjectDir + File.separator + projectName);
+        File projectDir = createFolderIfNotExist(workspace + File.separator + projectName);
 
         String srcDirPath = projectDir + File.separator + GatewayCliConstants.PROJECTS_SRC_DIRECTORY_NAME;
         createFolderIfNotExist(srcDirPath);
@@ -511,8 +488,7 @@ public class GatewayCmdUtils {
      * @return path to the given label project in the project root path
      */
     public static String getLabelDirectoryPath(String root, String labelName) {
-        return root + File.separator + GatewayCliConstants.MAIN_DIRECTORY_NAME + File.separator
-                + GatewayCliConstants.PROJECTS_DIRECTORY_NAME + File.separator + labelName;
+        return root + File.separator + labelName;
     }
 
     /**

--- a/distribution/resources/bin/micro-gw
+++ b/distribution/resources/bin/micro-gw
@@ -142,7 +142,7 @@ done
 
 #execute build command
 if [ "$CMD_COMMAND" = "build" ] && [ "$CMD_PRO_NAME_VAL" != "" ] && [ "$MICRO_GW_PROJECT_DIR" != "" ]; then
-    MICRO_GW_LABEL_PROJECT_DIR="$MICRO_GW_PROJECT_DIR/micro-gw-resources/projects/$CMD_PRO_NAME_VAL"
+    MICRO_GW_LABEL_PROJECT_DIR="$MICRO_GW_PROJECT_DIR/$CMD_PRO_NAME_VAL"
     pushd $MICRO_GW_LABEL_PROJECT_DIR > /dev/null
         # clean the content of target folder
         if [ -d "$MICRO_GW_LABEL_PROJECT_DIR/target" ]; then
@@ -152,7 +152,7 @@ if [ "$CMD_COMMAND" = "build" ] && [ "$CMD_PRO_NAME_VAL" != "" ] && [ "$MICRO_GW
         ballerina build src/ -o $CMD_PRO_NAME_VAL.balx
     popd > /dev/null
 elif [ "$CMD_COMMAND" = "run" ] && [ "$CMD_PRO_NAME_VAL" != "" ] && [ "$MICRO_GW_PROJECT_DIR" != "" ]; then
-    MICRO_GW_LABEL_PROJECT_TARGET_DIR="$MICRO_GW_PROJECT_DIR/micro-gw-resources/projects/$CMD_PRO_NAME_VAL/target"
+    MICRO_GW_LABEL_PROJECT_TARGET_DIR="$MICRO_GW_PROJECT_DIR/$CMD_PRO_NAME_VAL/target"
     pushd $MICRO_GW_LABEL_PROJECT_TARGET_DIR> /dev/null
         ballerina run $CMD_PRO_NAME_VAL.balx
         exit 1

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/common/CLIExecutor.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/common/CLIExecutor.java
@@ -62,8 +62,7 @@ public class CLIExecutor {
 
         String balCommand = this.cliHome + File.separator + GatewayCliConstants.CLI_LIB + File.separator + "platform"
                 + File.separator + GatewayCliConstants.GW_DIST_BIN + File.separator + "ballerina";
-        homeDirectory = path + File.separator + GatewayCliConstants.MAIN_DIRECTORY_NAME + File.separator
-                + GatewayCliConstants.PROJECTS_DIRECTORY_NAME + File.separator + project;
+        homeDirectory = path + File.separator + project;
 
         String[] cmdArray = new String[] { "bash", balCommand, "build" };
         String[] args2 = new String[] { "src", "-o", project };


### PR DESCRIPTION
## Purpose
Folders "microgw-resources/projects" are removed and the project will be created in the current location inside a folder that has the name of the project specified with -n.

```
$ micro-gw setup -a PizzaShackAPI -v 1.0.0 -n "pizzaproj"

BALLERINA_HOME environment variable is set to /home/malintha/wso2apim/cur/c4mgw/wso2am-micro-gw-toolkit-2.5.0-SNAPSHOT/lib/platform
MICROGW_TOOLKIT_HOME environment variable is set to /home/malintha/wso2apim/cur/c4mgw/wso2am-micro-gw-toolkit-2.5.0-SNAPSHOT
Enter Password for admin: 

Setting up project pizzaproj successful.
No changes received from the server. If you already have a built distribution, it can be reused.

$ tree -L 3
.
└── pizzaproj
    ├── conf
    │   └── label-config.toml
    ├── src
    │   ├── endpoints.bal
    │   ├── extension_filter.bal
    │   ├── PizzaShackAPI_1_0_0.bal
    │   └── policies
    └── target
```