### PR TITLE
Workaround to handle expect header at micro-gw

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/templates/service.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/service.mustache
@@ -57,6 +57,7 @@ service<http:Service> {{cut qualifiedServiceName " "}} bind {{#api.transport}}{{
     }
     @gateway:RateLimit{policy : "{{resourceTier}}"}
     {{operationId}} (endpoint outboundEp, http:Request req) {
+    gateway:checkExpectHeaderPresent(req);
     {{#if api.isDefaultVersion}}
     string urlPostfix = untaint req.rawPath.replace("{{api.context}}","");
     {{else}}

--- a/components/micro-gateway-core/src/main/ballerina/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/constants/constants.bal
@@ -281,6 +281,7 @@
 @final public string JWT_CONFIG_INSTANCE_ID = "jwtConfig";
 @Description { value: "JWT  header name"}
 @final public string JWT_HEADER = "header";
+@final public string EXPECT_HEADER = "Expect";
 
 // end of config constants
 

--- a/components/micro-gateway-core/src/main/ballerina/gateway/tokenServices/authorize_endpoint.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/tokenServices/authorize_endpoint.bal
@@ -25,6 +25,7 @@ service<http:Service> authorizeService bind tokenListenerEndpoint {
         path: "/*"
     }
     authorizeResource(endpoint caller, http:Request req) {
+        checkExpectHeaderPresent(req);
         var response = keyValidationEndpoint->forward(getConfigValue(KM_CONF_INSTANCE_ID, KM_TOKEN_CONTEXT, "/oauth2") +
                 untaint req.rawPath, req);
         match response {

--- a/components/micro-gateway-core/src/main/ballerina/gateway/tokenServices/revoke_endpoint.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/tokenServices/revoke_endpoint.bal
@@ -25,6 +25,7 @@ service<http:Service> revokeService bind tokenListenerEndpoint {
         path: "/*"
     }
     revokeResource(endpoint caller, http:Request req) {
+        checkExpectHeaderPresent(req);
         var response = keyValidationEndpoint->forward(getConfigValue(KM_CONF_INSTANCE_ID, KM_TOKEN_CONTEXT, "/oauth2") +
                 untaint req.rawPath, req);
         match response {

--- a/components/micro-gateway-core/src/main/ballerina/gateway/tokenServices/token_endpoint.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/tokenServices/token_endpoint.bal
@@ -25,6 +25,7 @@ service<http:Service> tokenService bind tokenListenerEndpoint {
         path: "/*"
     }
     tokenResource(endpoint caller, http:Request req) {
+        checkExpectHeaderPresent(req);
         var response = keyValidationEndpoint->forward(getConfigValue(KM_CONF_INSTANCE_ID, KM_TOKEN_CONTEXT, "/oauth2") +
                 untaint req.rawPath, req);
         match response {

--- a/components/micro-gateway-core/src/main/ballerina/gateway/tokenServices/user_info_endpoint.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/tokenServices/user_info_endpoint.bal
@@ -25,6 +25,7 @@ service<http:Service> userInfoService bind tokenListenerEndpoint {
         path: "/*"
     }
     userInfoResource(endpoint caller, http:Request req) {
+        checkExpectHeaderPresent(req);
         var response = keyValidationEndpoint->forward(getConfigValue(KM_CONF_INSTANCE_ID, KM_TOKEN_CONTEXT, "/oauth2") +
                 untaint req.rawPath, req);
         match response {

--- a/components/micro-gateway-core/src/main/ballerina/gateway/utils/utils.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/utils/utils.bal
@@ -460,3 +460,11 @@ function checkOrSetMessageID(http:FilterContext context) {
         context.attributes[MESSAGE_ID] = system:uuid();
     }
 }
+
+public function checkExpectHeaderPresent(http:Request request) {
+    if (request.expects100Continue()) {
+        request.removeHeader(EXPECT_HEADER);
+        printDebug(KEY_UTILS, "Expect header is removed from the request");
+
+    }
+}


### PR DESCRIPTION
## Purpose
> Ballerina 0.98.1 has a issue in handling requests with expect header. So in this PR we are removing Expect header from request once it reaches the micro gateway. The client will not be responded with 100 continue, only the main response will be sent.
We have created issue at ballerina to get this resolved in future [1]

[1] - https://github.com/ballerina-platform/ballerina-lang/issues/10389

