### PR TITLE
Add BE endpoint override capability

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/templates/service.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/service.mustache
@@ -1,6 +1,7 @@
 import ballerina/log;
 import ballerina/http;
 import ballerina/swagger;
+import ballerina/config;
 {{#if containerConfig.hasDocker}}import ballerinax/docker;{{/if}}
 {{#if containerConfig.hasKubernetes}}import ballerinax/kubernetes;{{/if}}
 
@@ -8,7 +9,7 @@ import wso2/gateway;
 
 {{#endpointConfig.prodEndpoints}}
 endpoint http:Client {{qualifiedServiceName}}_PROD_EP {
-    url: "{{endpointConfig.prodEndpoints.0.endpointUrl}}"{{#equals api.responseCaching "Disabled"}},
+    url: gateway:retrieveEndPointURL("{{api.name}}.{{api.version}}.prodEndpoints.0", "{{endpointConfig.prodEndpoints.0.endpointUrl}}"){{#equals api.responseCaching "Disabled"}},
     cache: { enabled: false }
     {{else}},
     cache: { isShared: true }
@@ -17,7 +18,7 @@ endpoint http:Client {{qualifiedServiceName}}_PROD_EP {
 {{/endpointConfig.prodEndpoints}}
 {{#endpointConfig.sandEndpoints}}
 endpoint http:Client {{qualifiedServiceName}}_SAND_EP {
-    url: "{{endpointConfig.sandEndpoints.0.endpointUrl}}"{{#equals api.responseCaching "Disabled"}},
+    url: gateway:retrieveEndPointURL("{{api.name}}.{{api.version}}.sandEndpoints.0", "{{endpointConfig.sandEndpoints.0.endpointUrl}}"){{#equals api.responseCaching "Disabled"}},
     cache: { enabled: false }
     {{else}},
         cache: { isShared: true }

--- a/components/micro-gateway-core/src/main/ballerina/gateway/utils/utils.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/utils/utils.bal
@@ -390,6 +390,9 @@ public function rotateFile(string fileName) returns string|error  {
         }
     }
 }
+public function retrieveEndPointURL(string key, string default) returns string { 
+    return config:getAsString(key, default = default);
+}
 
 function initStreamPublisher() {
     log:printInfo("Subscribing writing method to event stream");


### PR DESCRIPTION
## Purpose
Provide dynamic backend url setting capability. 

To override production endpoint for an API (Say TestAPI v1) provide following system variable during the startup
`-e TestAPI.v1.prodEndpoints.0="http://wso2.com"`

For sandbox endpoint
`-e TestAPI.v1.sandEndpoints.0="http://wso2.com"`

 
To set the endpoint using system properties, use following method (replace . with _ in linux environment)
`export TestAPI_v1_prodEndpoints_0="http://wso2.com"`
