### PR TITLE
Change the format of config keys

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/templates/basicAuth.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/basicAuth.mustache
@@ -1,6 +1,6 @@
 {{#api.endpointSecurity}}{{#equals api.endpointSecurity.type "basic"}},
     auth: {
         scheme: "Basic",
-        username: gateway:retrieveConfig("{{api.name}}.{{api.version}}.{{endpointUrlType}}.basic.username", "{{api.endpointSecurity.username}}"),
-        password: gateway:retrieveConfig("{{api.name}}.{{api.version}}.{{endpointUrlType}}.basic.password", "")
+        username: gateway:retrieveConfig("{{api.id}}_{{endpointUrlType}}_basic_username", "{{api.endpointSecurity.username}}"),
+        password: gateway:retrieveConfig("{{api.id}}_{{endpointUrlType}}_basic_password", "")
     }{{/equals}}{{/api.endpointSecurity}}

--- a/components/micro-gateway-cli/src/main/resources/templates/failoverEndpoint.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/failoverEndpoint.mustache
@@ -1,6 +1,6 @@
 endpoint http:FailoverClient {{qualifiedServiceName}}_{{endpointUrlType}} {
     targets: [
-    {{#endpoints}}    {url: gateway:retrieveConfig("{{api.name}}.{{api.version}}.{{endpointUrlType}}.endpoint.{{@index}}", "{{endpointUrl}}")}{{#unless @last}},
+    {{#endpoints}}    {url: gateway:retrieveConfig("{{api.id}}_{{endpointUrlType}}_endpoint_{{@index}}", "{{endpointUrl}}")}{{#unless @last}},
     {{/unless}}{{/endpoints}}
     ]{{>basicAuth}}
 };

--- a/components/micro-gateway-cli/src/main/resources/templates/lbEndpoint.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/lbEndpoint.mustache
@@ -1,6 +1,6 @@
 endpoint http:LoadBalanceClient {{qualifiedServiceName}}_{{endpointUrlType}} {
     targets: [
-    {{#endpoints}}    {url: gateway:retrieveConfig("{{api.name}}.{{api.version}}.{{endpointUrlType}}.endpoint.{{@index}}", "{{endpointUrl}}")}{{#unless @last}},
+    {{#endpoints}}    {url: gateway:retrieveConfig("{{api.id}}_{{endpointUrlType}}_endpoint_{{@index}}", "{{endpointUrl}}")}{{#unless @last}},
     {{/unless}}{{/endpoints}}
     ],
     algorithm: http:ROUND_ROBIN{{>caching}}{{>basicAuth}}


### PR DESCRIPTION
## Purpose
> In the current design, when providing values to override endpoints and when defining backend auth credentials,  the config keys contains "." character. Also if the API name consists of characters from other languages such as Chinese, it will be difficult to provide this config keys. So changed the format of config keys to use API ID and replaced "." character with "_" character.

## Approach
> Changed the relevant mustache files
basicAuth.mustache
lbEndpoint.mustache
failoverEndpoint.mustache

> For username: <API_ID>\_<ENDPOINT_TYPE>\_basic\_username
For password: <API_ID>\_<ENDPOINT_TYPE>\_basic\_username
For lbEndpoint : <API_ID>\_<ENDPOINT_TYPE>\_endpoint\_\<INDEX>
For failoverEndpoint : <API_ID>\_<ENDPOINT_TYPE>\_endpoint\_\<INDEX>
 

## Documentation
>  Doc has impact
