### PR TITLE
Handle project creation with invalid label scenario

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
@@ -32,6 +32,7 @@ import org.wso2.apimgt.gateway.cli.constants.GatewayCliConstants;
 import org.wso2.apimgt.gateway.cli.constants.RESTServiceConstants;
 import org.wso2.apimgt.gateway.cli.exception.BallerinaServiceGenException;
 import org.wso2.apimgt.gateway.cli.exception.CLIInternalException;
+import org.wso2.apimgt.gateway.cli.exception.CLIRuntimeException;
 import org.wso2.apimgt.gateway.cli.exception.CliLauncherException;
 import org.wso2.apimgt.gateway.cli.exception.ConfigParserException;
 import org.wso2.apimgt.gateway.cli.exception.HashingException;
@@ -268,7 +269,21 @@ public class SetupCmd implements GatewayLauncherCmd {
             apis = service.getAPIs(label, accessToken);
         } else {
             ExtendedAPI api = service.getAPI(apiName, version, accessToken);
-            apis.add(api);
+            if(api != null) {
+                apis.add(api);
+            }
+        }
+        if (apis == null || (apis != null && apis.isEmpty())) {
+            //Delete folder
+            GatewayCmdUtils.deleteProject(workspace + File.separator + projectName);
+            String errorMsg = "";
+            if (label != null) {
+                errorMsg = "No APIs found for the given label: " + label;
+            } else {
+                errorMsg = "No Published APIs matched for name:" + apiName + ", version:" + version;
+            }
+            logger.error("Error while generating ballerina source." + errorMsg);
+            throw new CLIRuntimeException(errorMsg);
         }
         List<ApplicationThrottlePolicyDTO> applicationPolicies = service.getApplicationPolicies(accessToken);
         List<SubscriptionThrottlePolicyDTO> subscriptionPolicies = service.getSubscriptionPolicies(accessToken);

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
@@ -276,13 +276,12 @@ public class SetupCmd implements GatewayLauncherCmd {
         if (apis == null || (apis != null && apis.isEmpty())) {
             // Delete folder
             GatewayCmdUtils.deleteProject(workspace + File.separator + projectName);
-            String errorMsg = "";
+            String errorMsg;
             if (label != null) {
                 errorMsg = "No APIs found for the given label: " + label;
             } else {
                 errorMsg = "No Published APIs matched for name:" + apiName + ", version:" + version;
             }
-            logger.error("Error while generating ballerina source." + errorMsg);
             throw new CLIRuntimeException(errorMsg);
         }
         List<ApplicationThrottlePolicyDTO> applicationPolicies = service.getApplicationPolicies(accessToken);

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
@@ -269,12 +269,12 @@ public class SetupCmd implements GatewayLauncherCmd {
             apis = service.getAPIs(label, accessToken);
         } else {
             ExtendedAPI api = service.getAPI(apiName, version, accessToken);
-            if(api != null) {
+            if (api != null) {
                 apis.add(api);
             }
         }
         if (apis == null || (apis != null && apis.isEmpty())) {
-            //Delete folder
+            // Delete folder
             GatewayCmdUtils.deleteProject(workspace + File.separator + projectName);
             String errorMsg = "";
             if (label != null) {

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/rest/RESTAPIServiceImpl.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/rest/RESTAPIServiceImpl.java
@@ -143,8 +143,7 @@ public class RESTAPIServiceImpl implements RESTAPIService {
                         }
                     }
                     if (matchedAPI == null) {
-                        throw new CLIRuntimeException(
-                                "No Published APIs matched for name:" + apiName + ", version:" + version);
+                        return matchedAPI;
                     }
                     //set additional configs such as CORS configs from the toolkit configuration
                     setAdditionalConfigs(matchedAPI);

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -819,4 +819,40 @@ public class GatewayCmdUtils {
             }
         }
     }
+    
+    /**
+     * Delete project folder
+     * @param projectPath project path
+     */
+    public static void deleteProject(String projectPath) {
+
+        File file = new File(projectPath);
+        try {
+            // Deleting the directory recursively.
+            delete(file);
+        } catch (IOException e) {
+	    //not throwing the error because deleting faild project is not
+            // a critical task. This can be deleted manually if not used.
+            logger.error("Failed to delete project : {} ", projectPath, e);
+        }
+
+    }
+
+    private static void delete(File file) throws IOException {
+
+        for (File childFile : file.listFiles()) {
+
+            if (childFile.isDirectory()) {
+                delete(childFile);
+            } else {
+                if (!childFile.delete()) {
+                    throw new IOException();
+                }
+            }
+        }
+
+        if (!file.delete()) {
+            throw new IOException();
+        }
+    }
 }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -825,23 +825,19 @@ public class GatewayCmdUtils {
      * @param projectPath project path
      */
     public static void deleteProject(String projectPath) {
-
         File file = new File(projectPath);
         try {
             // Deleting the directory recursively.
             delete(file);
         } catch (IOException e) {
-	    //not throwing the error because deleting faild project is not
+            // not throwing the error because deleting faild project is not
             // a critical task. This can be deleted manually if not used.
             logger.error("Failed to delete project : {} ", projectPath, e);
         }
-
     }
 
     private static void delete(File file) throws IOException {
-
         for (File childFile : file.listFiles()) {
-
             if (childFile.isDirectory()) {
                 delete(childFile);
             } else {
@@ -850,7 +846,6 @@ public class GatewayCmdUtils {
                 }
             }
         }
-
         if (!file.delete()) {
             throw new IOException();
         }


### PR DESCRIPTION
Handle project creation with invalid label scenario. When a project is created with an invalid label, show valid error message on the CLI and delete the partially created project. Same goes to project creation with api name version combination. 

