### PR TITLE
Add support for multiple trusted JWT providers

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/templates/listeners.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/listeners.mustache
@@ -63,7 +63,8 @@ registry.add(provider.scheme + "-" + i, gateway:createAuthHandler(provider));
 i++;
 }
 // Adding basic and JWT authentication providers to a the handler chain
-http:AuthnHandlerChain authnHandlerChain = new(registry);
+// TODO: use http:AuthnHandlerChain once we update the Ballerina version to 0.983+
+gateway:AuthnHandlerChain authnHandlerChain = new(registry);
 // OAuth authentication handler
 gateway:OAuthnAuthenticator oauthAuthenticator = new;
 // Register OAuth authentication handler,basic and JWT authentication providers to the authentication filter

--- a/components/micro-gateway-core/src/main/ballerina/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/constants/constants.bal
@@ -280,6 +280,17 @@
 @Description { value: "Trust store password" }
 @final public string TRSUT_STORE_PASSWORD = "trustStore.password";
 
+@Description { value: "Default value of JWT issuer if not provided in configuration" }
+@final public string DEFAULT_ISSUER = "https://localhost:9443/oauth2/token";
+@Description { value: "Default value of JWT audience if not provided in configuration" }
+@final public string DEFAULT_AUDIENCE = "RQIO7ti2OThP79wh3fE5_Zksszga";
+@Description { value: "Default value of JWT certificate alias if not provided in configuration" }
+@final public string DEFAULT_CERTIFICATE_ALIAS = "ballerina";
+@Description { value: "Default value of JWT validation trust store path if not provided in configuration" }
+@final public string DEFAULT_TRUST_STORE_PATH = "${ballerina.home}/bre/security/ballerinaTruststore.p12";
+@Description { value: "Default value of JWT validation trust store password if not provided in configuration" }
+@final public string DEFAULT_TRUST_STORE_PASSWORD = "ballerina";
+
 @Description { value: "Caching configs" }
 @final public string CACHING_ID = "caching";
 @Description { value: "Token cache enabled or not " }

--- a/components/micro-gateway-core/src/main/ballerina/gateway/filters/authn_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/filters/authn_filter.bal
@@ -32,7 +32,7 @@ import ballerina/reflect;
 public type AuthnFilter object {
 
     public OAuthnAuthenticator oauthnHandler;// Handles the oauth2 authentication;
-    public http:AuthnHandlerChain authnHandlerChain;
+    public AuthnHandlerChain authnHandlerChain;
 
 
     public new (oauthnHandler, authnHandlerChain) {}
@@ -91,7 +91,6 @@ public type AuthnFilter object {
             // if auth providers are there, use those to authenticate
             if(providerId != AUTH_SCHEME_OAUTH2) {
                 printDebug(KEY_AUTHN_FILTER, "Non-OAuth token found. Calling the auth scheme : " + providerId );
-                string[] providerIds = [providerId];
                 // if authorization header is not default auth header we need to set it to the default header in
                 // order for jwt to work. If there is an already default auth header we back up it to a temp auth
                 // header and set the default authentication header.
@@ -107,7 +106,7 @@ public type AuthnFilter object {
 
                 try {
                     printDebug(KEY_AUTHN_FILTER, "Processing request with the Authentication handler chain");
-                    isAuthorized = self.authnHandlerChain.handleWithSpecificAuthnHandlers(providerIds, request);
+                    isAuthorized = self.authnHandlerChain.handle(request);
                     printDebug(KEY_AUTHN_FILTER, "Authentication handler chain returned with value : " + isAuthorized);
                     checkAndRemoveAuthHeaders(request, authHeaderName);
                 } catch (error err) {

--- a/components/micro-gateway-core/src/main/ballerina/gateway/filters/authn_handler_chain.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/filters/authn_handler_chain.bal
@@ -1,0 +1,88 @@
+// Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file   except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+import ballerina/log;
+import ballerina/auth;
+import ballerina/http;
+
+documentation {
+    Representation of Authentication handler chain. Originally taken from ballerina/http package as the ballarina
+    version 0.981.1 http:AuthnHandlerChain does not validate against all the AuthHandlers in the AuthHandlerRegistry.
+    This implementation is based on the original fix for this issue.
+    See https://github.com/ballerina-platform/ballerina-lang/pull/11139
+    Once the Ballerina version is updated to 0.983.0 or above, we can reuse the http:AuthnHandlerChain
+
+    F{{authHandlerRegistry}} `AuthHandlerRegistry` instance
+}
+public type AuthnHandlerChain object {
+    private http:AuthHandlerRegistry authHandlerRegistry;
+
+    public new (authHandlerRegistry) {
+    }
+
+    documentation {
+        Tries to authenticate against any one of the available authentication handlers
+
+        P{{req}} `Request` instance
+        R{{}} true if authenticated successfully, else false
+    }
+    public function handle (http:Request req) returns (boolean);
+
+    documentation {
+        Tries to authenticate against a specifc sub set of the authentication handlers, using the given array of auth provider ids
+
+        P{{authProviderIds}} array of auth provider ids
+        P{{req}} `Request` instance
+        R{{}} true if authenticated successfully, else false
+    }
+    public function handleWithSpecificAuthnHandlers (string[] authProviderIds, http:Request req) returns (boolean);
+};
+
+function AuthnHandlerChain::handle (http:Request req) returns (boolean) {
+    foreach currentAuthProviderType, currentAuthHandler in self.authHandlerRegistry.getAll() {
+        var authnHandler = <http:HttpAuthnHandler> currentAuthHandler;
+        if (authnHandler.canHandle(req)) {
+            log:printDebug("Trying to authenticate with the auth provider: " + currentAuthProviderType);
+            boolean authnSuccessful = authnHandler.handle(req);
+            if (authnSuccessful) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+function AuthnHandlerChain::handleWithSpecificAuthnHandlers (string[] authProviderIds, http:Request req)
+                                returns (boolean) {
+    foreach authProviderId in authProviderIds {
+        match self.authHandlerRegistry.get(authProviderId) {
+            http:HttpAuthnHandler authnHandler => {
+                if (authnHandler.canHandle(req)) {
+                    log:printDebug("Trying to authenticate with the auth provider: " + authProviderId);
+                    boolean authnSuccessful = authnHandler.handle(req);
+                    if (authnSuccessful) {
+                        return true;
+                    }
+                }
+            }
+            () => {
+                // nothing to do
+            }
+        }
+    }
+    return false;
+}


### PR DESCRIPTION
## Purpose
This PR adds the support for configuring multiple JWT providers for validating.

## Goals
To validate JWT tokens offered by multiple issuers.

## User stories
Microgateway should be able to validate JWT tokens offered by different issuers.

## Documentation
The Microgateway can be configured to allow multiple JWT issuers as follows,
```
[jwtTokenConfig]
# Comma separated list of provider keys (Optional for backward compatibility) 
providers="provider1,provider2"

# Provider 1 configuration. This should match the name provided in "providers" section
[jwtTokenConfig.provider1]
issuer=
audience=
certificateAlias=
trustStore.path=
trustStore.password=

[jwtTokenConfig.provider2]
issuer=
audience=
certificateAlias=
trustStore.path=
trustStore.password=
```
