### PR TITLE
Add optional support for Mutual ssl

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/templates/mutualSSL.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/mutualSSL.mustache
@@ -4,8 +4,8 @@ path:  config:getAsString("listenerConfig.keyStore.path"),
 password: config:getAsString("listenerConfig.keyStore.password")
 },
 trustStore: {
-path:  config:getAsString("jwtTokenConfig.trustStore.path"),
-password: config:getAsString("jwtTokenConfig.trustStore.password")
+path:  config:getAsString("listenerConfig.trustStore.path"),
+password: config:getAsString("listenerConfig.trustStore.password")
 },
 protocol: {
 name: config:getAsString("mutualSSLConfig.ProtocolName"),

--- a/components/micro-gateway-core/src/main/ballerina/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/constants/constants.bal
@@ -69,6 +69,8 @@
  public const string API_VERSION = "apiVersion";
  public const string USER_NAME_UNKNOWN = "Unknown";
  public const string UNKNOWN_VALUE = "__unknown__";
+ public const string STATUS = "status";
+ public const string PASSED = "passed";
 
  public const string FILTER_FAILED = "filter_failed";
  public const string REMOTE_ADDRESS = "remote_address";

--- a/components/micro-gateway-core/src/main/ballerina/gateway/endpoints/etcd_endpoint.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/endpoints/etcd_endpoint.bal
@@ -22,8 +22,9 @@ http:Client etcdEndpoint = new (
     retrieveConfig("etcdurl", "http://127.0.0.1:2379"), config = {
         secureSocket: {
             trustStore: {
-                path: config:getAsString("jwtTokenConfig.trustStore.path"),
-                password: config:getAsString("jwtTokenConfig.trustStore.password")
+                path: getConfigValue(LISTENER_CONF_INSTANCE_ID, TRUST_STORE_PATH,
+                    "${ballerina.home}/bre/security/ballerinaTruststore.p12"),
+                password: getConfigValue(LISTENER_CONF_INSTANCE_ID, TRSUT_STORE_PASSWORD, "ballerina")
             }
         }
     }

--- a/components/micro-gateway-core/src/main/ballerina/gateway/filters/authn_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/filters/authn_filter.bal
@@ -31,18 +31,16 @@ public type AuthnFilter object {
     // public variables in order to satisfy filter interface
     public OAuthnAuthenticator oauthAuthenticator;
     public http:AuthnHandlerChain authnHandlerChain;
-    public string authRequired;
 
     public function __init(OAuthnAuthenticator oauthAuthenticator, http:AuthnHandlerChain authnHandlerChain) {
         self.oauthAuthenticator = oauthAuthenticator;
         self.authnHandlerChain = authnHandlerChain;
-        self.authRequired = getConfigValue(MTSL_CONF_INSTANCE_ID, MTSL_CONF_SSLVERIFYCLIENT, "");
     }
 
     public function filterRequest(http:Caller caller, http:Request request, http:FilterContext context)
                         returns boolean {
         //Setting UUID
-        if (self.authRequired != REQUIRE) {
+        if(request.mutualSslHandshake["status"] != PASSED) {
             int startingTime = getCurrentTime();
             context.attributes[REQUEST_TIME] = startingTime;
             checkOrSetMessageID(context);

--- a/components/micro-gateway-core/src/main/ballerina/gateway/listeners/api_gateway_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/listeners/api_gateway_listener.bal
@@ -115,9 +115,9 @@ public function getAuthProviders() returns http:AuthProvider[] {
         audience: getConfigValue(JWT_INSTANCE_ID, AUDIENCE, "RQIO7ti2OThP79wh3fE5_Zksszga"),
         certificateAlias: getConfigValue(JWT_INSTANCE_ID, CERTIFICATE_ALIAS, "ballerina"),
         trustStore: {
-            path: getConfigValue(JWT_INSTANCE_ID, TRUST_STORE_PATH,
+            path: getConfigValue(LISTENER_CONF_INSTANCE_ID, TRUST_STORE_PATH,
                 "${ballerina.home}/bre/security/ballerinaTruststore.p12"),
-            password: getConfigValue(JWT_INSTANCE_ID, TRSUT_STORE_PASSWORD, "ballerina")
+            password: getConfigValue(LISTENER_CONF_INSTANCE_ID, TRSUT_STORE_PASSWORD, "ballerina")
         }
     };
     http:AuthProvider basicAuthProvider = {
@@ -145,9 +145,9 @@ public function getJWTAuthProvider() returns http:AuthProvider[] {
         audience: getConfigValue(JWT_INSTANCE_ID, AUDIENCE, "RQIO7ti2OThP79wh3fE5_Zksszga"),
         certificateAlias: getConfigValue(JWT_INSTANCE_ID, CERTIFICATE_ALIAS, "ballerina"),
         trustStore: {
-            path: getConfigValue(JWT_INSTANCE_ID, TRUST_STORE_PATH,
+            path: getConfigValue(LISTENER_CONF_INSTANCE_ID, TRUST_STORE_PATH,
                 "${ballerina.home}/bre/security/ballerinaTruststore.p12"),
-            password: getConfigValue(JWT_INSTANCE_ID, TRSUT_STORE_PASSWORD, "ballerina")
+            password: getConfigValue(LISTENER_CONF_INSTANCE_ID, TRSUT_STORE_PASSWORD, "ballerina")
         }
     };
     return [jwtAuthProvider];

--- a/components/micro-gateway-core/src/main/ballerina/gateway/listeners/api_gateway_secure_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/listeners/api_gateway_secure_listener.bal
@@ -48,9 +48,9 @@ function initiateGatewaySecureConfigurations(http:ServiceEndpointConfiguration c
         "${ballerina.home}/bre/security/ballerinaKeystore.p12");
     string keyStorePassword = getConfigValue(LISTENER_CONF_INSTANCE_ID,
         LISTENER_CONF_KEY_STORE_PASSWORD, "ballerina");
-    string trustStorePath = getConfigValue(JWT_INSTANCE_ID,
+    string trustStorePath = getConfigValue(LISTENER_CONF_INSTANCE_ID,
         TRUST_STORE_PATH, "${ballerina.home}/bre/security/ballerinaTruststore.p12");
-    string trustStorePassword = getConfigValue(JWT_CONFIG_INSTANCE_ID,
+    string trustStorePassword = getConfigValue(LISTENER_CONF_INSTANCE_ID,
         TRSUT_STORE_PASSWORD, "ballerina");
     string protocolName = getConfigValue(MTSL_CONF_INSTANCE_ID,
         MTSL_CONF_PROTOCOL_NAME, "TLS");

--- a/distribution/resources/conf/micro-gw.conf
+++ b/distribution/resources/conf/micro-gw.conf
@@ -4,6 +4,8 @@ httpPort=9090
 httpsPort=9095
 keyStore.path="${ballerina.home}/bre/security/ballerinaKeystore.p12"
 keyStore.password="ballerina"
+trustStore.path="${ballerina.home}/bre/security/ballerinaTruststore.p12"
+trustStore.password="ballerina"
 tokenListenerPort=9096
 
 [authConfig]
@@ -22,8 +24,7 @@ verifyHostname=true
 issuer="https://localhost:9443/oauth2/token"
 audience="http://org.wso2.apimgt/gateway"
 certificateAlias="wso2apim"
-trustStore.path="${ballerina.home}/bre/security/ballerinaTruststore.p12"
-trustStore.password="ballerina"
+
 
 [jwtConfig]
 header="X-JWT-Assertion"


### PR DESCRIPTION
## Purpose
> Now we can specify optional values as well configuring mutual ssl. When we specify value as optional if mutual ssl is passed then further authentication will not happen. If mutual ssl is failed then other authentications mechanisms like oauth2, jwt and etc will be checked.
`
sslVerifyClient="optional"
`

> Move the trustStore.path and trustStore.password configs from "[jwtTokenConfig]" to "[listenerConfig]" in micro-gw.conf file

`[listenerConfig]
host="0.0.0.0"
httpPort=9090
httpsPort=9095
keyStore.path="${ballerina.home}/bre/security/ballerinaKeystore.p12"
keyStore.password="ballerina"
trustStore.path="${ballerina.home}/bre/security/ballerinaTruststore.p12"
trustStore.password="ballerina"
tokenListenerPort=9096
`