### PR TITLE
Adding json.toString convertion to metaData.

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/gateway/data_writer.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/data_writer.bal
@@ -40,9 +40,9 @@ function getPayload(AnalyticsRequestStream requestStreamForPayload) returns (str
         .applicationOwner;
 }
 
-function getMetaData(AnalyticsRequestStream requestStreamForMetaData) returns (string) {
-    return "{\\\"keyType\\\":\"" + requestStreamForMetaData.keyType + "\",\\\"correlationID\\\":\"" + requestStreamForMetaData
-        .correlationID + "\"}";
+function getMetaData(AnalyticsRequestStream dto) returns (string) {
+    json metaData = { "keyType": dto.keyType, "correlationID": dto.correlationID };
+    return metaData.toString();
 }
 
 function getCorrelationData(AnalyticsRequestStream request) returns (string) {

--- a/components/micro-gateway-core/src/main/ballerina/gateway/executiontime_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/executiontime_util.bal
@@ -31,7 +31,8 @@ function getExecutionTimePayload(ExecutionTimeDTO executionTimeDTO) returns stri
 }
 
 function getMetaDataForExecutionTimeDTO(ExecutionTimeDTO dto) returns string {
-    return "{\\\"keyType\\\":\"" + dto.keyType + "\",\\\"correlationID\\\":\"" + dto.correleationID + "\"}";
+    json metaData = { "keyType": dto.keyType, "correlationID": dto.correleationID };
+    return metaData.toString();
 }
 
 function generateEventFromExecutionTime(ExecutionTimeDTO executionTimeDTO) returns EventDTO {

--- a/components/micro-gateway-core/src/main/ballerina/gateway/responsetime_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/responsetime_util.bal
@@ -36,7 +36,8 @@ function getReponseDataPayload(ResponseDTO responseDTO) returns string {
 }
 
 function getMetaDataForResponseData(ResponseDTO dto) returns string {
-    return "{\\\"keyType\\\":\"" + dto.keyType + "\",\\\"correlationID\\\":\"" + dto.correlationID + "\"}";
+    json metaData = { "keyType": dto.keyType, "correlationID": dto.correlationID };
+    return metaData.toString();
 }
 
 function generateEventFromResponseDTO(ResponseDTO responseDTO) returns EventDTO {


### PR DESCRIPTION
## Purpose
Avoid using string in JSON format for meta data

