### PR TITLE
Multiple endpoint support for developer first

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
@@ -20,6 +20,9 @@ package org.wso2.apimgt.gateway.cli.cmd;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
 import org.ballerinalang.packerina.init.InitHandler;
 import org.slf4j.Logger;
@@ -45,6 +48,8 @@ import org.wso2.apimgt.gateway.cli.utils.GatewayCmdUtils;
 import org.wso2.apimgt.gateway.cli.utils.OpenApiCodegenUtils;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.MalformedURLException;
@@ -60,6 +65,7 @@ import java.util.List;
  */
 @Parameters(commandNames = "setup", commandDescription = "setup information")
 public class SetupCmd implements GatewayLauncherCmd {
+
     private static final Logger logger = LoggerFactory.getLogger(SetupCmd.class);
     private static PrintStream outStream = System.out;
 
@@ -93,6 +99,9 @@ public class SetupCmd implements GatewayLauncherCmd {
     @Parameter(names = {"-ec", "--endpointConfig"}, hidden = true)
     private String endpointConfig;
 
+    @Parameter(names = {"-ms", "--multi-swag"}, hidden = true)
+    private String multipleSwagger;
+
     @Parameter(names = {"-t", "--truststore"}, hidden = true)
     private String trustStoreLocation;
 
@@ -125,7 +134,6 @@ public class SetupCmd implements GatewayLauncherCmd {
     @Parameter(names = {"-b", "--security"}, hidden = true)
     private String security;
 
-
     private String publisherEndpoint;
     private String adminEndpoint;
     private String registrationEndpoint;
@@ -134,9 +142,11 @@ public class SetupCmd implements GatewayLauncherCmd {
     private String clientCertEndpoint;
 
     public void execute() {
+
         String clientID;
         String workspace = GatewayCmdUtils.getUserDir();
         boolean isOpenApi = StringUtils.isNotEmpty(openApi);
+        boolean isMultiSwag = StringUtils.isNotEmpty(multipleSwagger);
         String projectName = GatewayCmdUtils.getProjectName(mainArgs);
         if (projectName.contains(" ")) {
             throw GatewayCmdUtils.createUsageException("Only one argument accepted as the project name. but provided:" +
@@ -157,9 +167,51 @@ public class SetupCmd implements GatewayLauncherCmd {
         boolean isOverwriteRequired = false;
 
         /*
+         * If user requires multiple endpoint support
+         */
+        if (isMultiSwag) {
+            try (InputStream fileStream = new FileInputStream(multipleSwagger)) {
+                ObjectMapper mapper = new ObjectMapper();
+                APIConfig[] apiDefinitions = mapper.readValue(fileStream, APIConfig[].class);
+                String[] apiList = new String[apiDefinitions.length];
+                String[] endpointConfList = new String[apiDefinitions.length];
+                for (int i = 0; i < apiDefinitions.length; i++) {
+                    APIConfig apiDefinition = apiDefinitions[i];
+                    String swaggerPath = apiDefinition.getSwaggerPath();
+                    String swaggerHost = apiDefinition.getEndpoint();
+                    outStream.println("Loading Open Api Specification from Path: " + swaggerPath);
+                    String api = OpenApiCodegenUtils.readApi(swaggerPath);
+                    logger.debug("Successfully read the api definition file");
+                    String endpointConf = "{\"production_endpoints\":{\"url\":\"" + swaggerHost.trim() +
+                            "\"},\"endpoint_type\":\"http\"}";
+                    apiList[i] = api;
+                    endpointConfList[i] = endpointConf;
+                }
+                CodeGenerator codeGenerator = new CodeGenerator();
+                codeGenerator.generate(projectName, apiList, endpointConfList, true);
+                //Initializing the ballerina project and creating .bal folder.
+                logger.debug("Creating source artifacts");
+                InitHandler.initialize(Paths.get(GatewayCmdUtils.getProjectDirectoryPath(projectName)), null,
+                        new ArrayList<>(), null);
+            } catch (JsonParseException e) {
+                logger.error("Error while parsing JSON", e);
+                throw GatewayCmdUtils.createUsageException("Error while parsing JSON");
+            } catch (JsonMappingException e) {
+                logger.error("Error while mapping JSON", e);
+                throw GatewayCmdUtils.createUsageException("Error while mapping JSON");
+            } catch (IOException e) {
+                logger.error("API config File not found or accessible", e);
+                throw GatewayCmdUtils.createUsageException("API config File not found or accessible");
+            } catch (BallerinaServiceGenException e) {
+                logger.error("Error while generating ballerina source.", e);
+                throw new CLIInternalException("Error while generating ballerina source.");
+            }
+            outStream.println("Setting up project " + projectName + " is successful.");
+        }
+        /*
          * If api is created via an api definition, the setup flow is altered
          */
-        if (isOpenApi) {
+        else if (isOpenApi) {
             outStream.println("Loading Open Api Specification from Path: " + openApi);
             String api = OpenApiCodegenUtils.readApi(openApi);
             logger.debug("Successfully read the api definition file");
@@ -178,7 +230,7 @@ public class SetupCmd implements GatewayLauncherCmd {
                     endpointConfig = "{\"production_endpoints\":{\"url\":\"" + endpoint.trim() +
                             "\"},\"endpoint_type\":\"http\"}";
                 }
-                codeGenerator.generate(projectName, api, endpointConfig, true);
+                codeGenerator.generate(projectName, new String[]{api}, new String[]{endpointConfig}, true);
                 //Initializing the ballerina project and creating .bal folder.
                 logger.debug("Creating source artifacts");
                 InitHandler.initialize(Paths.get(GatewayCmdUtils.getProjectDirectoryPath(projectName)), null,
@@ -423,6 +475,7 @@ public class SetupCmd implements GatewayLauncherCmd {
      * @param version API version
      */
     private void validateAPIGetRequestParams(String label, String apiName, String version) {
+
         if ((StringUtils.isEmpty(label) && (StringUtils.isEmpty(apiName) || StringUtils.isEmpty(version))) ||
                 StringUtils.isNotEmpty(label) && (StringUtils.isNotEmpty(apiName) || StringUtils.isNotEmpty(version)) ||
                 (StringUtils.isEmpty(apiName) && StringUtils.isNotEmpty(version)) ||
@@ -437,24 +490,29 @@ public class SetupCmd implements GatewayLauncherCmd {
 
     @Override
     public String getName() {
+
         return GatewayCliCommands.SETUP;
     }
 
     @Override
     public void setParentCmdParser(JCommander parentCmdParser) {
+
     }
 
     private String promptForTextInput(String msg) {
+
         outStream.println(msg);
         return System.console().readLine();
     }
 
     private String promptForPasswordInput(String msg) {
+
         outStream.println(msg);
         return new String(System.console().readPassword());
     }
 
     private void populateHosts(String host) {
+
         try {
             publisherEndpoint = new URL(new URL(host), RESTServiceConstants.PUB_RESOURCE_PATH).toString();
             clientCertEndpoint = new URL(new URL(host), RESTServiceConstants.PUB_CLIENT_CERT_PATH).toString();
@@ -468,6 +526,7 @@ public class SetupCmd implements GatewayLauncherCmd {
     }
 
     private static void init(String projectName, String configPath, String deploymentConfigPath) {
+
         try {
             GatewayCmdUtils.createProjectStructure(projectName);
             GatewayCmdUtils.createDeploymentConfig(projectName, deploymentConfigPath);
@@ -498,6 +557,7 @@ public class SetupCmd implements GatewayLauncherCmd {
     }
 
     public void setSecuritySchemas(String schemas) {
+
         Config config = GatewayCmdUtils.getConfig();
         BasicAuth basicAuth = new BasicAuth();
         boolean basic = false;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/config/APIConfig.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/config/APIConfig.java
@@ -1,0 +1,23 @@
+package org.wso2.apimgt.gateway.cli.model.config;
+
+public class APIConfig {
+
+    private String swaggerPath;
+    private String endpoint;
+
+    public String getSwaggerPath() {
+        return swaggerPath;
+    }
+
+    public void setSwaggerPath(String swaggerPath) {
+        this.swaggerPath = swaggerPath;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+}


### PR DESCRIPTION
## Purpose
Adds multiple endpoint support using swaggers for existing developer first approach.

## Approach
Introduce a new flag called -ms. 
User must specify a path to json similar to below json.
```json
[
    {
      "swaggerPath":"/home/anjana/mg-test/swaggers/swag1.json",
      "endpoint":"http://0.0.0.0:9091/ser1"
    },
    {
      "swaggerPath":"/home/anjana/mg-test/waggers/swag2.json",
      "endpoint":"http://0.0.0.0:9092/ser2"
    },
    {
      "swaggerPath":"/home/anjana/mg-test/waggers/swag3.json",
      "endpoint":"http://0.0.0.0:9093/ser3"
    }
]
```

## Samples
./micro-gw setup test-proj -ms /home/anjana/mg-test/cellery/cells/apicfg.json
