### PR TITLE
Fix microgateway building issue with API name having hyphon or dot

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/CodegenUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/CodegenUtils.java
@@ -121,10 +121,7 @@ public class CodegenUtils {
         if (key == null) {
             return null;
         }
-        key = key.replaceAll(" ", "_");
-        key = key.replaceAll("/", "_");
-        key = key.replaceAll("\\{", "_");
-        key = key.replaceAll("}", "_");
+        key = key.replaceAll("(\\.)|(-)|(\\{)|(})|(\\s)|(/)", "_");
         if (key.contains("*")) {
             key = key.replaceAll("\\*", UUID.randomUUID().toString().replaceAll("-", "_"));
         }


### PR DESCRIPTION
## Purpose
> When APIs having names like "ABC-API" or "ABC.DEF", microgateway fails to build since "-,." is not allowed in compile time.

## Goals
> The fix is to trim such special characters to an allowed character in compile time.

## Approach
> N/A

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A
## Related PRs
> N/A

## Migrations (if applicable)
> N/A
