### PR TITLE
Fix setup and build command output stream issue

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
@@ -38,7 +38,7 @@ import java.util.List;
 @Parameters(commandNames = "build", commandDescription = "micro gateway build information")
 public class BuildCmd implements GatewayLauncherCmd {
     private static final Logger logger = LoggerFactory.getLogger(BuildCmd.class);
-    private static PrintStream outStream = System.err;
+    private static PrintStream outStream = System.out;
     @SuppressWarnings("unused")
     @Parameter(names = "--java.debug", hidden = true)
     private String javaDebugPort;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
@@ -68,7 +68,7 @@ import java.util.List;
 @Parameters(commandNames = "setup", commandDescription = "setup information")
 public class SetupCmd implements GatewayLauncherCmd {
     private static final Logger logger = LoggerFactory.getLogger(SetupCmd.class);
-    private static PrintStream outStream = System.err;
+    private static PrintStream outStream = System.out;
 
     @SuppressWarnings("unused")
     @Parameter(hidden = true, required = true)


### PR DESCRIPTION
## Purpose
> microgateway build command output and setup command output successful messages are getting as error output streams. This code change is to fix the issue and get the output as a system out string instead of an error.

## Goals
> Fixing following issue
![image](https://user-images.githubusercontent.com/8381009/46654652-09507b80-cbc7-11e8-9d2e-aeb17fa85cd3.png)

## Approach
> N/A

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK 1.8
 
## Learning
> N/A