### PR TITLE
Remove JWT expiry check in Subscription filter

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/gateway/filters/subscription_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/filters/subscription_filter.bal
@@ -51,20 +51,6 @@ public type SubscriptionFilter object {
                     match getDecodedJWTPayload(jwtPayload) {
                         json decodedPayload => {
                             printTrace(KEY_SUBSCRIPTION_FILTER, "Decoded JWT payload: " + decodedPayload.toString());
-
-                            //todo: Adding this as a temporary fix until Ballerina validates the JWT expiry.
-                            APIKeyValidationDto apiKeyValidationDto;
-                            int tokenIssuedTime = check <int> decodedPayload.iat;
-                            int tokenExpiredTime = check <int> decodedPayload.exp;
-                            apiKeyValidationDto.validityPeriod = <string>(tokenExpiredTime - tokenIssuedTime);
-                            apiKeyValidationDto.issuedTime = <string>tokenIssuedTime;
-
-                            if (isAccessTokenExpired(apiKeyValidationDto)) {
-                                printDebug(KEY_SUBSCRIPTION_FILTER, "JWT Access token has expired.");
-                                setErrorMessageToFilterContext(filterContext, API_AUTH_INVALID_CREDENTIALS);
-                                sendErrorResponse(listener, request, filterContext);
-                                return false;
-                            }
                             json subscribedAPIList = decodedPayload.subscribedAPIs;
                             APIConfiguration apiConfig = getAPIDetailsFromServiceAnnotation(reflect:
                                 getServiceAnnotations(filterContext.serviceType));

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/common/BaseTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/common/BaseTestCase.java
@@ -39,6 +39,7 @@ import java.security.PrivateKey;
 import java.security.Signature;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.concurrent.TimeUnit;
 import java.util.UUID;
 
 /**
@@ -76,7 +77,8 @@ public class BaseTestCase {
         MockAPIPublisher.getInstance().clear();
     }
 
-    protected String getJWT(API api, ApplicationDTO applicationDTO, String tier, String keyType) throws Exception {
+    protected String getJWT(API api, ApplicationDTO applicationDTO, String tier, String keyType, int validityPeriod)
+            throws Exception {
         SubscribedApiDTO subscribedApiDTO = new SubscribedApiDTO();
         subscribedApiDTO.setContext("/" + api.getContext() + "/" + api.getVersion());
         subscribedApiDTO.setName(api.getName());
@@ -93,7 +95,7 @@ public class BaseTestCase {
         jwtTokenInfo.put("iss", "https://localhost:8244/token");
         jwtTokenInfo.put("keytype", keyType);
         jwtTokenInfo.put("subscribedAPIs", new JSONArray(Arrays.asList(subscribedApiDTO)));
-        jwtTokenInfo.put("exp", System.currentTimeMillis() + 3600 * 1000);
+        jwtTokenInfo.put("exp", (int) TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()) + validityPeriod);
         jwtTokenInfo.put("iat", System.currentTimeMillis());
         jwtTokenInfo.put("jti", UUID.randomUUID());
 

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/toolkit/ThrottlingTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/toolkit/ThrottlingTestCase.java
@@ -88,10 +88,10 @@ public class ThrottlingTestCase extends BaseTestCase {
         application3.setId((int) (Math.random() * 1000));
 
         //Register a token with key validation info
-        jwtToken = getJWT(api, application, subscriptionPolicy.getPolicyName(), TestConstant.KEY_TYPE_PRODUCTION);
-        jwtToken2 = getJWT(api, application2, "Unlimited", TestConstant.KEY_TYPE_PRODUCTION);
+        jwtToken = getJWT(api, application, subscriptionPolicy.getPolicyName(), TestConstant.KEY_TYPE_PRODUCTION, 3600);
+        jwtToken2 = getJWT(api, application2, "Unlimited", TestConstant.KEY_TYPE_PRODUCTION, 3600);
         continueOnQuotaToken = getJWT(api, application3, subPolicyContinueOnLimit.getPolicyName(),
-                TestConstant.KEY_TYPE_PRODUCTION);
+                TestConstant.KEY_TYPE_PRODUCTION, 3600);
 
         KeyValidationInfo info = new KeyValidationInfo();
         info.setApi(api);
@@ -114,8 +114,8 @@ public class ThrottlingTestCase extends BaseTestCase {
         appWithNonExistPolicy.setTier("AppPolicyNotExist");
         appWithNonExistPolicy.setId((int) (Math.random() * 1000));
 
-        noSubPolicyJWT = getJWT(api, application, "SubPolicyNotExist", TestConstant.KEY_TYPE_PRODUCTION);
-        noAppPolicyJWT = getJWT(api, appWithNonExistPolicy, "Unlimited", TestConstant.KEY_TYPE_PRODUCTION);
+        noSubPolicyJWT = getJWT(api, application, "SubPolicyNotExist", TestConstant.KEY_TYPE_PRODUCTION, 3600);
+        noAppPolicyJWT = getJWT(api, appWithNonExistPolicy, "Unlimited", TestConstant.KEY_TYPE_PRODUCTION, 3600);
 
         KeyValidationInfo info3 = new KeyValidationInfo();
         info3.setApi(api);


### PR DESCRIPTION
## Purpose
> Remove JWT token expiry check from the subscription filter
> Refactor integration test util methods
> Add a test for API invocation with expired JWT 