### PR TITLE
Fixed the error when build with forward slash

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
@@ -61,6 +61,7 @@ public class BuildCmd implements GatewayLauncherCmd {
 
         try {
             projectName = GatewayCmdUtils.getProjectName(mainArgs);
+            projectName = projectName.replaceAll("\\/","");
             File projectLocation = new File(GatewayCmdUtils.getProjectDirectoryPath(projectName));
             if (!projectLocation.exists()) {
                 throw new CLIRuntimeException("Project " + projectName + " does not exist.");

--- a/distribution/resources/bin/micro-gw
+++ b/distribution/resources/bin/micro-gw
@@ -157,7 +157,7 @@ done
 set -- "${ALL_ARGS[@]}"
 
 # take the first default argument as the project name
-CMD_PRO_NAME_VAL=${DEFAULT_ARGS[0]}
+CMD_PRO_NAME_VAL=$(echo ${DEFAULT_ARGS[0]}|sed 's#/##g')
 
 #execute build command
 if [ "$IS_BUILD_COMMAND" = true ] && [ "$CMD_PRO_NAME_VAL" != "" ] && [ "$MICRO_GW_PROJECT_DIR" != "" ]; then


### PR DESCRIPTION
## Purpose
This fixes for the error occuring when forward slash is added after the projectName while building the microgateway

##Approach
It couldn't provide proper error message for that since the error thrown from ballerina backend.
Therefore,change the bash file in micro gateway as omiting slashes when it takes the first default argument in project name.
Also it escapes the the slashes when build the java program







Resolved: https://github.com/wso2/product-apim/issues/3894