### PR TITLE
Add gRPC support for API product micro-gateway 2.x 

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
@@ -231,10 +231,8 @@ public class SetupCmd implements GatewayLauncherCmd {
                             throw GatewayCmdUtils.createUsageException("Micro gateway setup failed: empty endpoint.");
                         }
                     }
-                    endpointConfig = "{\"production_endpoints\":{\"url\":\"" + endpoint.trim() +
-                            "\"},\"endpoint_type\":\"http\"}";
                 }
-                codeGenerator.generateGrpc(projectName, api, endpointConfig, true);
+                codeGenerator.generateGrpc(projectName, api, true);
                 //Initializing the ballerina project and creating .bal folder.
                 logger.debug("Creating source artifacts");
                 InitHandler.initialize(Paths.get(GatewayCmdUtils.getProjectDirectoryPath(projectName)), null,

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
@@ -205,6 +205,9 @@ public class CodeGenerator {
      * Generated source will be written to a ballerina package at {@code outPath}
      * <p>Method can be user for generating Ballerina mock services and clients</p>
      *
+     * @param projectName name of the project being set up
+     * @param apiDef      api definition string
+     * @param overwrite   whether existing files overwrite or not
      * @throws IOException                  when file operations fail
      * @throws BallerinaServiceGenException when code generator fails
      */

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
@@ -204,7 +204,6 @@ public class CodeGenerator {
      * Generates ballerina source for provided Open APIDetailedDTO Definition in {@code definitionPath}.
      * Generated source will be written to a ballerina package at {@code outPath}
      * <p>Method can be user for generating Ballerina mock services and clients</p>
-     *
      * @param projectName name of the project being set up
      * @param apiDef      api definition string
      * @param overwrite   whether existing files overwrite or not

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
@@ -208,7 +208,7 @@ public class CodeGenerator {
      * @throws IOException                  when file operations fail
      * @throws BallerinaServiceGenException when code generator fails
      */
-    public void generateGrpc(String projectName, String apiDef, String endpointDef, boolean overwrite)
+    public void generateGrpc(String projectName, String apiDef, boolean overwrite)
             throws IOException, BallerinaServiceGenException {
         BallerinaService definitionContext;
         String projectSrcPath = GatewayCmdUtils
@@ -219,21 +219,22 @@ public class CodeGenerator {
         File[] files = dir.listFiles();
         genFiles.add(generateCommonEndpoints());
         CodegenUtils.writeGeneratedSources(genFiles, Paths.get(projectSrcPath), overwrite);
+
         GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getFiltersFolderLocation() + File.separator
                         + GatewayCliConstants.GW_DIST_EXTENSION_FILTER,
                 projectSrcPath + File.separator + GatewayCliConstants.GW_DIST_EXTENSION_FILTER);
+
         for (File file : dir.listFiles()) {
             String filePath = file.getAbsolutePath();
             String fileName = file.getName();
             FileSystem fileSys = FileSystems.getDefault();
             Path source = fileSys.getPath(filePath);
             Path destination = fileSys.getPath(projectSrcPath + File.separator + fileName);
-            Files.move(source , destination, StandardCopyOption.REPLACE_EXISTING);
+            Files.move(source, destination, StandardCopyOption.REPLACE_EXISTING);
         }
+
         File temp = new File(GatewayCmdUtils.getProjectGrpcSoloDirectoryPath());
-        boolean k =dir.delete();
-        boolean m = temp.delete();
-        System.out.println(k);
-        System.out.println(m);
+        dir.delete();
+        temp.delete();
     }
 }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
@@ -31,13 +31,18 @@ import org.wso2.apimgt.gateway.cli.model.template.GenSrcFile;
 import org.wso2.apimgt.gateway.cli.model.template.service.BallerinaService;
 import org.wso2.apimgt.gateway.cli.model.template.service.ListenerEndpoint;
 import org.wso2.apimgt.gateway.cli.utils.CodegenUtils;
-import org.wso2.apimgt.gateway.cli.utils.OpenApiCodegenUtils;
 import org.wso2.apimgt.gateway.cli.utils.GatewayCmdUtils;
+import org.wso2.apimgt.gateway.cli.utils.OpenApiCodegenUtils;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Paths;
+import java.nio.file.FileSystems;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -71,7 +76,7 @@ public class CodeGenerator {
             swagger = parser.parse(api.getApiDefinition());
             definitionContext = new BallerinaService().buildContext(swagger, api);
             // we need to generate the bal service for default versioned apis as well
-            if(definitionContext.getApi().getIsDefaultVersion()) {
+            if (definitionContext.getApi().getIsDefaultVersion()) {
                 // without building the definitionContext again we use the same context to build default version as
                 // well. Hence setting the default version as false to generate the api with base path having version.
                 definitionContext.getApi().setIsDefaultVersion(false);
@@ -89,18 +94,16 @@ public class CodeGenerator {
         GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getFiltersFolderLocation() + File.separator
                         + GatewayCliConstants.GW_DIST_EXTENSION_FILTER,
                 projectSrcPath + File.separator + GatewayCliConstants.GW_DIST_EXTENSION_FILTER);
-
-
     }
     /**
      * Generates ballerina source for provided Open APIDetailedDTO Definition in {@code definitionPath}.
      * Generated source will be written to a ballerina package at {@code outPath}
      * <p>Method can be user for generating Ballerina mock services and clients</p>
      *
-     * @param projectName   name of the project being set up
-     * @param apiDef        api definition string
-     * @param endpointDef   endpoint definition string
-     * @param overwrite     whether existing files overwrite or not
+     * @param projectName name of the project being set up
+     * @param apiDef      api definition string
+     * @param endpointDef endpoint definition string
+     * @param overwrite   whether existing files overwrite or not
      * @throws IOException                  when file operations fail
      * @throws BallerinaServiceGenException when code generator fails
      */
@@ -183,7 +186,7 @@ public class CodeGenerator {
     /**
      * Retrieve generated source content as a String value.
      *
-     * @param endpoints       context to be used by template engine
+     * @param endpoints    context to be used by template engine
      * @param templateDir  templates directory
      * @param templateName name of the template to be used for this code generation
      * @return String with populated template
@@ -195,5 +198,42 @@ public class CodeGenerator {
                 .resolver(MapValueResolver.INSTANCE, JavaBeanValueResolver.INSTANCE, FieldValueResolver.INSTANCE)
                 .build();
         return template.apply(context);
+    }
+
+    /**
+     * Generates ballerina source for provided Open APIDetailedDTO Definition in {@code definitionPath}.
+     * Generated source will be written to a ballerina package at {@code outPath}
+     * <p>Method can be user for generating Ballerina mock services and clients</p>
+     *
+     * @throws IOException                  when file operations fail
+     * @throws BallerinaServiceGenException when code generator fails
+     */
+    public void generateGrpc(String projectName, String apiDef, String endpointDef, boolean overwrite)
+            throws IOException, BallerinaServiceGenException {
+        BallerinaService definitionContext;
+        String projectSrcPath = GatewayCmdUtils
+                .getProjectSrcDirectoryPath(projectName);
+        String projectGrpcPath = GatewayCmdUtils.getProjectGrpcDirectoryPath();
+        List<GenSrcFile> genFiles = new ArrayList<>();
+        File dir = new File(projectGrpcPath);
+        File[] files = dir.listFiles();
+        genFiles.add(generateCommonEndpoints());
+        CodegenUtils.writeGeneratedSources(genFiles, Paths.get(projectSrcPath), overwrite);
+        GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getFiltersFolderLocation() + File.separator
+                        + GatewayCliConstants.GW_DIST_EXTENSION_FILTER,
+                projectSrcPath + File.separator + GatewayCliConstants.GW_DIST_EXTENSION_FILTER);
+        for (File file : dir.listFiles()) {
+            String filePath = file.getAbsolutePath();
+            String fileName = file.getName();
+            FileSystem fileSys = FileSystems.getDefault();
+            Path source = fileSys.getPath(filePath);
+            Path destination = fileSys.getPath(projectSrcPath + File.separator + fileName);
+            Files.move(source , destination, StandardCopyOption.REPLACE_EXISTING);
+        }
+        File temp = new File(GatewayCmdUtils.getProjectGrpcSoloDirectoryPath());
+        boolean k =dir.delete();
+        boolean m = temp.delete();
+        System.out.println(k);
+        System.out.println(m);
     }
 }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
@@ -26,6 +26,8 @@ import java.util.List;
 public class GatewayCliConstants {
     public static final String CONF_DIRECTORY_NAME = "conf";
     public static final String PROJECTS_SRC_DIRECTORY_NAME = "src";
+    public static final String PROJECTS_GRPC_SERVICE_DIRECTORY_NAME = "grpc_service";
+    public static final String PROJECTS_GRPC_CLIENT_DIRECTORY_NAME = "client";
     public static final String PROJECTS_LOGS_DIRECTORY_NAME = "logs";
     public static final String PROJECTS_API_USAGE_DIRECTORY_NAME = "api-usage-data";
     public static final String ACCESS_LOG_FILE = "access_logs";

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -35,13 +35,7 @@ import org.wso2.apimgt.gateway.cli.model.config.ContainerConfig;
 import org.wso2.apimgt.gateway.cli.model.rest.APICorsConfigurationDTO;
 import org.wso2.apimgt.gateway.cli.model.config.Etcd;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -83,7 +77,7 @@ public class GatewayCmdUtils {
     /**
      * Read file as string
      *
-     * @param path to the file
+     * @param path       to the file
      * @param inResource whether file is in resources directory of jar or not
      * @return file content
      * @throws IOException if file read went wrong
@@ -198,8 +192,7 @@ public class GatewayCmdUtils {
         String currentDirProp = System.getProperty(GatewayCliConstants.SYS_PROP_CURRENT_DIR);
         if (currentDirProp != null) {
             return currentDirProp;
-        }
-        else {
+        } else {
             return System.getProperty(GatewayCliConstants.SYS_PROP_USER_DIR);
         }
     }
@@ -262,7 +255,7 @@ public class GatewayCmdUtils {
 
     /**
      * Get temp folder location
-     * 
+     *
      * @param projectName name of the project
      * @return temp folder location
      */
@@ -294,7 +287,7 @@ public class GatewayCmdUtils {
     /**
      * Create a micro gateway distribution for the provided project name
      *
-     * @param projectName   name of the project
+     * @param projectName name of the project
      * @throws IOException erro while creating micro gateway distribution
      */
     public static void createProjectGWDistribution(String projectName) throws IOException {
@@ -326,7 +319,7 @@ public class GatewayCmdUtils {
     /**
      * Creates the distribution structure for the project name
      *
-     * @param projectName   name of the label
+     * @param projectName name of the label
      */
     private static void createTargetGatewayDistStructure(String projectName) {
         //path : {projectName}/target
@@ -384,7 +377,7 @@ public class GatewayCmdUtils {
     /**
      * Saves the resource hash content to the CLI temp folder
      *
-     * @param content resource hash content
+     * @param content     resource hash content
      * @param projectName name of the project
      * @throws IOException error while saving resource hash content
      */
@@ -409,13 +402,13 @@ public class GatewayCmdUtils {
 
     /**
      * Validate the list of main args and returns the first element as the project name
-     * 
+     *
      * @param mainArgs List of main args provided to the command
      * @return first element
      */
-    public static String getProjectName (List<String> mainArgs) {
+    public static String getProjectName(List<String> mainArgs) {
         if (mainArgs.size() != 1) {
-            throw new CLIRuntimeException("Only one argument accepted as the project name, " 
+            throw new CLIRuntimeException("Only one argument accepted as the project name, "
                     + "but provided: " + String.join(",", mainArgs));
         } else {
             return mainArgs.get(0);
@@ -424,7 +417,7 @@ public class GatewayCmdUtils {
 
     /**
      * Get resource hash holder file path
-     * 
+     *
      * @param projectName name of the project
      * @return resource hash holder file path
      */
@@ -436,7 +429,7 @@ public class GatewayCmdUtils {
     /**
      * Get the distribution path for a given project name
      *
-     * @param projectName   name of the project
+     * @param projectName name of the project
      * @return distribution path for a given project name
      */
     private static String getTargetDistPath(String projectName) {
@@ -446,7 +439,7 @@ public class GatewayCmdUtils {
     /**
      * Get the gateway distribution path for a given project name
      *
-     * @param projectName   name of the project
+     * @param projectName name of the project
      * @return gateway distribution path for a given project name
      */
     private static String getTargetGatewayDistPath(String projectName) {
@@ -456,7 +449,7 @@ public class GatewayCmdUtils {
     /**
      * Copies shell scripts to the distribution location
      *
-     * @param projectName   name of the project
+     * @param projectName name of the project
      * @throws IOException error while coping scripts
      */
     private static void copyTargetDistBinScripts(String projectName) throws IOException {
@@ -466,19 +459,19 @@ public class GatewayCmdUtils {
 
         String linuxShContent = readFileAsString(GatewayCliConstants.GW_DIST_SH_PATH, true);
         linuxShContent = linuxShContent.replace(GatewayCliConstants.LABEL_PLACEHOLDER, projectName);
-        File shPathFile = new File(binDir+GatewayCliConstants.GW_DIST_SH);
+        File shPathFile = new File(binDir + GatewayCliConstants.GW_DIST_SH);
         saveScript(linuxShContent, shPathFile);
 
         String winBatContent = readFileAsString(GatewayCliConstants.GW_DIST_BAT_PATH, true);
         winBatContent = winBatContent.replace(GatewayCliConstants.LABEL_PLACEHOLDER, projectName);
-        File batPathFile = new File(binDir+GatewayCliConstants.GW_DIST_BAT);
+        File batPathFile = new File(binDir + GatewayCliConstants.GW_DIST_BAT);
         saveScript(winBatContent, batPathFile);
     }
 
     /**
      * Copies balx binaries to the distribution location
      *
-     * @param projectName   name of the project
+     * @param projectName name of the project
      * @throws IOException error while coping balx files
      */
     private static void copyTargetDistBalx(String projectName) throws IOException {
@@ -547,6 +540,27 @@ public class GatewayCmdUtils {
     }
 
     /**
+     * Returns path to the /grpc_service/client of a given project in the current working directory
+     *
+     * @return path to the /grpc_service/client of a given project in the current working directory
+     */
+    public static String getProjectGrpcDirectoryPath() {
+        return getUserDir() + File.separator
+                + GatewayCliConstants.PROJECTS_GRPC_SERVICE_DIRECTORY_NAME + File.separator +
+                GatewayCliConstants.PROJECTS_GRPC_CLIENT_DIRECTORY_NAME;
+    }
+
+    /**
+     * Returns path to the /grpc_service of a given project in the current working directory
+     *
+     * @return path to the /grpc_service of a given project in the current working directory
+     */
+    public static String getProjectGrpcSoloDirectoryPath() {
+        return getUserDir() + File.separator
+                + GatewayCliConstants.PROJECTS_GRPC_SERVICE_DIRECTORY_NAME;
+    }
+
+    /**
      * Returns path to the /target of a given project in the current working directory
      *
      * @param projectName name of the project
@@ -584,9 +598,9 @@ public class GatewayCmdUtils {
     /**
      * Cleans the given folder by deleting a set of specified files
      *
-     * @param targetPath    path of folder to clean
-     * @param delete          files to delete
-     * @throws IOException  error while cleaning the folder
+     * @param targetPath path of folder to clean
+     * @param delete     files to delete
+     * @throws IOException error while cleaning the folder
      */
     private static void cleanFolder(String targetPath, String... delete) throws IOException {
         File targetFolder = new File(targetPath);
@@ -697,7 +711,7 @@ public class GatewayCmdUtils {
      * Write content to a specified file
      *
      * @param content content to be written
-     * @param file file object initialized with path
+     * @param file    file object initialized with path
      * @throws IOException error while writing content to file
      */
     private static void writeContent(String content, File file) throws IOException {
@@ -715,7 +729,7 @@ public class GatewayCmdUtils {
     /**
      * Creates file if not exist
      *
-     * @param path folder path
+     * @param path     folder path
      * @param fileName name of the file
      */
     private static void createFileIfNotExist(String path, String fileName) {
@@ -738,16 +752,16 @@ public class GatewayCmdUtils {
     }
 
     /**
-     * Create initial deployment configuration file. If external file is provided using 'deploymentConfPath', 
-     *  it will be taken as the deployment configuration. Otherwise, a default configuration will be copied. 
+     * Create initial deployment configuration file. If external file is provided using 'deploymentConfPath',
+     * it will be taken as the deployment configuration. Otherwise, a default configuration will be copied.
      *
-     * @param projectName project name
+     * @param projectName        project name
      * @param deploymentConfPath path to deployment config
      * @throws IOException if file create went wrong
      */
     public static void createDeploymentConfig(String projectName, String deploymentConfPath)
             throws IOException {
-        
+
         String depConfig = getProjectConfigDirPath(projectName) + File.separator
                 + GatewayCliConstants.DEPLOYMENT_CONFIG_FILE_NAME;
         File file = new File(depConfig);
@@ -814,6 +828,7 @@ public class GatewayCmdUtils {
 
     /**
      * Replace backslashes `\` in windows path string with forward slashes `/`
+     *
      * @param path Location of a resource (file or directory)
      * @return {String} File path with unix style file separator
      */
@@ -823,8 +838,9 @@ public class GatewayCmdUtils {
 
     /**
      * Create script file in the given path with the given content
+     *
      * @param content Content needs to be added to the script file
-     * @param path File object containing the path to save the script
+     * @param path    File object containing the path to save the script
      */
     private static void saveScript(String content, File path) throws IOException {
         try (FileWriter writer = new FileWriter(path)) {
@@ -838,9 +854,10 @@ public class GatewayCmdUtils {
             }
         }
     }
-    
+
     /**
      * Delete project folder
+     *
      * @param projectPath project path
      */
     public static void deleteProject(String projectPath) {

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -35,7 +35,14 @@ import org.wso2.apimgt.gateway.cli.model.config.ContainerConfig;
 import org.wso2.apimgt.gateway.cli.model.rest.APICorsConfigurationDTO;
 import org.wso2.apimgt.gateway.cli.model.config.Etcd;
 
-import java.io.*;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GRPCUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GRPCUtils.java
@@ -1,0 +1,263 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.apimgt.gateway.cli.utils.grpc;
+
+import org.ballerinalang.net.grpc.builder.BallerinaFileBuilder;
+import org.ballerinalang.net.grpc.exception.BalGenerationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.apimgt.gateway.cli.constants.GatewayCliConstants;
+import org.wso2.apimgt.gateway.cli.exception.CLIInternalException;
+import org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalFileGenerationUtils;
+import org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenToolException;
+import org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.DescriptorsGenerator;
+import org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.OSDetector;
+
+import java.io.*;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalFileGenerationUtils.*;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.*;
+
+public class GRPCUtils {
+
+    private final String protoPath;
+
+    public GRPCUtils(String protoPath) {
+        this.protoPath = protoPath;
+    }
+
+    private static PrintStream outStream = System.out;
+    private static final Logger LOG = LoggerFactory.getLogger(GRPCUtils.class);
+    private String balOutPath = "";
+    private String exePath;
+    private String protocVersion = "3.4.0";
+
+    public void execute() {
+        if (protoPath == null || !protoPath.toLowerCase(Locale.ENGLISH).endsWith(PROTO_SUFFIX)) {
+            String errorMessage = "Invalid proto file path. Please input valid proto file location.";
+            outStream.println(errorMessage);
+            throw new BalGenToolException(errorMessage);
+        }
+
+        if (!Files.isReadable(Paths.get(protoPath))) {
+            String errorMessage = "Provided service proto file is not readable. Please input valid proto file " +
+                    "location.";
+            outStream.println(errorMessage);
+            throw new BalGenToolException(errorMessage);
+        }
+
+        try {
+            downloadProtocexe();
+        } catch (BalGenToolException e) {
+            LOG.error("Error while generating protoc executable. ", e);
+            throw new BalGenToolException("Error while generating protoc executable. ", e);
+        }
+
+        File descFile = createTempDirectory();
+        StringBuilder msg = new StringBuilder();
+        outStream.println("Initializing the gateway proxy code generation.");
+
+        byte[] root;
+        List<byte[]> dependant;
+
+        try {
+            ClassLoader classLoader = this.getClass().getClassLoader();
+            List<String> protoFiles = readProperties(classLoader);
+            for (String file : protoFiles) {
+                try {
+                    exportResource(file, classLoader);
+                } catch (Exception e) {
+                    msg.append("Error extracting resource file ").append(file).append(NEW_LINE_CHARACTER);
+                    outStream.println(msg.toString());
+                    LOG.error("Error exacting resource file " + file, e);
+                }
+            }
+            msg.append("Successfully generated initial files.").append(NEW_LINE_CHARACTER);
+            root = BalFileGenerationUtils.getProtoByteArray(this.exePath, this.protoPath, descFile.getAbsolutePath());
+            if (root.length == 0) {
+                throw new BalGenerationException("Error occurred at generating proto descriptor.");
+            }
+
+            LOG.info("Successfully generated root descriptor.");
+            dependant = DescriptorsGenerator.generateDependentDescriptor
+                    (descFile.getAbsolutePath(), this.protoPath, new ArrayList<>(), exePath, classLoader);
+            LOG.info("Successfully generated dependent descriptor.");
+        } finally {
+            //delete temporary meta files
+            delete(new File(META_LOCATION));
+            delete(new File(TEMP_GOOGLE_DIRECTORY));
+            LOG.debug("Successfully deleted temporary files.");
+        }
+        try {
+            BallerinaFileBuilder ballerinaFileBuilder;
+            // By this user can generate stub at different location
+            if (EMPTY_STRING.equals(balOutPath)) {
+                ballerinaFileBuilder = new BallerinaFileBuilder(dependant);
+            } else {
+                ballerinaFileBuilder = new BallerinaFileBuilder(dependant, balOutPath);
+            }
+            ballerinaFileBuilder.setRootDescriptor(root);
+            ballerinaFileBuilder.build();
+        } catch (BalGenerationException e) {
+            LOG.error("Error generating ballerina file.", e);
+            msg.append("Error generating ballerina file.").append(NEW_LINE_CHARACTER);
+            outStream.println(msg.toString());
+        }
+        msg.append("Successfully generated ballerina file.").append(NEW_LINE_CHARACTER);
+
+        outStream.println(msg.toString());
+    }
+
+    /**
+     * Download the protoc executor.
+     */
+    private void downloadProtocexe() {
+        if (exePath == null) {
+            exePath = "protoc-" + OSDetector.getDetectedClassifier() + ".exe";
+            File exeFile = new File(exePath);
+            exePath = exeFile.getAbsolutePath(); // if file already exists will do nothing
+            if (!exeFile.isFile()) {
+                outStream.println("Downloading proc executor ...");
+                try {
+                    boolean newFile = exeFile.createNewFile();
+                    if (newFile) {
+                        LOG.info("Successfully created new protoc exe file" + exePath);
+                    }
+                } catch (IOException e) {
+                    throw new BalGenToolException("Exception occurred while creating new file for protoc exe. ", e);
+                }
+                String url = PROTOC_PLUGIN_EXE_URL_SUFFIX + protocVersion + "/protoc-" + protocVersion + "-" +
+                        OSDetector.getDetectedClassifier() + PROTOC_PLUGIN_EXE_PREFIX;
+                try {
+                    saveFile(new URL(url), exePath);
+                    File file = new File(exePath);
+                    //set application user permissions to 455
+                    grantPermission(file);
+                } catch (IOException e) {
+                    throw new BalGenToolException("Exception occurred while writing protoc executable to file. ", e);
+                }
+                outStream.println("Download successfully completed!");
+            } else {
+                grantPermission(exeFile);
+                outStream.println("Continue with existing protoc executor.");
+            }
+        } else {
+            outStream.println("Pre-Downloaded descriptor detected ...");
+        }
+    }
+
+    /**
+     * Export a resource embedded into a Jar file to the local file path.
+     *
+     * @param resourceName ie.: "/wrapper.proto"
+     */
+    private static void exportResource(String resourceName, ClassLoader classLoader) {
+        try (InputStream initialStream = classLoader.getResourceAsStream(resourceName);
+             OutputStream resStreamOut = new FileOutputStream(resourceName.replace("stdlib",
+                     "protobuf"))) {
+            if (initialStream == null) {
+                throw new BalGenToolException("Cannot get resource \"" + resourceName + "\" from Jar file.");
+            }
+            int readBytes;
+            byte[] buffer = new byte[4096];
+            while ((readBytes = initialStream.read(buffer)) > 0) {
+                resStreamOut.write(buffer, 0, readBytes);
+            }
+        } catch (IOException e) {
+            throw new BalGenToolException("Cannot find '" + resourceName + "' resource  at the jar.", e);
+        }
+    }
+
+    /**
+     * Create meta temp directory which needed for intermediate processing.
+     *
+     * @return Temporary Created meta file.
+     */
+    private File createTempDirectory() {
+        File metadataHome = new File(META_LOCATION);
+        if (!metadataHome.exists() && !metadataHome.mkdir()) {
+            throw new IllegalStateException("Couldn't create dir: " + metadataHome);
+        }
+
+        File googleHome = new File(TEMP_GOOGLE_DIRECTORY);
+        createTempDirectory(googleHome);
+
+        File protobufHome = new File(googleHome, TEMP_PROTOBUF_DIRECTORY);
+        createTempDirectory(protobufHome);
+
+        File compilerHome = new File(protobufHome, TEMP_COMPILER_DIRECTORY);
+        createTempDirectory(compilerHome);
+
+        return new File(metadataHome, getProtoFileName() + "-descriptor.desc");
+    }
+
+    private void createTempDirectory(File dirName) {
+        if (!dirName.exists() && !dirName.mkdir()) {
+            throw new IllegalStateException("Couldn't create dir: " + dirName);
+        }
+    }
+
+    private String getProtoFileName() {
+        File file = new File(protoPath);
+        return file.getName().replace(PROTO_SUFFIX, EMPTY_STRING);
+    }
+
+    private List<String> readProperties(ClassLoader classLoader) {
+        String fileName;
+        List<String> protoFilesList = new ArrayList<>();
+        try (InputStream initialStream = classLoader.getResourceAsStream("standardProtos.properties");
+             BufferedReader reader = new BufferedReader(new InputStreamReader(initialStream, StandardCharsets.UTF_8))) {
+            while ((fileName = reader.readLine()) != null) {
+                protoFilesList.add(fileName);
+            }
+        } catch (IOException e) {
+            throw new BalGenToolException("Error in reading standardProtos.properties.", e);
+        }
+        return protoFilesList;
+    }
+
+    public void setBalOutPath(String balOutPath) {
+        this.balOutPath = balOutPath;
+    }
+
+    public void setExePath(String exePath) {
+        this.exePath = exePath;
+    }
+
+    public void setProtocVersion(String protocVersion) {
+        this.protocVersion = protocVersion;
+    }
+
+    public static String readApi(String filePath) {
+        String responseStr;
+        try {
+            responseStr = new String(Files.readAllBytes(Paths.get(filePath)), GatewayCliConstants.CHARSET_UTF8);
+        } catch (IOException e) {
+            LOG.error("Error while reading api definition.", e);
+            throw new CLIInternalException("Error while reading api definition.");
+        }
+        return responseStr;
+    }
+}

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GRPCUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GRPCUtils.java
@@ -44,8 +44,19 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalFileGenerationUtils.*;
-import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.*;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalFileGenerationUtils.delete;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalFileGenerationUtils.saveFile;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalFileGenerationUtils.grantPermission;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.NEW_LINE_CHARACTER;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.PROTO_SUFFIX;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.META_LOCATION;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.TEMP_GOOGLE_DIRECTORY;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.EMPTY_STRING;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.PROTOC_PLUGIN_EXE_URL_SUFFIX;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.PROTOC_PLUGIN_EXE_PREFIX;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.TEMP_PROTOBUF_DIRECTORY;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.TEMP_COMPILER_DIRECTORY;
+
 /**
  * This class represents the "gRPC utils" functions and it holds functions to generate root descriptors.
  */

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GRPCUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GRPCUtils.java
@@ -28,7 +28,14 @@ import org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenToolException;
 import org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.DescriptorsGenerator;
 import org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.OSDetector;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.io.OutputStream;
+import java.io.FileOutputStream;
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GRPCUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GRPCUtils.java
@@ -31,7 +31,6 @@ import org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.OSDetector;
 import java.io.*;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/BalFileGenerationUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/BalFileGenerationUtils.java
@@ -21,7 +21,14 @@ import com.google.protobuf.DescriptorProtos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+
+import java.io.File;
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/BalFileGenerationUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/BalFileGenerationUtils.java
@@ -1,0 +1,230 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen;
+
+import com.google.protobuf.DescriptorProtos;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.*;
+
+
+/**
+ * Util function used when generating bal file from .proto definition.
+ */
+public class BalFileGenerationUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(BalFileGenerationUtils.class);
+
+    /**
+     * Create meta folder for storing meta files which is used in intermediate processing.
+     *
+     * @param folderPath folder path which is needed to be created.
+     */
+    public static void createMetaFolder(String folderPath) {
+        boolean isFileCreated = new File(folderPath).getParentFile().mkdirs();
+        if (!isFileCreated) {
+            LOG.debug("Meta folder did not create successfully '" + folderPath + "'");
+        }
+        byte dataBytes[] = new byte[0];
+        try {
+            Path file = Paths.get(folderPath);
+            Files.write(file, dataBytes);
+        } catch (IOException e) {
+            throw new BalGenToolException("Error creating .desc meta files.", e);
+        }
+    }
+
+    /**
+     * Execute command and generate file descriptor.
+     *
+     * @param command protoc executor command.
+     */
+    public static void generateDescriptor(String command) {
+        boolean isWindows = System.getProperty("os.name")
+                .toLowerCase(Locale.ENGLISH).startsWith("windows");
+        ProcessBuilder builder = new ProcessBuilder();
+        if (isWindows) {
+            builder.command("cmd.exe", "/c", command);
+        } else {
+            builder.command("sh", "-c", command);
+        }
+        builder.directory(new File(System.getProperty("user.home")));
+        Process process;
+        try {
+            process = builder.start();
+        } catch (IOException e) {
+            throw new BalGenToolException("Error in executing protoc command '" + command + "'.", e);
+        }
+        try {
+            process.waitFor();
+        } catch (InterruptedException e) {
+            throw new BalGenToolException("Process not successfully completed. Process is interrupted while" +
+                    " running the protoC executor.", e);
+        }
+        if (process.exitValue() != 0) {
+            try (BufferedReader bufferedReader = new BufferedReader(new
+                    InputStreamReader(process.getErrorStream(), "UTF-8"))) {
+                String err;
+                StringBuilder errMsg = new StringBuilder();
+                while ((err = bufferedReader.readLine()) != null) {
+                    errMsg.append(System.lineSeparator()).append(err);
+                }
+                throw new BalGenToolException(errMsg.toString());
+            } catch (IOException e) {
+                throw new BalGenToolException("Invalid command syntax.", e);
+            }
+        }
+    }
+
+    /**
+     * Build descriptor path using dependent proto path.
+     *
+     * @param protoPath dependent protoPath
+     * @return descriptor path of proto
+     */
+    public static String getDescriptorPath(String protoPath) {
+        return BalGenerationConstants.META_DEPENDENCY_LOCATION + protoPath
+                .substring(protoPath.lastIndexOf(BalGenerationConstants
+                        .FILE_SEPARATOR), protoPath.length()).replace(PROTO_SUFFIX,
+                        EMPTY_STRING) + DESC_SUFFIX;
+    }
+
+    /**
+     * Resolve proto folder path from Proto file path.
+     *
+     * @param protoPath Proto file path
+     * @return
+     */
+    public static String resolveProtoFloderPath(String protoPath) {
+        int idx = protoPath.lastIndexOf(BalGenerationConstants.FILE_SEPARATOR);
+        String protofolderPath = EMPTY_STRING;
+        if (idx > 0) {
+            protofolderPath = protoPath.substring(0, idx);
+        }
+        return protofolderPath;
+    }
+
+    /**
+     * Generate proto file and convert it to byte array.
+     *
+     * @param exePath        protoc executor path
+     * @param protoPath      .proto file path
+     * @param descriptorPath file descriptor path.
+     * @return byte array of generated proto file.
+     */
+    public static byte[] getProtoByteArray(String exePath, String protoPath, String descriptorPath) {
+
+        String command = new ProtocCommandBuilder
+                (exePath, protoPath, resolveProtoFloderPath(protoPath), descriptorPath).build();
+        generateDescriptor(command);
+        File initialFile = new File(descriptorPath);
+        try (InputStream targetStream = new FileInputStream(initialFile)) {
+            DescriptorProtos.FileDescriptorSet set = DescriptorProtos.FileDescriptorSet.parseFrom(targetStream);
+            if (set.getFileList().size() > 0) {
+                return set.getFile(0).toByteArray();
+            }
+        } catch (IOException e) {
+            throw new BalGenToolException("Error reading generated descriptor file '" + descriptorPath + "'.", e);
+        }
+        return new byte[0];
+    }
+
+    /**
+     * Used to clear the temporary files.
+     *
+     * @param file file to be deleted
+     */
+    public static void delete(File file) {
+        if ((file != null) && file.exists() && file.isDirectory()) {
+            String files[] = file.list();
+            if (files != null) {
+                if (files.length != 0) {
+                    for (String temp : files) {
+                        File fileDelete = new File(file, temp);
+                        if (fileDelete.isDirectory()) {
+                            delete(fileDelete);
+                        }
+                        if (fileDelete.delete()) {
+                            LOG.debug("Successfully deleted file " + file.toString());
+                        }
+                    }
+                }
+            }
+            if (file.delete()) {
+                LOG.debug("Successfully deleted file " + file.toString());
+            }
+            if ((file.getParentFile() != null) && (file.getParentFile().delete())) {
+                LOG.debug("Successfully deleted parent file " + file.toString());
+            }
+        } else if (file != null) {
+            if (file.delete()) {
+                LOG.debug("Successfully deleted parent file " + file.toString());
+            }
+        }
+    }
+
+    /**
+     * Sae generated intermediate files.
+     *
+     * @param url  file URL
+     * @param file destination file location
+     */
+    public static void saveFile(URL url, String file) {
+        try (InputStream in = url.openStream(); FileOutputStream fos = new FileOutputStream(new File(file))) {
+            int length;
+            byte[] buffer = new byte[1024]; // buffer for portion of data from
+            while ((length = in.read(buffer)) > -1) {
+                fos.write(buffer, 0, length);
+            }
+            fos.close();
+            in.close();
+        } catch (IOException e) {
+            throw new BalGenToolException("Error saving file '" + file + "'.", e);
+        }
+    }
+
+    /**
+     * Grant permission to the protoc executor file.
+     *
+     * @param file protoc executor file.
+     */
+    public static void grantPermission(File file) {
+        boolean isExecutable = file.setExecutable(true);
+        boolean isReadable = file.setReadable(true);
+        boolean isWritable = file.setWritable(true);
+        if (isExecutable && isReadable && isWritable) {
+            LOG.debug("Successfully grated permission for protoc exe file");
+        } else {
+            LOG.debug("Failed to prowide execute permission to protoc executor.");
+        }
+    }
+}

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/BalFileGenerationUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/BalFileGenerationUtils.java
@@ -18,17 +18,10 @@
 package org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen;
 
 import com.google.protobuf.DescriptorProtos;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/BalFileGenerationUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/BalFileGenerationUtils.java
@@ -35,7 +35,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
 
-import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.*;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.DESC_SUFFIX;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.EMPTY_STRING;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.PROTO_SUFFIX;
 
 
 /**
@@ -193,7 +195,7 @@ public class BalFileGenerationUtils {
     }
 
     /**
-     * Sae generated intermediate files.
+     * Save generated intermediate files.
      *
      * @param url  file URL
      * @param file destination file location
@@ -205,8 +207,6 @@ public class BalFileGenerationUtils {
             while ((length = in.read(buffer)) > -1) {
                 fos.write(buffer, 0, length);
             }
-            fos.close();
-            in.close();
         } catch (IOException e) {
             throw new BalGenToolException("Error saving file '" + file + "'.", e);
         }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/BalGenToolException.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/BalGenToolException.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen;
+
+
+/**
+ * Thrown to indicate that the requested field type is not supported.
+ *
+ */
+public class BalGenToolException extends RuntimeException {
+
+    /**
+     * Constructs an UnsupportedFieldTypeException with the specified detail message.
+     *
+     * @param message the detail message
+     */
+    public BalGenToolException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param  message the detail message
+     * @param  cause the cause
+     */
+    public BalGenToolException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause.
+     *
+     * @param  cause the cause
+     */
+    public BalGenToolException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/BalGenToolException.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/BalGenToolException.java
@@ -20,7 +20,6 @@ package org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen;
 
 /**
  * Thrown to indicate that the requested field type is not supported.
- *
  */
 public class BalGenToolException extends RuntimeException {
 
@@ -36,8 +35,8 @@ public class BalGenToolException extends RuntimeException {
     /**
      * Constructs a new exception with the specified detail message and cause.
      *
-     * @param  message the detail message
-     * @param  cause the cause
+     * @param message the detail message
+     * @param cause   the cause
      */
     public BalGenToolException(String message, Throwable cause) {
         super(message, cause);
@@ -46,7 +45,7 @@ public class BalGenToolException extends RuntimeException {
     /**
      * Constructs a new exception with the specified cause.
      *
-     * @param  cause the cause
+     * @param cause the cause
      */
     public BalGenToolException(Throwable cause) {
         super(cause);

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/BalGenerationConstants.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/BalGenerationConstants.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen;
+
+import java.io.File;
+
+/**
+ * Bal Generation Tool contants class.
+ */
+public class BalGenerationConstants {
+    public static final String OS_NAME_SYSTEM_PROPERTY = "os.name";
+    public static final String OS_ARCH_SYSTEM_PROPERTY = "os.arch";
+    public static final String FILE_SEPARATOR = File.separator;
+    public static final String BUILD_COMMAND_NAME = "build";
+    public static final String META_LOCATION = "desc_gen";
+    public static final String TEMP_GOOGLE_DIRECTORY = "google";
+    public static final String TEMP_PROTOBUF_DIRECTORY = "protobuf";
+    public static final String TEMP_COMPILER_DIRECTORY = "compiler";
+
+    public static final String META_DEPENDENCY_LOCATION = "desc_gen" + FILE_SEPARATOR
+            + "dependencies";
+    public static final String NEW_LINE_CHARACTER = System.getProperty("line.separator");
+    public static final String GOOGLE_STANDARD_LIB = "google" + FILE_SEPARATOR + "protobuf";
+    public static final String SPACE_CHARACTER = " ";
+    public static final String EMPTY_STRING = "";
+    public static final String EXE_PATH_PLACEHOLDER = "{{EXE_PATH}}";
+    public static final String PROTO_PATH_PLACEHOLDER = "{{PROTO_PATH}}";
+    public static final String PROTO_FOLDER_PLACEHOLDER = "{{PROTO_FOLDER}}";
+    public static final String DESC_PATH_PLACEHOLDER = "{{DESC_PATH}}";
+    public static final String COMPONENT_IDENTIFIER = "grpc";
+    public static final String PROTOC_PLUGIN_EXE_PREFIX = ".exe";
+    public static final String PROTO_SUFFIX = ".proto";
+    public static final String DESC_SUFFIX = ".desc";
+    public static final String PROTOC_PLUGIN_EXE_URL_SUFFIX = "http://repo1.maven.org/maven2/com/google/" +
+            "protobuf/protoc/";
+}

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/DescriptorsGenerator.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/DescriptorsGenerator.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -22,7 +22,12 @@ import org.ballerinalang.net.grpc.exception.BalGenerationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.FileOutputStream;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/DescriptorsGenerator.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/DescriptorsGenerator.java
@@ -32,14 +32,21 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalFileGenerationUtils.*;
-import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.*;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalFileGenerationUtils.generateDescriptor;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalFileGenerationUtils.getDescriptorPath;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalFileGenerationUtils.resolveProtoFloderPath;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalFileGenerationUtils.createMetaFolder;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.META_LOCATION;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.PROTO_SUFFIX;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.DESC_SUFFIX;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.GOOGLE_STANDARD_LIB;
 
 /**
  * Class for generate file descriptors for proto files.
  */
 public class DescriptorsGenerator {
     private static final Logger LOG = LoggerFactory.getLogger(DescriptorsGenerator.class);
+    private static final CharSequence EMPTY_STRING = "";
 
     public static List<byte[]> generateDependentDescriptor(String parentDescPath, String parentProtoPath,
                                                            List<byte[]> list,

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/DescriptorsGenerator.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/DescriptorsGenerator.java
@@ -1,0 +1,117 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen;
+
+import com.google.protobuf.DescriptorProtos;
+import org.ballerinalang.net.grpc.exception.BalGenerationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalFileGenerationUtils.*;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.*;
+
+/**
+ * Class for generate file descriptors for proto files.
+ */
+public class DescriptorsGenerator {
+    private static final Logger LOG = LoggerFactory.getLogger(DescriptorsGenerator.class);
+
+    public static List<byte[]> generateDependentDescriptor(String parentDescPath, String parentProtoPath,
+                                                           List<byte[]> list,
+                                                           String exePath, ClassLoader classLoader) {
+
+        File initialFile = new File(parentDescPath);
+        try (InputStream targetStream = new FileInputStream(initialFile)) {
+            DescriptorProtos.FileDescriptorSet descSet = DescriptorProtos.FileDescriptorSet.parseFrom(targetStream);
+            for (String depPath : descSet.getFile(0).getDependencyList()) {
+                if (System.getProperty("os.name")
+                        .toLowerCase(Locale.ENGLISH).startsWith("windows")) {
+                    depPath = depPath.replaceAll("/", "\\\\");
+                }
+                String path = BalGenerationConstants.META_DEPENDENCY_LOCATION + depPath.substring(
+                        depPath.lastIndexOf(BalGenerationConstants.FILE_SEPARATOR)
+                        , depPath.length()).replace(PROTO_SUFFIX, EMPTY_STRING) + DESC_SUFFIX;
+                createMetaFolder(path);
+                String protoPath;
+                if (!depPath.contains(GOOGLE_STANDARD_LIB)) {
+                    protoPath = new File(new File(resolveProtoFloderPath(parentProtoPath)).toURI().getPath()
+                            + depPath).toURI().getPath();
+                } else {
+                    //Get file from resources folder
+                    File dependentDesc = new File(META_LOCATION, depPath);
+                    File parentFile = dependentDesc.getParentFile();
+                    if (!parentFile.exists() && !parentFile.mkdirs()) {
+                        throw new IllegalStateException("Couldn't create directory " + dependentDesc);
+                    }
+                    try (InputStream initialStream = new FileInputStream(new File(depPath));
+                         OutputStream outStream = new FileOutputStream(dependentDesc)) {
+                        byte[] buffer = new byte[initialStream.available()];
+                        int read = initialStream.read(buffer);
+                        if (read == -1) {
+                            throw new IllegalStateException("Couldn't read input stream of 'google/protobuf'" +
+                                    " resource: ");
+                        }
+                        outStream.write(buffer);
+                        outStream.close();
+                        protoPath = dependentDesc.getAbsolutePath();
+                    } catch (IOException e) {
+                        throw new BalGenToolException("Error reading resource file '" + depPath + "'", e);
+                    }
+                }
+
+                String command = new ProtocCommandBuilder(exePath, protoPath, resolveProtoFloderPath(protoPath)
+                        , new File(getDescriptorPath(depPath)).getAbsolutePath()).build();
+                generateDescriptor(command);
+                File childFile = new File(path);
+                try (InputStream childStream = new FileInputStream(childFile)) {
+                    DescriptorProtos.FileDescriptorSet childDescSet = DescriptorProtos.FileDescriptorSet
+                            .parseFrom(childStream);
+                    if (childDescSet.getFile(0).getDependencyCount() != 0) {
+                        List<byte[]> newList = new ArrayList<>();
+                        generateDependentDescriptor(path, protoPath, newList,
+                                exePath, classLoader);
+                    } else {
+                        initialFile = new File(path);
+                        try (InputStream dependentStream = new FileInputStream(initialFile)) {
+                            DescriptorProtos.FileDescriptorSet set = DescriptorProtos.FileDescriptorSet
+                                    .parseFrom(dependentStream);
+                            byte[] dependentDesc = set.getFile(0).toByteArray();
+                            if (dependentDesc.length == 0) {
+                                throw new BalGenerationException("Error occurred at generating dependent proto " +
+                                        "descriptor for dependent proto '" + parentProtoPath + "'.");
+                            }
+                            list.add(dependentDesc);
+                        } catch (IOException e) {
+                            throw new BalGenToolException("Error reading dependent descriptor.", e);
+                        }
+                    }
+                } catch (IOException e) {
+                    throw new BalGenToolException("Error extracting dependent bal.", e);
+                }
+            }
+        } catch (IOException e) {
+            throw new BalGenToolException("Error parsing descriptor file " + initialFile, e);
+        }
+        return list;
+    }
+}

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/OSDetector.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/OSDetector.java
@@ -1,0 +1,154 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen;
+
+import java.util.Locale;
+
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.OS_ARCH_SYSTEM_PROPERTY;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.OS_NAME_SYSTEM_PROPERTY;
+
+/**
+ * Class for detecting the system operating system version and type.
+ * Ref : https://github.com/trustin/os-maven-plugin/blob/master/src/main/java/kr/motd/maven/os/Detector.java
+ */
+public abstract class OSDetector {
+
+    public static final String AIX = "aix";
+    public static final String HPUX = "hpux";
+    public static final String OS400 = "os400";
+    public static final String LINUX = "linux";
+    public static final String MACOSX = "macosx";
+    public static final String OSX = "osx";
+    public static final String FREEBSD = "freebsd";
+    public static final String OPENBSD = "openbsd";
+    public static final String NETBSD = "netbsd";
+    public static final String WINDOWS = "windows";
+    public static final String SOLARIS = "solaris";
+    public static final String SUNOS = "sunos";
+    private static final String UNKNOWN = "unknown";
+
+    public static String getDetectedClassifier() {
+
+        final String osName = System.getProperty(OS_NAME_SYSTEM_PROPERTY);
+        final String osArch = System.getProperty(OS_ARCH_SYSTEM_PROPERTY);
+
+        final String detectedName = normalizeOs(osName);
+        final String detectedArch = normalizeArch(osArch);
+
+        final String failOnUnknownOS = System.getProperty("failOnUnknownOS");
+        if (!"false".equalsIgnoreCase(failOnUnknownOS)) {
+            if (UNKNOWN.equals(detectedName)) {
+                throw new RuntimeException("unknown os.name: " + osName);
+            }
+            if (UNKNOWN.equals(detectedArch)) {
+                throw new RuntimeException("unknown os.arch: " + osArch);
+            }
+        }
+        // Assume the default classifier, without any os "like" extension.
+        return detectedName + '-' + detectedArch;
+    }
+
+    private static String normalizeOs(String value) {
+
+        value = normalize(value);
+        if (value.startsWith(AIX)) {
+            return AIX;
+        }
+        if (value.startsWith(HPUX)) {
+            return HPUX;
+        }
+        if (value.startsWith(OS400)) {
+            // Avoid the names such as os4000
+            if (value.length() <= 5 || !Character.isDigit(value.charAt(5))) {
+                return OS400;
+            }
+        }
+        if (value.startsWith(LINUX)) {
+            return LINUX;
+        }
+        if (value.startsWith(MACOSX) || value.startsWith(OSX)) {
+            return "osx";
+        }
+        if (value.startsWith(FREEBSD)) {
+            return FREEBSD;
+        }
+        if (value.startsWith(OPENBSD)) {
+            return OPENBSD;
+        }
+        if (value.startsWith(NETBSD)) {
+            return NETBSD;
+        }
+        if (value.startsWith(SOLARIS) || value.startsWith(SUNOS)) {
+            return SUNOS;
+        }
+        if (value.startsWith(WINDOWS)) {
+            return WINDOWS;
+        }
+        return UNKNOWN;
+    }
+
+    private static String normalizeArch(String value) {
+
+        value = normalize(value);
+        if (value.matches("^(x8664|amd64|ia32e|em64t|x64)$")) {
+            return "x86_64";
+        }
+        if (value.matches("^(x8632|x86|i[3-6]86|ia32|x32)$")) {
+            return "x86_32";
+        }
+        if (value.matches("^(ia64|itanium64)$")) {
+            return "itanium_64";
+        }
+        if (value.matches("^(sparc|sparc32)$")) {
+            return "sparc_32";
+        }
+        if (value.matches("^(sparcv9|sparc64)$")) {
+            return "sparc_64";
+        }
+        if (value.matches("^(arm|arm32)$")) {
+            return "arm_32";
+        }
+        if ("aarch64".equals(value)) {
+            return "aarch_64";
+        }
+        if (value.matches("^(ppc|ppc32)$")) {
+            return "ppc_32";
+        }
+        if ("ppc64".equals(value)) {
+            return "ppc_64";
+        }
+        if ("ppc64le".equals(value)) {
+            return "ppcle_64";
+        }
+        if ("s390".equals(value)) {
+            return "s390_32";
+        }
+        if ("s390x".equals(value)) {
+            return "s390_64";
+        }
+        return UNKNOWN;
+    }
+
+    private static String normalize(String value) {
+
+        if (value == null) {
+            return "";
+        }
+        return value.toLowerCase(Locale.US).replaceAll("[^a-z0-9]+", "");
+    }
+}

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/ProtocCommandBuilder.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/ProtocCommandBuilder.java
@@ -18,8 +18,11 @@
 package org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen;
 
 
-import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.*;
-
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.DESC_PATH_PLACEHOLDER;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.PROTO_FOLDER_PLACEHOLDER;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.PROTO_PATH_PLACEHOLDER;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.EXE_PATH_PLACEHOLDER;
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.SPACE_CHARACTER;
 /**
  * This class is used to build the protoc compiler command to generate descriptor.
  */

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/ProtocCommandBuilder.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/grpc/GrpcGen/ProtocCommandBuilder.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen;
+
+
+import static org.wso2.apimgt.gateway.cli.utils.grpc.GrpcGen.BalGenerationConstants.*;
+
+/**
+ * This class is used to build the protoc compiler command to generate descriptor.
+ */
+public class ProtocCommandBuilder {
+    private static final String COMMAND_PLACEHOLDER = EXE_PATH_PLACEHOLDER + SPACE_CHARACTER +
+            "--proto_path=" + PROTO_FOLDER_PLACEHOLDER + SPACE_CHARACTER +
+            PROTO_PATH_PLACEHOLDER + SPACE_CHARACTER +
+            "--descriptor_set_out=" + DESC_PATH_PLACEHOLDER;
+    private String exePath;
+    private String protoPath;
+    private String protoFolderPath;
+    private String descriptorSetOutPath;
+
+    public ProtocCommandBuilder(String exePath, String protoPath, String protofolderPath, String descriptorSetOutPath) {
+        this.exePath = exePath;
+        this.protoPath = protoPath;
+        this.descriptorSetOutPath = descriptorSetOutPath;
+        this.protoFolderPath = protofolderPath;
+    }
+
+    public String build() {
+        return COMMAND_PLACEHOLDER.replace(EXE_PATH_PLACEHOLDER, this.exePath)
+                .replace(PROTO_PATH_PLACEHOLDER, this.protoPath)
+                .replace(DESC_PATH_PLACEHOLDER, descriptorSetOutPath)
+                .replace(PROTO_FOLDER_PLACEHOLDER, protoFolderPath);
+    }
+}

--- a/components/micro-gateway-cli/src/main/resources/templates/clientStub.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/clientStub.mustache
@@ -1,0 +1,88 @@
+import ballerina/grpc;
+import ballerina/io;
+{{#stubObject}}
+public type {{connectorId}}{{stubTypeName}}{{stubType}}Stub object {
+    {{#stubs}}
+    public grpc:Client clientEndpoint;
+    public grpc:Stub stub;
+
+    function initStub (grpc:Client ep) {
+        grpc:Stub navStub = new;
+        navStub.initStub(ep, "{{stubType}}", DESCRIPTOR_KEY, descriptorMap);
+        self.stub = navStub;
+    }
+    {{/stubs}}{{#blockingFunctions}}
+    function {{operationId}} ({{inputDataType}}{{&space}}{{inputAttributeName}}{{inputComma}}{{&space}}grpc:Headers? headers = ()) returns (({{outputDataType}}{{outputComma}} grpc:Headers)|error) {
+        {{&initEmptyStub}}
+        var unionResp = self.stub.blockingExecute("{{methodId}}", req, headers = headers);
+        match unionResp {
+            error payloadError => {
+                return payloadError;
+            }
+            (any, grpc:Headers) payload => {
+                any result;
+                grpc:Headers resHeaders;
+                ({{resultCast}}, resHeaders) = payload;
+                return {{&openBracket}}{{&checkOp}}{{&castSymbolOpen}}{{outputDataType}}{{&castSymbolClose}}{{resultOut}}{{outputComma}}{{&space}}resHeaders{{&closeBracket}};
+            }
+        }
+    }
+    {{/blockingFunctions}}{{#nonBlockingFunctions}}
+    function {{operationId}} ({{inputDataType}}{{&space}}{{inputAttributeName}}{{inputComma}}{{&space}}typedesc listener, grpc:Headers? headers = ()) returns (error?) {
+        return self.stub.nonBlockingExecute("{{methodId}}", req, listener, headers = headers);
+    }
+    {{/nonBlockingFunctions}}{{#streamingFunctions}}
+    function {{operationId}} (typedesc listener, grpc:Headers? headers = ()) returns (grpc:Client| error)  {
+        var res = self.stub.streamingExecute("{{methodId}}", listener, headers = headers);
+        match res {
+            error err => {
+                return err;
+            }
+            grpc:Client con => {
+                return con;
+            }
+        }
+    }
+    {{/streamingFunctions}}
+};
+{{/stubObject}}
+{{#client}}
+public type {{connectorId}}{{stubTypeName}}{{stubType}}Client object {
+    {{#stubObjects}}
+    public grpc:Client client;
+    public {{connectorId}}{{stubTypeName}}Stub stub;
+
+    public function init (grpc:ClientEndpointConfig config) {
+        // initialize client endpoint.
+        grpc:Client c = new;
+        c.init(config);
+        self.client = c;
+        // initialize service stub.
+        {{connectorId}}{{stubTypeName}}Stub s = new;
+        s.initStub(c);
+        self.stub = s;
+    }
+
+    public function getCallerActions () returns ({{connectorId}}{{stubTypeName}}Stub) {
+        return self.stub;
+    }{{/stubObjects}}
+};
+{{/client}}
+{{#structs}}
+type {{structId}} record {
+    {{#attribute}}{{type}}{{label}} {{name}};
+    {{/attribute}}
+};
+{{/structs}}
+{{#enums}}
+enum {{enumId}} {
+{{#enumAttribute}}{{name}}{{eoe}}
+{{/enumAttribute}}
+}
+{{/enums}}
+@final string DESCRIPTOR_KEY = "{{rootDescriptorKey}}";
+map descriptorMap =
+{ {{#descriptors}}
+    "{{descriptorKey}}":"{{descriptorData}}"{{eoe}}
+  {{/descriptors}}
+};

--- a/components/micro-gateway-cli/src/main/resources/templates/sample.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/sample.mustache
@@ -1,0 +1,32 @@
+import ballerina/io;
+import ballerina/grpc;
+
+function main (string... args) {
+{{#nonBlockingEndpoint}}
+     endpoint {{connectorId}}Client {{connectorIdName}}Ep {
+        url:"http://localhost:9090"
+     };{{/nonBlockingEndpoint}}{{#blockingEndpoint}}
+    endpoint {{connectorId}}BlockingClient {{connectorIdName}}BlockingEp {
+        url:"http://localhost:9090"
+    };
+{{/blockingEndpoint}}
+}
+
+{{#messageListener}}
+service<grpc:Service> {{connectorId}}MessageListener {
+
+    onMessage (string message) {
+        io:println("Response received from server: " + message);
+    }
+
+    onError (error err) {
+        if (err != ()) {
+            io:println("Error reported from server: " + err.message);
+        }
+    }
+
+    onComplete () {
+        io:println("Server Complete Sending Responses.");
+    }
+}
+{{/messageListener}}


### PR DESCRIPTION
## Purpose
Existing micro-gateway does not provide support for gRPC protocol. To include above mentioned benefits to micro-gateway it is required to implement this support into micro-gateway.

## Goals
Add gRPC support for API micro-gateway.

## Approach
Approach is to Implement gRPC support for product micro-gateway as a service which supports HTTP requests into gRPC supported ones. In this scenario we have to implement a ballerina service which receives REST requests and convert them to requests that can be identified in endpoint which is a gRPC service. But in this case we don't need to implement new gRPC filers for process request since receiving requests will be treated as REST/HTTP requests. After the filter processing these requests will be converted into gRPC supported ones. Then that converted ones will be sent to endpoint. When user provides the .proto API definition at Setup command level it reads the proto file and creates the ballerina file which act as service which do the REST to gRPC conversion. For that we have to implement logic to read .proto file from the scratch and implement the business logic of conversion according to the .proto file.


![image](https://user-images.githubusercontent.com/42435576/51911120-ff14f000-23f6-11e9-9141-cb9adf100dd7.png)

Figure 1


According to above approach this grpc feature is to be enabled at micro-gateway set up. At microgateway setup user required to provide .proto definition and the grpc endpoint. We will introduce a new setup command flag as **“-oa”** and **“--openApi”** which can be configured at setup command as **“-oa=”PATH_TO_”.proto”_API_DEFINITION_FILE”** to provide path of the “.proto” API definition file which required to setup micro-gateway with gRPC support. Then it requires to enter gRPC endpoint at the setup with “-e” flag. In this scenario user can only enter gRPC endpoint as the production endpoint. When this command is provided, the ballerina source will be generated in a way it can support above figure 1 diagram flaw.

Then from the given path, cmd side of product micro-gateway which written in Java will extract methods, models and configurations from the file and generate the java objects related to that definition given in the .proto file. Ballerina grpc support has a skeleton which used to generate ballerina source that support gRPC protocol. Then java objects will be mapped into that skelton and generate “Client_stub.bal” file and generate “Client.bal” file which includes logic of converting HTTP request payloads into gRPC supported objects. And this Client.bal file has the ability to convert gRPC responses into HTTP/REST responses also. This ballerina source files has to be generated using mustache templates. 
In the mapping of HTTP/ REST to gRPC there is a optional field in the proto files which uses to convert Resource methods and it’s paths into their respective gRPC supported functions. After the resources are generated then using build command user can get an executable and start the server.

**This PR does not completely provide gRPC support for the API micro-gateway. Some of the functionalities have to be provided from Ballerina, and that support not exists yet.
For more reference  https://github.com/wso2/product-microgateway/issues/283**


