### PR TITLE
Add capability to pass system variables from outside the startup script

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/distribution/bin/gateway
+++ b/components/micro-gateway-cli/src/main/resources/distribution/bin/gateway
@@ -125,4 +125,4 @@ elif [ "$CMD" = "restart" ]; then
 fi
 
 # run the balx created for ${label} APIs
-sh $BALLERINA_HOME/bin/ballerina run $GWHOME/exec/${label}.balx -e b7a.http.accesslog.path=$GWHOME/logs/access_logs --config $GWHOME/conf/micro-gw.conf
+sh $BALLERINA_HOME/bin/ballerina run $GWHOME/exec/${label}.balx -e b7a.http.accesslog.path=$GWHOME/logs/access_logs --config $GWHOME/conf/micro-gw.conf "$@"


### PR DESCRIPTION
System properties can be passed during the gatway startup time. 

ex:
`sh gateway -e BasicAuth.1.0.prod.basic.username=chamila -e BasicAuth.1.0.prod.basic.password=adhi`