### PR TITLE
Adding a flag to enable/disable file uploading task.

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/constants/constants.bal
@@ -165,6 +165,8 @@
 @final public string API_USAGE_PATH = "api.usage.data.path";
 @Description { value: "API usage data directory" }
 @final public string API_USAGE_DIR = "api-usage-data";
+@Description { value: "Key of file uploading config" }
+@final public string FILE_UPLOAD_TASK = "task.uploadFiles";
 
 
 

--- a/components/micro-gateway-core/src/main/ballerina/gateway/uploade_files_timer.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/uploade_files_timer.bal
@@ -57,10 +57,16 @@ function informError(error e) {
 function timerTask() {
     task:Timer? timer;
     map vals = getConfigMapValue(ANALYTICS);
-    int timeSpan =  check <int> vals[UPLOADING_TIME_SPAN];
-    (function() returns error?) onTriggerFunction = searchFilesToUpload;
-    function(error) onErrorFunction = informError;
-    timer = new task:Timer(onTriggerFunction, onErrorFunction, timeSpan, delay = 5000);
-    timer.start();
+    boolean uploadFiles = check <boolean>vals[FILE_UPLOAD_TASK];
+    if (uploadFiles) {
+        log:printInfo("File uploading task is enabled.");
+        int timeSpan = check <int>vals[UPLOADING_TIME_SPAN];
+        (function() returns error?) onTriggerFunction = searchFilesToUpload;
+        function(error) onErrorFunction = informError;
+        timer = new task:Timer(onTriggerFunction, onErrorFunction, timeSpan, delay = 5000);
+        timer.start();
+    } else {
+        log:printInfo("File uploading task is disabled.");
+    }
 }
 

--- a/distribution/resources/conf/micro-gw.conf
+++ b/distribution/resources/conf/micro-gw.conf
@@ -46,9 +46,10 @@ tokenCache.capacity=100
 tokenCache.evictionFactor=0.25
 
 [analytics]
-uploadingTimeSpanInMillis=60000
+uploadingTimeSpanInMillis=600000
 uploadingEndpoint="https://localhost:9443/micro-gateway/v0.10/usage/upload-file"
-rotatingPeriod=60000
+rotatingPeriod=600000
+task.uploadFiles=true
 
 [b7a.log]
 level="TRACE"

--- a/tests/src/test/resources/confs/base.conf
+++ b/tests/src/test/resources/confs/base.conf
@@ -46,3 +46,4 @@ tokenCache.evictionFactor=0.25
 uploadingTimeSpanInMillis=600000
 uploadingEndpoint="https://localhost:9443/micro-gateway/v0.9/usage/upload-file"
 rotatingPeriod=60000
+task.uploadFiles=true

--- a/tests/src/test/resources/confs/default-test-config.conf
+++ b/tests/src/test/resources/confs/default-test-config.conf
@@ -46,3 +46,4 @@ tokenCache.evictionFactor=0.25
 uploadingTimeSpanInMillis=600000
 uploadingEndpoint="https://localhost:9443/micro-gateway/v0.9/usage/upload-file"
 rotatingPeriod=60000
+task.uploadFiles=true

--- a/tests/src/test/resources/confs/startup.conf
+++ b/tests/src/test/resources/confs/startup.conf
@@ -46,3 +46,4 @@ tokenCache.evictionFactor=0.25
 uploadingTimeSpanInMillis=600000
 uploadingEndpoint="https://localhost:9443/micro-gateway/v0.9/usage/upload-file"
 rotatingPeriod=60000
+task.uploadFiles=true


### PR DESCRIPTION
## Purpose
To enable or disable file uploading tasks in a distributed environment with shared file system.

## Goals
Adding a flag to define as true or false in conf.
Depending on the value, it will activate or deactivate the task.
By default it has been set to true.

