### PR TITLE
Add default API support for developer first multi-swagger

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
@@ -111,7 +111,7 @@ public class CodeGenerator {
      * @throws IOException                  when file operations fail
      * @throws BallerinaServiceGenException when code generator fails
      */
-    public void generate(String projectName, String[] apiDefinitions, String[] endpointDefinitions, boolean[] defaultAPI, boolean overwrite)
+    public void generate(String projectName, String[] apiDefinitions, String[] endpointDefinitions, boolean[] defaultAPIs, boolean overwrite)
             throws IOException, BallerinaServiceGenException {
         BallerinaService definitionContext;
         SwaggerParser parser;
@@ -133,7 +133,7 @@ public class CodeGenerator {
             api.setTransport(Arrays.asList("http", "https"));
             OpenApiCodegenUtils.setAdditionalConfigs(api);
             definitionContext = new BallerinaService().buildContext(swagger, api);
-            if (defaultAPI[i]) {
+            if (defaultAPIs[i]) {
                 definitionContext.getApi().setIsDefaultVersion(false);
                 genFiles.add(generateService(definitionContext));
                 definitionContext.getApi().setIsDefaultVersion(true);

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
@@ -54,6 +54,7 @@ import java.util.UUID;
  * This class generates Ballerina Services/Clients for a provided OAS definition.
  */
 public class CodeGenerator {
+
     private static PrintStream outStream = System.out;
 
     /**
@@ -110,7 +111,7 @@ public class CodeGenerator {
      * @throws IOException                  when file operations fail
      * @throws BallerinaServiceGenException when code generator fails
      */
-    public void generate(String projectName, String[] apiDefinitions, String[] endpointDefinitions, boolean overwrite)
+    public void generate(String projectName, String[] apiDefinitions, String[] endpointDefinitions, boolean[] defaultAPI, boolean overwrite)
             throws IOException, BallerinaServiceGenException {
         BallerinaService definitionContext;
         SwaggerParser parser;
@@ -132,6 +133,11 @@ public class CodeGenerator {
             api.setTransport(Arrays.asList("http", "https"));
             OpenApiCodegenUtils.setAdditionalConfigs(api);
             definitionContext = new BallerinaService().buildContext(swagger, api);
+            if (defaultAPI[i]) {
+                definitionContext.getApi().setIsDefaultVersion(false);
+                genFiles.add(generateService(definitionContext));
+                definitionContext.getApi().setIsDefaultVersion(true);
+            }
             genFiles.add(generateService(definitionContext));
         }
         genFiles.add(generateCommonEndpoints());
@@ -208,6 +214,7 @@ public class CodeGenerator {
      * Generates ballerina source for provided Open APIDetailedDTO Definition in {@code definitionPath}.
      * Generated source will be written to a ballerina package at {@code outPath}
      * <p>Method can be user for generating Ballerina mock services and clients</p>
+     *
      * @param projectName name of the project being set up
      * @param apiDef      api definition string
      * @param overwrite   whether existing files overwrite or not

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/config/APIConfig.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/config/APIConfig.java
@@ -19,6 +19,7 @@ public class APIConfig {
 
     private String swaggerPath;
     private String endpoint;
+    private boolean defaultAPI;
 
     public String getSwaggerPath() {
         return swaggerPath;
@@ -34,5 +35,13 @@ public class APIConfig {
 
     public void setEndpoint(String endpoint) {
         this.endpoint = endpoint;
+    }
+
+    public boolean isDefaultAPI() {
+        return defaultAPI;
+    }
+
+    public void setDefaultAPI(boolean defaultAPI) {
+        this.defaultAPI = defaultAPI;
     }
 }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/config/APIConfig.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/config/APIConfig.java
@@ -19,7 +19,7 @@ public class APIConfig {
 
     private String swaggerPath;
     private String endpoint;
-    private boolean defaultAPI;
+    private boolean isDefaultAPI;
 
     public String getSwaggerPath() {
         return swaggerPath;
@@ -38,10 +38,10 @@ public class APIConfig {
     }
 
     public boolean isDefaultAPI() {
-        return defaultAPI;
+        return isDefaultAPI;
     }
 
     public void setDefaultAPI(boolean defaultAPI) {
-        this.defaultAPI = defaultAPI;
+        this.isDefaultAPI = defaultAPI;
     }
 }


### PR DESCRIPTION
## Purpose
Default API support was supported default label based MicroGW flow. However it wasn't available in developer first Approach. This PR introduces default API support for developer first multi swagger branch.

## Approach (After review)
Introduce a modification to the flag -ms.
User must specify a path to json similar to below json.
```json
[
    {
      "swaggerPath":"/home/anjana/mg-test/swaggers/swag1.json",
      "endpoint":"http://0.0.0.0:9091/ser1",
      "isDefaultAPI":true
    },
    {
      "swaggerPath":"/home/anjana/mg-test/swaggers/swag2.json",
      "endpoint":"http://0.0.0.0:9092/ser2",
      "isDefaultAPI":false
    },
    {
      "swaggerPath":"/home/anjana/mg-test/swaggers/swag3.json",
      "endpoint":"http://0.0.0.0:9093/ser3",
      "isDefaultAPI":true
    }
]
