### PR TITLE
Fix startup memory allocation param issue for MacOS

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/distribution/bin/gateway
+++ b/components/micro-gateway-cli/src/main/resources/distribution/bin/gateway
@@ -52,8 +52,9 @@ if [ -e "$GWHOME/bin/gateway.pid" ]; then
 fi
 
 # Set JAVA Xms and Xmx values in Ballerina runtime
-sed -i "s/-Xms[0-9]*m\+/-Xms$JAVA_XMS_VALUE/" $BALLERINA_HOME/bin/ballerina
-sed -i "s/-Xmx[0-9]*m\+/-Xmx$JAVA_XMX_VALUE/" $BALLERINA_HOME/bin/ballerina
+sed -i".back" "s/-Xms[0-9]*m/-Xms$JAVA_XMS_VALUE/" $BALLERINA_HOME/bin/ballerina
+sed -i".back" "s/-Xmx[0-9]*m/-Xmx$JAVA_XMX_VALUE/" $BALLERINA_HOME/bin/ballerina
+rm $BALLERINA_HOME/bin/ballerina.back
 
 # ----- Process the input command ----------------------------------------------
 args=""


### PR DESCRIPTION
Existing sed command only works in gnu-sed. sed comes in MacOS does not support this. Modified to work on both linux and MacOS