### PR TITLE
Read annotation during start up only

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GeneratorConstants.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GeneratorConstants.java
@@ -23,6 +23,7 @@ import java.io.File;
 public class GeneratorConstants {
 
     public static final String SERVICE_TEMPLATE_NAME = "service";
+    public static final String MAIN_TEMPLATE_NAME = "main";
     public static final String GENERATESWAGGER_TEMPLATE_NAME = "generateSwagger";
     public static final String THROTTLE_POLICY_TEMPLATE_NAME = "policy";
     public static final String LISTENERS_TEMPLATE_NAME = "listeners";

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -218,7 +218,7 @@ public class GatewayCmdUtils {
      *
      * @return resources file directory path
      */
-    private static String getResourceFolderLocation() {
+    public static String getResourceFolderLocation() {
         return System.getProperty(GatewayCliConstants.CLI_HOME) + File.separator
                 + GatewayCliConstants.GW_DIST_RESOURCES;
     }

--- a/components/micro-gateway-cli/src/main/resources/templates/main.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/main.mustache
@@ -1,0 +1,10 @@
+
+public function main() {
+    {{#each this}}
+    string[] {{cut qualifiedServiceName " "}}_service = [{{#paths}}{{#value}}{{#operations}}{{#value}} "{{operationId}}"{{#unless @last}},{{/unless}}
+                                {{/value}}{{/operations}}{{/value}}{{#unless @last}},{{/unless}}{{/paths}}];
+    gateway:populateAnnotationMaps("{{cut qualifiedServiceName " "}}", {{cut qualifiedServiceName " "}}, {{cut qualifiedServiceName " "}}_service);
+    {{/each}}
+
+    initThrottlePolicies();
+}

--- a/components/micro-gateway-cli/src/main/resources/templates/policy_init.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/policy_init.mustache
@@ -2,7 +2,6 @@ import ballerina/log;
 import ballerina/runtime;
 import wso2/gateway;
 
-future<()> ftr = start initThrottlePolicies();
 
 function initThrottlePolicies() {
     boolean globalThrottlingEnabled=gateway:initiateThrottlingJmsListener();

--- a/components/micro-gateway-core/src/main/ballerina/gateway/executiontime_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/executiontime_util.bal
@@ -26,13 +26,11 @@ public function generateExecutionTimeEvent(http:FilterContext context) returns E
         executionTimeDTO.provider = authContext.apiPublisher;
         executionTimeDTO.keyType = authContext.keyType;
     } else {
-        executionTimeDTO.provider = getAPIDetailsFromServiceAnnotation(
-                                        reflect:getServiceAnnotations(context.serviceRef)).publisher;
+        executionTimeDTO.provider = apiConfigAnnotationMap[getServiceName(context.serviceName)].publisher;
         executionTimeDTO.keyType = PRODUCTION_KEY_TYPE;
     }
     executionTimeDTO.apiName = getApiName(context);
-    executionTimeDTO.apiVersion = getAPIDetailsFromServiceAnnotation(reflect:getServiceAnnotations(context.serviceRef))
-    .apiVersion;
+    executionTimeDTO.apiVersion = apiConfigAnnotationMap[getServiceName(context.serviceName)].apiVersion;
     executionTimeDTO.tenantDomain = getTenantDomain(context);
     executionTimeDTO.context = getContext(context);
     executionTimeDTO.correleationID = <string>context.attributes[MESSAGE_ID];

--- a/components/micro-gateway-core/src/main/ballerina/gateway/filters/authn_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/filters/authn_filter.bal
@@ -82,7 +82,7 @@ function doAuthnFilterRequest(http:Caller caller, http:Request request, http:Fil
         string authHeader = "";
         string|error result = "";
         string|error extractedToken = "";
-        string authHeaderName = getAuthorizationHeader(reflect:getServiceAnnotations(context.serviceRef));
+        string authHeaderName = getAuthorizationHeader(serviceAnnotationMap[getServiceName(context.serviceName)] ?: []);
         //check for the header of the request and choose the path
         if (request.hasHeader(authHeaderName)) {
             authHeader = request.getHeader(authHeaderName);
@@ -272,11 +272,9 @@ function getResourceAuthConfig(http:FilterContext context) returns (boolean, str
     string[] authProviderIds = [];
     // get authn details from the resource level
     http:ListenerAuthConfig? resourceLevelAuthAnn = getAuthAnnotation(ANN_PACKAGE,
-        RESOURCE_ANN_NAME,
-        reflect:getResourceAnnotations(context.serviceRef, context.resourceName));
+        RESOURCE_ANN_NAME,resourceAnnotationMap[context.resourceName] ?: []);
     http:ListenerAuthConfig? serviceLevelAuthAnn = getAuthAnnotation(ANN_PACKAGE,
-        SERVICE_ANN_NAME,
-        reflect:getServiceAnnotations(context.serviceRef));
+        SERVICE_ANN_NAME,serviceAnnotationMap[getServiceName(context.serviceName)] ?: []);
     // check if authentication is enabled
     resourceSecured = isResourceSecured(resourceLevelAuthAnn, serviceLevelAuthAnn);
     // if resource is not secured, no need to check further

--- a/components/micro-gateway-core/src/main/ballerina/gateway/filters/subscription_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/filters/subscription_filter.bal
@@ -64,8 +64,7 @@ function doSubscriptionFilterRequest(http:Caller caller, http:Request request, h
         if(decodedPayload is json) {
             printTrace(KEY_SUBSCRIPTION_FILTER, "Decoded JWT payload: " + decodedPayload.toString());
             json subscribedAPIList = json.convert(decodedPayload.subscribedAPIs);
-            APIConfiguration? apiConfig = getAPIDetailsFromServiceAnnotation(reflect:
-                getServiceAnnotations(filterContext.serviceRef));
+            APIConfiguration? apiConfig = apiConfigAnnotationMap[getServiceName(filterContext.serviceName)];
             if (subscribedAPIList != null){
                 int l = subscribedAPIList.length();
                 if (l == 0){

--- a/components/micro-gateway-core/src/main/ballerina/gateway/filters/validation_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/filters/validation_filter.bal
@@ -67,7 +67,7 @@ function doValidationFilterRequest(http:Caller caller, http:Request request, htt
         var payload = request.getJsonPayload();
         isType = false;
         service serviceReference = <service>runtime:getInvocationContext().attributes[SERVICE_TYPE_ATTR];
-        APIConfiguration? apiConfig = getAPIDetailsFromServiceAnnotation(reflect:getServiceAnnotations(serviceReference));
+        APIConfiguration? apiConfig = apiConfigAnnotationMap[getServiceName(filterContext.serviceName)];
         json swagger = read(swaggerAbsolutePath);
         json model = {};
         json models = {};
@@ -77,7 +77,7 @@ function doValidationFilterRequest(http:Caller caller, http:Request request, htt
         //getting the method of the request
         requestMethod = request.method.toLower();
         //getting the path hit by the request
-        requestPath = getResourceConfigAnnotation(reflect:getResourceAnnotations(filterContext.serviceRef, filterContext.resourceName)).path;
+        requestPath = getResourceConfigAnnotation(resourceAnnotationMap[filterContext.resourceName] ?: []).path;
         //getting the name of the model hit by the request
         if (swagger.components.schemas != null) {//In swagger 3.0 models are defined under the components.schemas
             models = swagger.components.schemas;
@@ -138,7 +138,7 @@ public function doValidationFilterResponse(http:Response response, http:FilterCo
         //getting the payload of the response
         var payload = response.getJsonPayload();
         service serviceType = <service>runtime:getInvocationContext().attributes[SERVICE_TYPE_ATTR];
-        APIConfiguration? apiConfig = getAPIDetailsFromServiceAnnotation(reflect:getServiceAnnotations(serviceType));
+        APIConfiguration? apiConfig = apiConfigAnnotationMap[getServiceName(context.serviceName)];
         json swagger = read(swaggerAbsolutePath);
         json model = {};
         json models = {};

--- a/components/micro-gateway-core/src/main/ballerina/gateway/responsetime_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/responsetime_util.bal
@@ -86,8 +86,7 @@ public function generateRequestResponseExecutionDataEvent(http:Response response
         requestResponseExecutionDTO.applicationName = authContext.applicationName;
         requestResponseExecutionDTO.userTenantDomain = authContext.subscriberTenantDomain;
     } else {
-        requestResponseExecutionDTO.apiCreator = <string>getAPIDetailsFromServiceAnnotation(
-                                                     reflect:getServiceAnnotations(context.serviceRef)).publisher;
+        requestResponseExecutionDTO.apiCreator = <string>apiConfigAnnotationMap[getServiceName(context.serviceName)].publisher;
         requestResponseExecutionDTO.metaClientType = PRODUCTION_KEY_TYPE;
         requestResponseExecutionDTO.applicationConsumerKey = ANONYMOUS_CONSUMER_KEY;
         requestResponseExecutionDTO.userName = END_USER_ANONYMOUS;
@@ -96,9 +95,7 @@ public function generateRequestResponseExecutionDataEvent(http:Response response
         requestResponseExecutionDTO.userTenantDomain = ANONYMOUS_USER_TENANT_DOMAIN;
     }
     requestResponseExecutionDTO.apiName = getApiName(context);
-    requestResponseExecutionDTO.apiVersion = <string>getAPIDetailsFromServiceAnnotation(reflect:getServiceAnnotations(context.
-            serviceRef)).
-    apiVersion;
+    requestResponseExecutionDTO.apiVersion = <string>apiConfigAnnotationMap[getServiceName(context.serviceName)].apiVersion;
     requestResponseExecutionDTO.apiContext = getContext(context);
     requestResponseExecutionDTO.correlationId = <string>context.attributes[MESSAGE_ID];
 
@@ -115,9 +112,9 @@ public function generateRequestResponseExecutionDataEvent(http:Response response
     requestResponseExecutionDTO.responseSize = 0;
     requestResponseExecutionDTO.responseCode = response.statusCode;
     requestResponseExecutionDTO.apiResourcePath = <string>getResourceConfigAnnotation
-    (reflect:getResourceAnnotations(context.serviceRef, context.resourceName)).path;
+    (resourceAnnotationMap[context.resourceName] ?: []).path;
     requestResponseExecutionDTO.apiResourceTemplate = <string>getResourceConfigAnnotation
-    (reflect:getResourceAnnotations(context.serviceRef, context.resourceName)).path;
+    (resourceAnnotationMap[context.resourceName] ?: []).path;
     //request method
     requestResponseExecutionDTO.apiMethod = <string>context.attributes[API_METHOD_PROPERTY];
     int initTime = <int>context.attributes[REQUEST_TIME];

--- a/components/micro-gateway-core/src/main/ballerina/gateway/utils/analytics_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/utils/analytics_util.bal
@@ -20,7 +20,7 @@ boolean configsRead = false;
 function populateThrottleAnalyticsDTO(http:FilterContext context) returns (ThrottleAnalyticsEventDTO) {
     boolean isSecured = <boolean>context.attributes[IS_SECURED];
     ThrottleAnalyticsEventDTO eventDto = {};
-    var api_Version = getAPIDetailsFromServiceAnnotation(reflect:getServiceAnnotations(context.serviceRef)).apiVersion;
+    var api_Version = apiConfigAnnotationMap[getServiceName(context.serviceName)].apiVersion;
     string apiVersion = (api_Version is string) ? api_Version : "";
     time:Time time = time:currentTime();
     int currentTimeMills = time.time;
@@ -47,7 +47,7 @@ function populateThrottleAnalyticsDTO(http:FilterContext context) returns (Throt
     } else {
         metaInfo.keyType = PRODUCTION_KEY_TYPE;
         eventDto.userName = END_USER_ANONYMOUS;
-        var api_Creator = getAPIDetailsFromServiceAnnotation(reflect:getServiceAnnotations(context.serviceRef)).publisher;
+        var api_Creator = apiConfigAnnotationMap[getServiceName(context.serviceName)].publisher;
         eventDto.apiCreator = (api_Creator is string) ? api_Creator : "";
         eventDto.applicationName = ANONYMOUS_APP_NAME;
         eventDto.applicationId = ANONYMOUS_APP_ID;
@@ -66,12 +66,10 @@ function populateFaultAnalyticsDTO(http:FilterContext context, error err) return
     int currentTimeMills = time.time;
     json metaInfo = {};
     eventDto.apiContext = getContext(context);
-    var api_Version = getAPIDetailsFromServiceAnnotation(reflect:getServiceAnnotations(context.serviceRef)).
-    apiVersion;
+    var api_Version = apiConfigAnnotationMap[getServiceName(context.serviceName)].apiVersion;
     eventDto.apiVersion = (api_Version is string) ? api_Version : "";
     eventDto.apiName = getApiName(context);
-    var resource_Path = getResourceConfigAnnotation(reflect:getResourceAnnotations(context.serviceRef,
-            context.resourceName)).path;
+    var resource_Path = getResourceConfigAnnotation(resourceAnnotationMap[context.resourceName] ?: []).path;
     eventDto.resourcePath = (resource_Path is string) ? resource_Path : "";
     eventDto.method = <string>context.attributes[API_METHOD_PROPERTY];
     eventDto.errorCode = <int>runtime:getInvocationContext().attributes[ERROR_RESPONSE_CODE];
@@ -92,8 +90,7 @@ function populateFaultAnalyticsDTO(http:FilterContext context, error err) return
     } else {
         metaInfo.keyType = PRODUCTION_KEY_TYPE;
         eventDto.consumerKey = ANONYMOUS_CONSUMER_KEY;
-        var api_Creater = getAPIDetailsFromServiceAnnotation(
-                                    reflect:getServiceAnnotations(context.serviceRef)).publisher;
+        var api_Creater = apiConfigAnnotationMap[getServiceName(context.serviceName)].publisher;
         eventDto.apiCreator = (api_Creater is string) ? api_Creater : "";
         eventDto.userName = END_USER_ANONYMOUS;
         eventDto.applicationName = ANONYMOUS_APP_NAME;


### PR DESCRIPTION
## Purpose
> This is done to improve the performance
> This will read the annotations at service level and resource level during server startup and store them in a global map. Then it will read from the map per request. Earlier the annotations were read per request using reflect API.

## Goals
> Improve performance of MGW

