### PR TITLE
Writing unit tests for timeBatch and emitOnStateChange

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/gateway/throttler/tests/emitOnStateChangeTest.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/throttler/tests/emitOnStateChangeTest.bal
@@ -1,0 +1,88 @@
+import ballerina/http;
+import ballerina/log;
+import ballerina/io;
+import ballerina/test;
+import ballerina/config;
+import ballerina/runtime;
+
+type InputDTO record {
+    string throttleKey;
+    boolean isThrottled;
+};
+
+type OutputDTO record{
+    string throttleKey;
+    boolean isThrottled;
+    string outp;
+};
+
+int indexx = 0;
+stream<InputDTO> inputStreamTest1 = new;
+stream<OutputDTO > outputStreamTest1 = new;
+OutputDTO[] globalArray = [];
+
+@test:Config
+public function emittest(){
+
+    log:printInfo("starting emit on state change test");
+    OutputDTO[] arrayT = startEmitTest();
+    json[] testOut = [{throttleKey:"123", isThrottled:false, outp:"testout"}, {throttleKey:"456", isThrottled:false, outp:"testout"}, {throttleKey:"123", isThrottled:true, outp:"testout"}, {throttleKey:"123", isThrottled:true, outp:"testout"}];
+    test:assertEquals(arrayT, testOut, msg = "Test failed");
+}
+
+function startEmitTest() returns (OutputDTO[]) {
+
+    InputDTO t1 = { throttleKey: "123", isThrottled: false };
+    InputDTO t2 = { throttleKey: "456", isThrottled: false };
+    InputDTO t3 = { throttleKey: "123", isThrottled: false };
+    InputDTO t4 = { throttleKey: "123", isThrottled: true };
+    InputDTO t5 = { throttleKey: "456", isThrottled: false };
+    InputDTO t6 = { throttleKey: "123", isThrottled: true };
+
+    testwindow();
+
+    outputStreamTest1.subscribe(function(OutputDTO e) {printT(e);});
+
+    inputStreamTest1.publish(t1);
+    inputStreamTest1.publish(t2);
+    runtime:sleep(1200);
+    inputStreamTest1.publish(t3);
+    inputStreamTest1.publish(t4);
+    runtime:sleep(3000);
+    inputStreamTest1.publish(t5);
+    inputStreamTest1.publish(t6);
+    runtime:sleep(1200);
+
+
+    return globalArray;
+}
+
+function testwindow() {
+
+    forever {
+        from inputStreamTest1
+
+        window emitOnStateChange(inputStreamTest1.throttleKey, inputStreamTest1.isThrottled,"inputStreamTest1")
+
+        select inputStreamTest1.throttleKey, inputStreamTest1.isThrottled, "testout" as outp
+
+        => (OutputDTO[] emp) {
+
+            foreach var e in emp {
+                outputStreamTest1.publish(e);
+            }
+        }
+
+    }
+}
+
+function printT(OutputDTO e) {
+    addToGlobalArray(e);
+}
+
+function addToGlobalArray(OutputDTO e) {
+    globalArray[indexx] = e;
+    indexx = indexx + 1;
+}
+
+

--- a/components/micro-gateway-core/src/main/ballerina/gateway/throttler/tests/timeBatchTest.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/throttler/tests/timeBatchTest.bal
@@ -1,0 +1,87 @@
+import ballerina/http;
+import ballerina/log;
+import ballerina/io;
+import ballerina/test;
+import ballerina/config;
+import ballerina/runtime;
+import ballerina/time;
+
+type InputStreamDTO record {
+    string throttleKey;
+    int expiryTimestamp?;
+};
+
+type OutputStreamDTO record{
+    string throttleKey;
+    int eventCount;
+    int expiryTimeStamp=0;
+};
+
+int ind = 0;
+stream<InputStreamDTO> inputStreamTimeBatchTest1 = new;
+stream<OutputStreamDTO> outputStreamTimeBatchTest1 = new;
+OutputStreamDTO[] gArray = [];
+
+@test:Config
+public function timebatchtest(){
+    log:printInfo("starting time batch test");
+    OutputStreamDTO[] arrayOut = startTimeBatchTest();
+
+    test:assertEquals(arrayOut[1].eventCount, 2, msg = "Test time batch failed, batch count failed");
+    test:assertEquals(arrayOut[5].eventCount, 4, msg = "Test time batch failed, batch count failed");
+    test:assertFalse(arrayOut[5].expiryTimeStamp == 0, msg= "expiry time stamp is not added properly");
+}
+
+
+function startTimeBatchTest() returns (OutputStreamDTO[]) {
+
+    InputStreamDTO t1 = { throttleKey: "123" , expiryTimestamp: 0};
+    InputStreamDTO t2 = { throttleKey: "456" , expiryTimestamp: 0};
+    InputStreamDTO t3 = { throttleKey: "625" , expiryTimestamp: 0};
+    InputStreamDTO t4 = { throttleKey: "128" , expiryTimestamp: 0};
+    InputStreamDTO t5 = { throttleKey: "856" , expiryTimestamp: 0};
+    InputStreamDTO t6 = { throttleKey: "193" , expiryTimestamp: 0};
+
+    testTimeBatchwindow();
+
+    outputStreamTimeBatchTest1.subscribe(function(OutputStreamDTO e) {printTe(e);});
+
+    inputStreamTimeBatchTest1.publish(t1);
+    inputStreamTimeBatchTest1.publish(t2);
+    runtime:sleep(2000);
+    inputStreamTimeBatchTest1.publish(t3);
+    inputStreamTimeBatchTest1.publish(t4);
+    inputStreamTimeBatchTest1.publish(t5);
+    inputStreamTimeBatchTest1.publish(t6);
+    runtime:sleep(1000);
+
+
+
+    return gArray;
+}
+
+function testTimeBatchwindow() {
+
+    forever {
+        from inputStreamTimeBatchTest1
+        window timeBatch(2000,0)
+        select inputStreamTimeBatchTest1.throttleKey as throttleKey, count() as eventCount, inputStreamTimeBatchTest1.expiryTimestamp as expiryTimeStamp
+        => (OutputStreamDTO[] counts) {
+            foreach var c in counts{
+                outputStreamTimeBatchTest1.publish(c);
+            }
+        }
+
+    }
+}
+
+function printTe(OutputStreamDTO e) {
+    addToGArray(e);
+}
+
+function addToGArray(OutputStreamDTO e) {
+    gArray[ind] = e;
+    ind = ind + 1;
+}
+
+


### PR DESCRIPTION
## Purpose
The timeBatch and emitOnStateChange are used in throttling policy streams. Earlier those functions were written as siddhi extensions in java. Later, since the throttling streams are handled by ballerina, it was decided to implement those functions using ballerina. These ballerina unit tests are written to check those functions.
