### PR TITLE
Fix background process starting issue

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/distribution/bin/gateway
+++ b/components/micro-gateway-cli/src/main/resources/distribution/bin/gateway
@@ -74,7 +74,7 @@ do
 done
 
 if [ "$CMD" = "start" ]; then
-  if [ -e "$GWHOME/bin/gateway.pid" ] && [ -z "$PID" ]; then
+  if [ -e "$GWHOME/bin/gateway.pid" ]; then
     if  ps -p $PID > /dev/null ; then
       echo "Process is already running"
       exit 0


### PR DESCRIPTION
When a process is started in background (**sh gateway start**) and when a new process is started again in background (**sh gateway start**), no message is shown. Currently, a new process starts with errors. 

Fix displays "Process already running" message for this scenario 