### PR TITLE
Fixed bugs and improvements

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
@@ -102,6 +102,9 @@ public class SetupCmd implements GatewayLauncherCmd {
     @Parameter(names = { "-v", "--version" }, hidden = true)
     private String version;
 
+    @Parameter(names = { "-f", "--force" }, hidden = true, arity = 0)
+    private boolean isForcefully;
+
     private String publisherEndpoint;
     private String adminEndpoint;
     private String registrationEndpoint;
@@ -118,6 +121,10 @@ public class SetupCmd implements GatewayLauncherCmd {
             configPath = GatewayCmdUtils.getMainConfigLocation();
         }
 
+        if (new File(workspace + File.separator + projectName).exists() && !isForcefully) {
+            throw GatewayCmdUtils.createUsageException("Project name `" + projectName
+                    + "` already exist. use -f or --force to forcefully update the project directory.");
+        }
         init(workspace, projectName, configPath);
 
         Config config = GatewayCmdUtils.getConfig();

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -576,7 +576,13 @@ public class GatewayCmdUtils {
             }
         } else {
             //Copy the file content from one place to another
-            Files.copy(sourceFolder.toPath(), destinationFolder.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(sourceFolder.toPath(), destinationFolder.toPath(), StandardCopyOption.REPLACE_EXISTING,
+                    StandardCopyOption.COPY_ATTRIBUTES);
+            //Make it writable, so that next time can clear the files without a permission issue
+            boolean success = destinationFolder.setWritable(true);
+            if (!success) {
+                logger.debug("Setting write permission failed for {}", destinationFolder.getAbsolutePath());
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose
> Fixed permission issue when clearing write protected files which are generated in first time.

> Add option to forcefully update the project 

 ex:
$micro-gw setup -l apimTestLabel -n myProject -s https://localhost:9444/ -u admin -p admin
$[micro-gw: Project name `myProject` already exist. use -f or --force to forcefully update the project directory., Run 'micro-gw help' for usage.]

$micro-gw setup -l apimTestLabel -n myProject -s https://localhost:9444/ -u admin -p admin -f
$Setting up project myProject successful.