### PR TITLE
Add basic auth support for backend EP

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/templates/service.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/service.mustache
@@ -13,7 +13,14 @@ endpoint http:Client {{qualifiedServiceName}}_PROD_EP {
     cache: { enabled: false }
     {{else}},
     cache: { isShared: true }
+    {{/equals}}{{#api.endpointSecurity}}{{#equals api.endpointSecurity.type "basic"}},
+    auth: {
+        scheme: "Basic",
+        username: gateway:retrieveConfig("{{api.name}}.{{api.version}}.basic.username", "{{api.endpointSecurity.username}}"),
+        password: gateway:retrieveConfig("{{api.name}}.{{api.version}}.basic.password", "")
+    }
     {{/equals}}
+    {{/api.endpointSecurity}}
 };
 {{/endpointConfig.prodEndpoints}}
 {{#endpointConfig.sandEndpoints}}
@@ -22,7 +29,14 @@ endpoint http:Client {{qualifiedServiceName}}_SAND_EP {
     cache: { enabled: false }
     {{else}},
         cache: { isShared: true }
+    {{/equals}}{{#api.endpointSecurity}}{{#equals api.endpointSecurity.type "basic"}},
+    auth: {
+        scheme: "Basic",
+        username: gateway:retrieveConfig("{{api.name}}.{{api.version}}.basic.username", "{{api.endpointSecurity.username}}"),
+        password: gateway:retrieveConfig("{{api.name}}.{{api.version}}.basic.password", "")
+    }
     {{/equals}}
+    {{/api.endpointSecurity}}
 };
 {{/endpointConfig.sandEndpoints}}
 

--- a/components/micro-gateway-core/src/main/ballerina/gateway/utils/utils.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/utils/utils.bal
@@ -394,6 +394,11 @@ public function retrieveEndPointURL(string key, string default) returns string {
     return config:getAsString(key, default = default);
 }
 
+@Description {value:"Retrieve external configurations defined against a key"}
+public function retrieveConfig(string key, string default) returns string { 
+    return config:getAsString(key, default = default);
+}
+
 function initStreamPublisher() {
     log:printInfo("Subscribing writing method to event stream");
     eventStream.subscribe(writeEventToFile);


### PR DESCRIPTION
If the backend EP is protected with basic auth, you have to provide credentials related to that endpoint. Use following system variables to define them

`-e TestAPI.v1.basic.username="admin" -e TestAPI.v1.basic.password="admin" `

If username is not defined, username defined in the API (During the API implementation time) will be used.
To set the credentials using system properties, use following method (replace . with _ in linux environment)
`export TestAPI_v1_basic_username="admin"`
`export TestAPI_v1_basic_password="admin"`

