### PR TITLE
Make authorization enable by default in gateway

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/templates/service.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/service.mustache
@@ -45,8 +45,7 @@ endpoint http:Client {{qualifiedServiceName}}_SAND_EP {
 @http:ServiceConfig {
     basePath: "{{api.context}}{{#unless api.isDefaultVersion}}/{{api.version}}{{/unless}}",{{!-- {{only one base path is allowed for all  endpoints}} --}}
     authConfig:{
-        authProviders:["oauth2"],
-        authentication:{enabled:true}
+        authProviders:["oauth2"]
     },
     cors: {
             allowOrigins: [{{#api.corsConfiguration.accessControlAllowOrigins}}"{{.}}"{{#unless @last}},{{/unless}}{{/api.corsConfiguration.accessControlAllowOrigins}}],

--- a/components/micro-gateway-core/src/main/ballerina/gateway/utils/utils.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/utils/utils.bal
@@ -32,13 +32,14 @@ public function isResourceSecured(http:ListenerAuthConfig? resourceLevelAuthAnn,
             isSecured = authn.enabled;
         }
         () => {
-            // if not found at resource level, check in the rest level
+            // if not found at resource level, check in the service level
             match serviceLevelAuthAnn.authentication {
                 http:Authentication authn => {
                     isSecured = authn.enabled;
                 }
                 () => {
-                    isSecured = false;
+                    // by default if no value given, we think auth is enabled in gateway
+                    isSecured = true;
                 }
             }
         }


### PR DESCRIPTION
## Purpose
> In service level we had a annotation to check whether the authentication is enabled. But in gateway auth should be enabled  by default. If disable only we should add the annotation

