### PR TITLE
Restructure micro gateway toolkit distribution

### DIFF
--- a/components/micro-gateway-cli/pom.xml
+++ b/components/micro-gateway-cli/pom.xml
@@ -60,10 +60,6 @@
         </dependency>
         <dependency>
             <groupId>org.ballerinalang</groupId>
-            <artifactId>ballerina-config</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.ballerinalang</groupId>
             <artifactId>ballerina-packerina</artifactId>
         </dependency>
         <dependency>

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cipher/AESCipherTool.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cipher/AESCipherTool.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.apimgt.gateway.cli.cipher;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * This tools is used to encrypt and decrypt data using AES Algorithm CBC mode and PKCS #5 padding.
+ *
+ */
+public class AESCipherTool {
+
+    private static final Logger log = LoggerFactory.getLogger(AESCipherTool.class);
+    private static final String ALGORITHM_AES_CBC_PKCS5 = "AES/CBC/PKCS5Padding";
+    private static final String ALGORITHM_AES = "AES";
+    private static final String ALGORITHM_SHA_256 = "SHA-256";
+    private static final int IV_SIZE = 16;
+    private static final int SECRET_KEY_LENGTH = 16; // TODO: Make this 32 again after switching to Java 9
+
+    private final SecretKey secretKey;
+    private final SecureRandom secureRandom;
+
+    /**
+     * Create an AESCipherTool instance by passing in a user secret string.
+     *
+     * @param userSecret User secret string to encode and decode a value.
+     * @throws AESCipherToolException if any error occurs while initializing the cipher tool.
+     */
+    public AESCipherTool(String userSecret) throws AESCipherToolException {
+        this.secretKey = new SecretKeySpec(getSHA256Key(userSecret, SECRET_KEY_LENGTH), ALGORITHM_AES);
+        this.secureRandom = new SecureRandom();
+    }
+
+    /**
+     * Create an AESCipherTool instance by passing in the path of a file containing the user secret.
+     *
+     * @param userSecretFile The path to the file containing the user secret.
+     * @throws IOException            Thrown if any I/O error occurs while reading the user secret file.
+     * @throws AESCipherToolException Thrown if any error occurs while initializing the cipher tool.
+     */
+    public AESCipherTool(Path userSecretFile) throws IOException, AESCipherToolException {
+        List<String> userSecret = Files.readAllLines(userSecretFile, StandardCharsets.UTF_8);
+        Files.deleteIfExists(userSecretFile);
+
+        if (userSecret.size() > 1) {
+            throw new AESCipherToolException("Multi-line user secrets not allowed");
+        }
+
+        this.secretKey = new SecretKeySpec(getSHA256Key(userSecret.get(0), SECRET_KEY_LENGTH), ALGORITHM_AES);
+        this.secureRandom = new SecureRandom();
+    }
+
+    /**
+     * This method is used to encrypt and base64 encode a plain value.
+     *
+     * @param value Value to be encrypted.
+     * @return Encrypted value.
+     * @throws AESCipherToolException Thrown if any error occurs while initializing the cipher tool.
+     */
+    public String encrypt(String value) throws AESCipherToolException {
+        try {
+            byte[] ivByteArray = getSecureRandomBytes();
+            IvParameterSpec ivParameterSpec = new IvParameterSpec(ivByteArray);
+            Cipher encryptionCipher = Cipher.getInstance(ALGORITHM_AES_CBC_PKCS5);
+            encryptionCipher.init(Cipher.ENCRYPT_MODE, secretKey, ivParameterSpec);
+            byte[] encryptedBytes = encryptionCipher.doFinal(getBytes(value));
+            return encodeBase64(appendByteArrays(ivByteArray, encryptedBytes));
+        } catch (BadPaddingException | IllegalBlockSizeException | NoSuchPaddingException
+                | NoSuchAlgorithmException | InvalidAlgorithmParameterException | InvalidKeyException  err) {
+            log.error("Failed to encrypt value: " + value, err);
+            throw new AESCipherToolException(err.getMessage(), err);
+        }
+    }
+
+    /**
+     * This method is used to decrypt a given encrypted and base64 encoded value.
+     *
+     * @param value Encrypted value to be decrypted.
+     * @return Decrypted value.
+     * @throws AESCipherToolException Thrown if any error occurs while initializing the cipher tool.
+     */
+    public String decrypt(String value) throws AESCipherToolException {
+        try {
+            byte[] decodedByteArray = decodeBase64(value);
+            IvParameterSpec ivParameterSpec =
+                    new IvParameterSpec(Arrays.copyOfRange(decodedByteArray, 0, IV_SIZE));
+            Cipher decryptionCipher = Cipher.getInstance(ALGORITHM_AES_CBC_PKCS5);
+            decryptionCipher.init(Cipher.DECRYPT_MODE, secretKey, ivParameterSpec);
+            byte[] encryptedByteArray = Arrays.copyOfRange(decodedByteArray, IV_SIZE, decodedByteArray.length);
+            return new String(decryptionCipher.doFinal(encryptedByteArray), StandardCharsets.UTF_8);
+        } catch (BadPaddingException | IllegalBlockSizeException | NoSuchPaddingException
+                | NoSuchAlgorithmException | InvalidAlgorithmParameterException | InvalidKeyException err) {
+            log.error("Failed to decrypt value: " + value, err);
+            throw new AESCipherToolException(err.getMessage(), err);
+        }
+    }
+
+    private byte[] appendByteArrays(byte[] ivArray, byte[] encryptedArray) {
+        int arrayLength = ivArray.length + encryptedArray.length;
+        byte[] bytes = new byte[arrayLength];
+        System.arraycopy(ivArray, 0, bytes, 0, ivArray.length);
+        System.arraycopy(encryptedArray, 0, bytes, ivArray.length, encryptedArray.length);
+        return bytes;
+    }
+
+    private byte[] getSecureRandomBytes() {
+        byte[] bytes = new byte[IV_SIZE];
+        secureRandom.nextBytes(bytes);
+        return bytes;
+    }
+
+    private byte[] getSHA256Key(String key, int keyLengthInBytes) throws AESCipherToolException {
+        try {
+            MessageDigest messageDigest = MessageDigest.getInstance(ALGORITHM_SHA_256);
+            messageDigest.update(getBytes(key));
+            byte[] keyBytes = new byte[keyLengthInBytes];
+            System.arraycopy(messageDigest.digest(), 0, keyBytes, 0, keyBytes.length);
+            return keyBytes;
+        } catch (NoSuchAlgorithmException e) {
+            log.error("Failed to generate SHA256 digest for: " + key, e);
+            throw new AESCipherToolException(e.getMessage(), e);
+        }
+    }
+
+    private String encodeBase64(byte[] bytes) {
+        return Base64.getEncoder().encodeToString(bytes);
+    }
+
+    private byte[] decodeBase64(String encodedValue) {
+        return Base64.getDecoder().decode(getBytes(encodedValue));
+    }
+
+    private byte[] getBytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cipher/AESCipherTool.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cipher/AESCipherTool.java
@@ -43,7 +43,6 @@ import javax.crypto.spec.SecretKeySpec;
 
 /**
  * This tools is used to encrypt and decrypt data using AES Algorithm CBC mode and PKCS #5 padding.
- *
  */
 public class AESCipherTool {
 

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cipher/AESCipherToolException.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cipher/AESCipherToolException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.apimgt.gateway.cli.cipher;
+
+import java.security.GeneralSecurityException;
+
+public class AESCipherToolException extends GeneralSecurityException {
+    public AESCipherToolException(String msg) {
+        super(msg);
+    }
+
+    public AESCipherToolException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
@@ -41,9 +41,9 @@ import org.wso2.apimgt.gateway.cli.model.config.BasicAuth;
 import org.wso2.apimgt.gateway.cli.model.config.Client;
 import org.wso2.apimgt.gateway.cli.model.config.Config;
 import org.wso2.apimgt.gateway.cli.model.config.ContainerConfig;
+import org.wso2.apimgt.gateway.cli.model.config.Etcd;
 import org.wso2.apimgt.gateway.cli.model.config.Token;
 import org.wso2.apimgt.gateway.cli.model.config.TokenBuilder;
-import org.wso2.apimgt.gateway.cli.model.config.Etcd;
 import org.wso2.apimgt.gateway.cli.model.rest.ClientCertMetadataDTO;
 import org.wso2.apimgt.gateway.cli.model.rest.ext.ExtendedAPI;
 import org.wso2.apimgt.gateway.cli.model.rest.policy.ApplicationThrottlePolicyDTO;
@@ -54,6 +54,7 @@ import org.wso2.apimgt.gateway.cli.rest.RESTAPIService;
 import org.wso2.apimgt.gateway.cli.rest.RESTAPIServiceImpl;
 import org.wso2.apimgt.gateway.cli.utils.GatewayCmdUtils;
 import org.wso2.apimgt.gateway.cli.utils.OpenApiCodegenUtils;
+import org.wso2.apimgt.gateway.cli.utils.ZipUtils;
 import org.wso2.apimgt.gateway.cli.utils.grpc.GRPCUtils;
 
 import java.io.File;
@@ -168,7 +169,8 @@ public class SetupCmd implements GatewayLauncherCmd {
             throw GatewayCmdUtils.createUsageException("Project name `" + projectName
                     + "` already exist. use -f or --force to forcefully update the project directory.");
         }
-
+        // Extracts the zipped ballerina platform and runtime
+        extractPlatformAndRuntime();
         init(projectName, toolkitConfigPath, deploymentConfigPath);
 
         //set etcd requirement
@@ -332,6 +334,7 @@ public class SetupCmd implements GatewayLauncherCmd {
 
             //set the trustStore
             System.setProperty("javax.net.ssl.keyStoreType", "pkcs12");
+            System.setProperty("javax.net.ssl.trustStoreType", "pkcs12");
             System.setProperty("javax.net.ssl.trustStore", trustStoreLocation);
             System.setProperty("javax.net.ssl.trustStorePassword", trustStorePassword);
 
@@ -687,5 +690,40 @@ public class SetupCmd implements GatewayLauncherCmd {
         outStream.println(
                 "You are using REST version - " + restVersion + " of API Manager. (If you want to change this, go to "
                         + "<MICROGW_HOME>/conf/toolkit-config.toml)");
+    }
+
+    private void extractPlatformAndRuntime() {
+        try {
+            String libPath = GatewayCmdUtils.getCLILibPath();
+            String baloPath = GatewayCliConstants.CLI_GATEWAY + File.separator + GatewayCliConstants.CLI_BALO;
+            String breLibPath = GatewayCliConstants.CLI_BRE + File.separator + GatewayCliConstants.CLI_LIB;
+            String runtimeExtractedPath = libPath + File.separator + GatewayCliConstants.CLI_RUNTIME;
+            if (!Files.exists(Paths.get(runtimeExtractedPath))) {
+                ZipUtils.unzip(runtimeExtractedPath + GatewayCliConstants.EXTENSION_ZIP, runtimeExtractedPath, false);
+                //copy balo to the runtime
+                GatewayCmdUtils.copyFolder(libPath + File.separator + baloPath,
+                        runtimeExtractedPath + File.separator + GatewayCliConstants.CLI_LIB + File.separator
+                                + GatewayCliConstants.CLI_REPO);
+                //copy gateway jars to runtime
+                GatewayCmdUtils.copyFolder(libPath + File.separator + GatewayCliConstants.CLI_GATEWAY + File.separator
+                        + GatewayCliConstants.CLI_RUNTIME, runtimeExtractedPath + File.separator + breLibPath);
+            }
+            String platformExtractedPath =
+                    GatewayCmdUtils.getCLILibPath() + File.separator + GatewayCliConstants.CLI_PLATFORM;
+            if (!Files.exists(Paths.get(platformExtractedPath))) {
+                ZipUtils.unzip(platformExtractedPath + GatewayCliConstants.EXTENSION_ZIP, platformExtractedPath, true);
+                //copy balo to the platform
+                GatewayCmdUtils.copyFolder(libPath + File.separator + baloPath,
+                        platformExtractedPath + File.separator + GatewayCliConstants.CLI_LIB + File.separator
+                                + GatewayCliConstants.CLI_REPO);
+                //copy gateway jars to platform
+                GatewayCmdUtils.copyFolder(libPath + File.separator + GatewayCliConstants.CLI_GATEWAY + File.separator
+                        + GatewayCliConstants.CLI_PLATFORM, platformExtractedPath + File.separator + breLibPath);
+            }
+        } catch (IOException e) {
+            String message = "Error while unzipping platform and runtime while project setup";
+            logger.error(message, e);
+            throw new CLIInternalException(message);
+        }
     }
 }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
@@ -39,11 +39,17 @@ public class GatewayCliConstants {
     public static final String DEFAULT_DEPLOYMENT_CONFIG_FILE_NAME = "default-deployment-config.toml";
     public static final String CLI_HOME = "cli.home";
     public static final String CLI_LIB = "lib";
+    public static final String CLI_REPO = "repo";
     public static final String CLI_CONF = "conf";
     public static final String CLI_RUNTIME = "runtime";
+    public static final String CLI_PLATFORM = "platform";
+    public static final String CLI_GATEWAY = "gateway";
+    public static final String CLI_BALO = "balo";
+    public static final String CLI_BRE = "bre";
     public static final String POLICY_DIR = "policies";
     public static final String EXTENSION_BALX = ".balx";
     public static final String EXTENSION_ZIP = ".zip";
+    public static final String EXTENSION_JAR = ".jar";
     public static final String GW_TARGET_DIST = "distribution";
     public static final String GW_DIST_PREFIX = "micro-gw-";
     public static final String GW_DIST_BIN = "bin";

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
@@ -36,6 +36,7 @@ public class GatewayCliConstants {
     public static final String DEPLOYMENT_CONFIG_FILE_NAME = "deployment-config.toml";
     public static final String TEMP_DIR_NAME = "temp";
     public static final String RESOURCE_HASH_HOLDER_FILE_NAME = "hashes.json";
+    public static final String LIB_HASH_HOLDER_FILE_NAME = "hashes";
     public static final String DEFAULT_DEPLOYMENT_CONFIG_FILE_NAME = "default-deployment-config.toml";
     public static final String CLI_HOME = "cli.home";
     public static final String CLI_LIB = "lib";

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/hashing/HashUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/hashing/HashUtils.java
@@ -28,7 +28,6 @@ import org.wso2.apimgt.gateway.cli.model.rest.ext.ExtendedAPI;
 import org.wso2.apimgt.gateway.cli.model.rest.policy.ApplicationThrottlePolicyDTO;
 import org.wso2.apimgt.gateway.cli.model.rest.policy.SubscriptionThrottlePolicyDTO;
 import org.wso2.apimgt.gateway.cli.model.rest.policy.ThrottlePolicyDTO;
-import org.wso2.apimgt.gateway.cli.model.template.policy.ThrottlePolicy;
 import org.wso2.apimgt.gateway.cli.utils.GatewayCmdUtils;
 
 import java.io.IOException;
@@ -243,4 +242,7 @@ public class HashUtils {
 
         return sb.toString();
     }
+
+
+
 }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/hashing/LibHashUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/hashing/LibHashUtils.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.apimgt.gateway.cli.hashing;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.apimgt.gateway.cli.constants.GatewayCliConstants;
+import org.wso2.apimgt.gateway.cli.exception.HashingException;
+import org.wso2.apimgt.gateway.cli.utils.GatewayCmdUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.xml.bind.DatatypeConverter;
+
+/**
+ * Utility class used for hashing the changes in the lib directory of micro gateway.
+ *
+ */
+public class LibHashUtils {
+    private static final Logger logger = LoggerFactory.getLogger(LibHashUtils.class);
+    private static final String MD5 = "MD5";
+
+    /**
+     * Generate hashes for the library zip files inside CLI lib folder. If the hashes of the zip file is different.
+     *
+     * @return true if there are changes detected vs the previous check.
+     * @throws HashingException error while change detection.
+     */
+    public static boolean detectChangesInLibraries() throws HashingException {
+        boolean iseDetected = false;
+        try {
+            String hashFilePath = GatewayCmdUtils.getCLILibHashHolderFileLocation();
+            Map<String, String> storedHashes;
+            if (Files.exists(Paths.get(hashFilePath))) {
+                storedHashes = GatewayCmdUtils.readFileToMap(hashFilePath);
+            } else {
+                // if file does not exist add default values to the map.
+                storedHashes = new HashMap<>();
+                storedHashes.put(GatewayCliConstants.CLI_PLATFORM, "");
+                storedHashes.put(GatewayCliConstants.CLI_RUNTIME, "");
+            }
+            String libPath = GatewayCmdUtils.getCLILibPath();
+            for (Map.Entry<String, String> entry : storedHashes.entrySet()) {
+                String filePath = libPath + File.separator + entry.getKey() + GatewayCliConstants.EXTENSION_ZIP;
+                try {
+                    if (Files.exists(Paths.get(filePath))) {
+                        String checkSum = getFileCheckSum(filePath);
+                        if (!checkSum.equals(entry.getValue())) {
+                            logger.debug("Checksum difference detected for key : " + entry.getKey());
+                            storedHashes.put(entry.getKey(), checkSum);
+                            iseDetected = true;
+                        }
+                    }
+                } catch (NoSuchAlgorithmException | IOException e) {
+                    logger.error("Error while calculating check sum for path : " + filePath, e);
+                }
+            }
+            if (iseDetected) {
+                GatewayCmdUtils.writeMapToFile(storedHashes, hashFilePath);
+                return true;
+            } else {
+                logger.debug("No checksum difference detected in the lib directories");
+                return false;
+            }
+
+        } catch (IOException | ClassNotFoundException e) {
+            throw new HashingException("Error while gateway library change detection", e);
+        }
+    }
+
+    private static String getFileCheckSum(String filePath) throws NoSuchAlgorithmException, IOException {
+        MessageDigest md = MessageDigest.getInstance(MD5);
+        md.update(Files.readAllBytes(Paths.get(filePath)));
+        byte[] digest = md.digest();
+        return DatatypeConverter.printHexBinary(digest).toUpperCase();
+    }
+}

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/logging/LogLevelMapper.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/logging/LogLevelMapper.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.apimgt.gateway.cli.logging;
+
+import java.util.logging.Level;
+
+/**
+ * A mapper class to map log levels from JDK logging to CLI log levels.
+ * Similar to https://www.slf4j.org/apidocs/org/slf4j/bridge/SLF4JBridgeHandler.html
+ */
+public class LogLevelMapper {
+    public static String getCLILogLevel(Level level) {
+        switch (level.getName()) {
+        case "SEVERE":
+            return "ERROR";
+        case "WARNING":
+            return "WARN";
+        case "INFO":
+            return "INFO";
+        case "FINE":
+            return "DEBUG";
+        case "FINER":
+            return "DEBUG";
+        case "FINEST":
+            return "TRACE";
+        default:
+            return "<UNDEFINED>";
+        }
+    }
+}

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/logging/formatters/DefaultLogFormatter.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/logging/formatters/DefaultLogFormatter.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.apimgt.gateway.cli.logging.formatters;
+
+import org.wso2.apimgt.gateway.cli.logging.LogLevelMapper;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Date;
+import java.util.logging.Formatter;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+
+/**
+ * A custom log formatter for formatting log file of the CLI.
+ */
+public class DefaultLogFormatter extends Formatter {
+
+    private static final String format = LogManager.getLogManager().getProperty(
+            DefaultLogFormatter.class.getCanonicalName() + ".format");
+
+    @Override
+    public String format(LogRecord record) {
+        String source = record.getLoggerName();
+        String ex = "";
+
+        if (record.getThrown() != null) {
+            StringWriter stringWriter = new StringWriter();
+            stringWriter.append('\n');
+            record.getThrown().printStackTrace(new PrintWriter(stringWriter));
+            ex = stringWriter.toString();
+        }
+
+        return String.format(format,
+                new Date(record.getMillis()),
+                LogLevelMapper.getCLILogLevel(record.getLevel()),
+                source,
+                record.getMessage(),
+                ex);
+    }
+}

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -38,15 +38,19 @@ import org.wso2.apimgt.gateway.cli.model.rest.APICorsConfigurationDTO;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.Map;
 
 public class GatewayCmdUtils {
 
@@ -440,6 +444,17 @@ public class GatewayCmdUtils {
     private static String getResourceHashHolderFileLocation(String projectName) {
         return getProjectTempFolderLocation(projectName) + File.separator
                 + GatewayCliConstants.RESOURCE_HASH_HOLDER_FILE_NAME;
+    }
+
+
+    /**
+     * Get library zip files hash holder file path with in the CLI tool
+     *
+     * @return library zip hash holder file path of the CLI tool
+     */
+    public static String getCLILibHashHolderFileLocation() {
+        return getCLIHome() + File.separator + GatewayCliConstants.TEMP_DIR_NAME + File.separator + GatewayCliConstants
+                .LIB_HASH_HOLDER_FILE_NAME;
     }
 
     /**
@@ -894,6 +909,32 @@ public class GatewayCmdUtils {
         }
         if (!file.delete()) {
             throw new IOException();
+        }
+    }
+
+    /**
+     * Writes the map after serializing  to given path
+     *
+     * @param map      resource hash content
+*    * @param filePath file path the map should be written to
+     * @throws IOException error while saving resource hash content
+     */
+    public static void writeMapToFile(Map<String,String> map, String filePath) throws IOException {
+        try(FileOutputStream fos = new FileOutputStream(filePath); ObjectOutputStream obs = new
+                ObjectOutputStream(fos)){
+            obs.writeObject(map);
+        }
+    }
+
+    /**
+     * Read the deserialize file content to map
+     *
+     * @param filePath file path the map should be written to
+     * @throws IOException error while saving resource hash content
+     */
+    public static Map<String ,String> readFileToMap(String filePath) throws IOException, ClassNotFoundException {
+        try(FileInputStream fis = new FileInputStream(filePath);ObjectInputStream obi = new ObjectInputStream(fis)){
+            return (Map<String , String>) obi.readObject();
         }
     }
 }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -19,10 +19,10 @@ package org.wso2.apimgt.gateway.cli.utils;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
-import org.ballerinalang.config.cipher.AESCipherTool;
-import org.ballerinalang.config.cipher.AESCipherToolException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.apimgt.gateway.cli.cipher.AESCipherTool;
+import org.wso2.apimgt.gateway.cli.cipher.AESCipherToolException;
 import org.wso2.apimgt.gateway.cli.codegen.CodeGenerationContext;
 import org.wso2.apimgt.gateway.cli.config.TOMLConfigParser;
 import org.wso2.apimgt.gateway.cli.constants.GatewayCliConstants;
@@ -32,17 +32,16 @@ import org.wso2.apimgt.gateway.cli.exception.CliLauncherException;
 import org.wso2.apimgt.gateway.cli.exception.ConfigParserException;
 import org.wso2.apimgt.gateway.cli.model.config.Config;
 import org.wso2.apimgt.gateway.cli.model.config.ContainerConfig;
-import org.wso2.apimgt.gateway.cli.model.rest.APICorsConfigurationDTO;
 import org.wso2.apimgt.gateway.cli.model.config.Etcd;
+import org.wso2.apimgt.gateway.cli.model.rest.APICorsConfigurationDTO;
 
-
-import java.io.File;
-import java.io.FileWriter;
 import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -56,6 +55,7 @@ public class GatewayCmdUtils {
     private static ContainerConfig containerConfig;
     private static CodeGenerationContext codeGenerationContext;
     private static Etcd etcd;
+    private static final String algorithm = "AES";
 
     public static Etcd getEtcd() {
         return etcd;
@@ -211,6 +211,15 @@ public class GatewayCmdUtils {
      */
     public static String getCLIHome() {
         return System.getProperty(GatewayCliConstants.CLI_HOME);
+    }
+
+    /**
+     * Get cli library location
+     *
+     * @return cli lib location
+     */
+    public static String getCLILibPath() {
+        return getCLIHome() + File.separator + GatewayCliConstants.CLI_LIB;
     }
 
     /**

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/ZipUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/ZipUtils.java
@@ -17,16 +17,32 @@
  */
 package org.wso2.apimgt.gateway.cli.utils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.apimgt.gateway.cli.constants.GatewayCliConstants;
 import org.wso2.apimgt.gateway.cli.exception.CLIZipException;
 
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
 public class ZipUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(ZipUtils.class);
+    private static final String ADD_URL = "addURL";
 
     /**
      * A method to zip a folder with given path.
@@ -56,6 +72,80 @@ public class ZipUtils {
                     });
         } catch (CLIZipException e) {
             throw new IOException("Error while creating a zip from " + sourceDirPath, e);
+        }
+    }
+
+    /**
+     * A method to unzip a zip file to given folder path.
+     *
+     * Note: this unzip method does not preserve permissions of files. eg: "execute" permissions.
+     *
+     * @param zipFilePath src path of the zip
+     * @param unzipLocation the path zip should be extracted to
+     * @param isAddToClasspath if the file is jar, whether add it to the CLI class path
+     * @throws IOException error while unzipping the file
+     */
+    public static void unzip(final String zipFilePath, final String unzipLocation, boolean isAddToClasspath) throws
+            IOException {
+
+        if (!(Files.exists(Paths.get(unzipLocation)))) {
+            Files.createDirectories(Paths.get(unzipLocation));
+        }
+        try (ZipInputStream zipInputStream = new ZipInputStream(new FileInputStream(zipFilePath))) {
+            ZipEntry entry = zipInputStream.getNextEntry();
+            while (entry != null) {
+                Path filePath = Paths.get(unzipLocation, entry.getName());
+                if (!entry.isDirectory()) {
+                    unzipFiles(zipInputStream, filePath);
+                    //Explicitly set exection permission to files inside bin folders.
+                    if(filePath.toString().contains(File.separator + GatewayCliConstants.GW_DIST_BIN + File.separator)){
+                        filePath.toFile().setExecutable(true, false);
+                    }
+                    //If file is a jar add it to the class loader dynamically.
+                    if(isAddToClasspath && entry.getName().endsWith(GatewayCliConstants.EXTENSION_JAR)) {
+                        addJarToClasspath(new File(filePath.toString()));
+                    }
+                } else {
+                    Files.createDirectories(filePath);
+                }
+
+                zipInputStream.closeEntry();
+                entry = zipInputStream.getNextEntry();
+            }
+        }
+    }
+
+    private static void unzipFiles(final ZipInputStream zipInputStream, final Path unzipFilePath) throws IOException {
+
+        try (BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(unzipFilePath.toAbsolutePath().toString()))) {
+            byte[] bytesIn = new byte[1024];
+            int read = 0;
+            while ((read = zipInputStream.read(bytesIn)) != -1) {
+                bos.write(bytesIn, 0, read);
+            }
+        }
+    }
+
+    /**
+     * A method to add a given jar to the system class loader.
+     *
+     * @param jar Jar file to be added to the class loader
+     */
+    private static void addJarToClasspath(File jar) {
+        // Get the ClassLoader class
+        try {
+            ClassLoader cl = ClassLoader.getSystemClassLoader();
+            Class<?> clazz = cl.getClass();
+
+            // Get the protected addURL method from the parent URLClassLoader class
+            Method method = clazz.getSuperclass().getDeclaredMethod(ADD_URL, URL.class);
+
+            // Run projected addURL method to add JAR to classpath
+            method.setAccessible(true);
+            method.invoke(cl, jar.toURI().toURL() );
+        } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException |
+                InvocationTargetException | MalformedURLException e) {
+            logger.error("Error while adding jar : " + jar.getName() + " to the class path", e);
         }
     }
 }

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -110,6 +110,40 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>micro-gateway-platform</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>attached</goal>
+                        </goals>
+                        <configuration>
+                            <filters>
+                                <filter>${basedir}/src/main/assembly/filter.properties</filter>
+                            </filters>
+                            <descriptors>
+                                <descriptor>src/main/assembly/platform_zip.xml</descriptor>
+                            </descriptors>
+                            <finalName>platform</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>micro-gateway-runtime</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>attached</goal>
+                        </goals>
+                        <configuration>
+                            <filters>
+                                <filter>${basedir}/src/main/assembly/filter.properties</filter>
+                            </filters>
+                            <descriptors>
+                                <descriptor>src/main/assembly/runtime_zip.xml</descriptor>
+                            </descriptors>
+                            <finalName>runtime</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>micro-gateway</id>
                         <phase>package</phase>
                         <goals>

--- a/distribution/resources/bin/micro-gw
+++ b/distribution/resources/bin/micro-gw
@@ -61,6 +61,10 @@ fi
 # set BALLERINA_HOME
 BALLERINA_HOME="$MICROGW_HOME/lib/platform"
 
+if [ ! -d "$BALLERINA_HOME" ]; then
+  BALLERINA_HOME="$MICROGW_HOME/lib"
+fi
+
 export BALLERINA_HOME=$BALLERINA_HOME
 export PATH=$BALLERINA_HOME/bin:$PATH
 
@@ -145,6 +149,11 @@ case $key in
     IS_BUILD_COMMAND=true
     shift # past build argument
     ;;
+    setup)
+    ALL_ARGS+=("$1")
+    IS_SETUP_COMMAND=true
+    shift # past build argument
+    ;;
     *)    # default argument
     DEFAULT_ARGS+=("$1") # save it in DEFAULT_ARGS array
     ALL_ARGS+=("$1")
@@ -205,6 +214,18 @@ for j in "$MICROGW_HOME"/target/*.jar
 do
     CLI_CLASSPATH="$CLI_CLASSPATH":$j
 done
+
+if [ "$IS_SETUP_COMMAND" = true ]; then
+for j in "$MICROGW_HOME"/lib/gateway/platform/*.jar
+do
+    CLI_CLASSPATH="$CLI_CLASSPATH":$j
+done
+
+for j in "$MICROGW_HOME"/lib/gateway/cli/*.jar
+do
+    CLI_CLASSPATH="$CLI_CLASSPATH":$j
+done
+fi
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then

--- a/distribution/resources/bin/micro-gw
+++ b/distribution/resources/bin/micro-gw
@@ -215,7 +215,7 @@ do
     CLI_CLASSPATH="$CLI_CLASSPATH":$j
 done
 
-if [ "$IS_SETUP_COMMAND" = true ]; then
+if [ "$IS_SETUP_COMMAND" = true ] && [ ! -d "$MICROGW_HOME/lib/platform/" ]; then
 for j in "$MICROGW_HOME"/lib/gateway/platform/*.jar
 do
     CLI_CLASSPATH="$CLI_CLASSPATH":$j

--- a/distribution/resources/bin/micro-gw.bat
+++ b/distribution/resources/bin/micro-gw.bat
@@ -48,6 +48,7 @@ if "%MICROGW_HOME%" == "" set MICROGW_HOME=%PRGDIR%..
 
 REM  set BALLERINA_HOME
 set BALLERINA_HOME=%MICROGW_HOME%\lib\platform
+if not exist "%MICROGW_HOME%\lib\platform" BALLERINA_HOME="$MICROGW_HOME/lib"
 set PATH=%PATH%;%BALLERINA_HOME%\bin\
 if %verbose%==T echo BALLERINA_HOME environment variable is set to %BALLERINA_HOME%
 

--- a/distribution/resources/cli-conf/logging.properties
+++ b/distribution/resources/cli-conf/logging.properties
@@ -18,23 +18,23 @@
 
 ####################### HANDLERS #######################
 # Configurations for console logging
-java.util.logging.ConsoleHandler.formatter=org.ballerinalang.logging.formatters.DefaultLogFormatter
+java.util.logging.ConsoleHandler.formatter=org.wso2.apimgt.gateway.cli.logging.formatters.DefaultLogFormatter
 
 # Log file for logging microgateway related logs
-org.ballerinalang.logging.handlers.DefaultLogFileHandler.pattern=${cli.home}/logs/microgw.log
-org.ballerinalang.logging.handlers.DefaultLogFileHandler.limit=100000000
-org.ballerinalang.logging.handlers.DefaultLogFileHandler.append=true
-org.ballerinalang.logging.handlers.DefaultLogFileHandler.formatter=org.ballerinalang.logging.formatters.DefaultLogFormatter
-org.ballerinalang.logging.formatters.DefaultLogFormatter.format=[%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS,%1$tL] %2$-5s {%3$s} - %4$s %5$s %n
+java.util.logging.FileHandler.pattern=${cli.home}/logs/microgw.log
+java.util.logging.FileHandler.limit=100000000
+java.util.logging.FileHandler.append=true
+java.util.logging.FileHandler.formatter=org.wso2.apimgt.gateway.cli.logging.formatters.DefaultLogFormatter
+org.wso2.apimgt.gateway.cli.logging.formatters.DefaultLogFormatter.format=[%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS,%1$tL] %2$-5s {%3$s} - %4$s %5$s %n
 
 
 ####################### LOGGERS #######################
 # Root logger
-handlers=org.ballerinalang.logging.handlers.DefaultLogFileHandler
+handlers=java.util.logging.FileHandler
 .level=WARNING
 
 # Uncomment below to Log warnings/errors in both console and logfile
-#handlers=org.ballerinalang.logging.handlers.DefaultLogFileHandler, java.util.logging.ConsoleHandler
+#handlers=java.util.logging.FileHandler, java.util.logging.ConsoleHandler
 #.level=WARNING
 
 #org.wso2.apimgt.gateway.level=FINEST

--- a/distribution/src/main/assembly/bin.xml
+++ b/distribution/src/main/assembly/bin.xml
@@ -38,6 +38,10 @@
             <outputDirectory>wso2am-micro-gw-${pom.version}/resources/conf</outputDirectory>
         </fileSet>
         <fileSet>
+            <directory>${basedir}/resources/temp</directory>
+            <outputDirectory>wso2am-micro-gw-${pom.version}/temp</outputDirectory>
+        </fileSet>
+        <fileSet>
             <directory>${basedir}/resources/cli-conf</directory>
             <outputDirectory>wso2am-micro-gw-${pom.version}/conf</outputDirectory>
         </fileSet>

--- a/distribution/src/main/assembly/bin.xml
+++ b/distribution/src/main/assembly/bin.xml
@@ -37,9 +37,13 @@
             <directory>${basedir}/resources/conf</directory>
             <outputDirectory>wso2am-micro-gw-${pom.version}/resources/conf</outputDirectory>
         </fileSet>
+        <!--create an empty temp folder-->
         <fileSet>
             <directory>${basedir}/resources/temp</directory>
             <outputDirectory>wso2am-micro-gw-${pom.version}/temp</outputDirectory>
+            <excludes>
+                <exclude>*/**</exclude>
+            </excludes>
         </fileSet>
         <fileSet>
             <directory>${basedir}/resources/cli-conf</directory>

--- a/distribution/src/main/assembly/bin.xml
+++ b/distribution/src/main/assembly/bin.xml
@@ -26,14 +26,6 @@
 
     <fileSets>
         <fileSet>
-            <directory>${basedir}/target/ballerina/ballerina-${ballerina.platform.version}</directory>
-            <outputDirectory>wso2am-micro-gw-${pom.version}/lib/platform</outputDirectory>
-        </fileSet>
-        <fileSet>
-            <directory>${basedir}/target/ballerina/ballerina-runtime-${ballerina.platform.version}</directory>
-            <outputDirectory>wso2am-micro-gw-${pom.version}/lib/runtime</outputDirectory>
-        </fileSet>
-        <fileSet>
             <directory>${basedir}/../components/micro-gateway-cli/src/main/resources/templates</directory>
             <outputDirectory>wso2am-micro-gw-${pom.version}/resources/templates</outputDirectory>
         </fileSet>
@@ -55,15 +47,15 @@
         </fileSet>
         <fileSet>
             <directory>
-                ${project.build.directory}/lib
+                ${project.build.directory}/lib/repo/
             </directory>
-            <outputDirectory>wso2am-micro-gw-${pom.version}/lib/runtime/lib</outputDirectory>
+            <outputDirectory>wso2am-micro-gw-${pom.version}/lib/gateway/balo</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>
-                ${project.build.directory}/lib
+                ${project.build.directory}/lib/repo/
             </directory>
-            <outputDirectory>wso2am-micro-gw-${pom.version}/lib/platform/lib</outputDirectory>
+            <outputDirectory>wso2am-micro-gw-${pom.version}/lib/gateway/balo</outputDirectory>
         </fileSet>
 
         <!--create an empty logs folder-->
@@ -78,12 +70,13 @@
 
     <files>
         <file>
-            <source>${basedir}/resources/ballerinaTruststore.p12</source>
-            <outputDirectory>wso2am-micro-gw-${pom.version}/lib/platform/bre/security</outputDirectory>
+            <source>${basedir}/target/platform.zip</source>
+            <outputDirectory>wso2am-micro-gw-${pom.version}/lib</outputDirectory>
         </file>
         <file>
-            <source>${basedir}/resources/ballerinaTruststore.p12</source>
-            <outputDirectory>wso2am-micro-gw-${pom.version}/lib/runtime/bre/security</outputDirectory>
+            <source>${basedir}/target/runtime.zip</source>
+            <outputDirectory>wso2am-micro-gw-${pom.version}/lib</outputDirectory>
+            <destName>runtime.zip</destName>
         </file>
         <file>
             <source>${basedir}/resources/bin/micro-gw</source>
@@ -113,26 +106,35 @@
 
     <dependencySets>
         <dependencySet>
-            <outputDirectory>wso2am-micro-gw-${pom.version}/lib/platform/bre/lib</outputDirectory>
+            <outputDirectory>wso2am-micro-gw-${pom.version}/lib/gateway/platform/</outputDirectory>
             <scope>runtime</scope>
             <includes>
                 <include>org.wso2.am.microgw:org.wso2.micro.gateway.core:jar</include>
             </includes>
         </dependencySet>
         <dependencySet>
-            <outputDirectory>wso2am-micro-gw-${pom.version}/lib/runtime/bre/lib</outputDirectory>
+            <outputDirectory>wso2am-micro-gw-${pom.version}/lib/gateway/runtime</outputDirectory>
             <scope>runtime</scope>
             <includes>
                 <include>org.wso2.am.microgw:org.wso2.micro.gateway.core:jar</include>
             </includes>
         </dependencySet>
         <dependencySet>
-            <outputDirectory>wso2am-micro-gw-${pom.version}/lib/platform/bre/lib</outputDirectory>
+            <outputDirectory>wso2am-micro-gw-${pom.version}/lib/gateway/platform</outputDirectory>
             <scope>runtime</scope>
             <includes>
                 <include>org.wso2.am.microgw:org.wso2.micro.gateway.cli:jar</include>
                 <include>com.moandjiezana.toml:toml4j:jar</include>
                 <include>com.beust:jcommander:jar</include>
+            </includes>
+        </dependencySet>
+        <dependencySet>
+            <outputDirectory>wso2am-micro-gw-${pom.version}/lib/gateway/cli</outputDirectory>
+            <scope>runtime</scope>
+            <includes>
+                <include>org.slf4j:slf4j-api</include>
+                <include>org.slf4j:slf4j-jdk14</include>
+                <include>org.apache.commons:commons-lang3</include>
             </includes>
         </dependencySet>
 

--- a/distribution/src/main/assembly/platform_zip.xml
+++ b/distribution/src/main/assembly/platform_zip.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<assembly>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <id>Micro Gateway Platform Zip</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+
+    <fileSets>
+        <fileSet>
+        <directory>${basedir}/target/ballerina/ballerina-${ballerina.platform.version}</directory>
+        <outputDirectory>/</outputDirectory>
+        </fileSet>
+    </fileSets>
+
+</assembly>

--- a/distribution/src/main/assembly/platform_zip.xml
+++ b/distribution/src/main/assembly/platform_zip.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
   ~
   ~ WSO2 Inc. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except

--- a/distribution/src/main/assembly/runtime_zip.xml
+++ b/distribution/src/main/assembly/runtime_zip.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<assembly>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <id>Micro Gateway Runtime Zip</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}/target/ballerina/ballerina-runtime-${ballerina.platform.version}</directory>
+            <outputDirectory>/</outputDirectory>
+        </fileSet>
+    </fileSets>
+
+</assembly>

--- a/distribution/src/main/assembly/runtime_zip.xml
+++ b/distribution/src/main/assembly/runtime_zip.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
   ~
   ~ WSO2 Inc. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,6 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-jdk14</artifactId>
                 <version>${slf4j.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/common/BaseTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/common/BaseTestCase.java
@@ -96,7 +96,7 @@ public class BaseTestCase {
 
     public void finalize() throws Exception {
         mockHttpServer.stopIt();
-        microGWServer.stopServer(false);
+        microGWServer.stopServer(true);
         MockAPIPublisher.getInstance().clear();
     }
 


### PR DESCRIPTION
## Purpose
> This will restructure the toolkit lib folder. The existing structure is as follows

wso2am-micro-gw
├── lib
│   ├── platform (b7a platform + Additionally contains toolkit jars and gateway related jars and balos)
│   |__ runtime (b7a runtime + Additionally contains gateway related jars and balos)

The restructured lib folder would be as follows
lib/
├── gateway 
│   ├── balo(Balo files needed to be copied to run time and platform)
│   │   └── wso2
│   │       └── gateway
│   │           └── 0.0.0
│   │               └── gateway.zip
│   ├── cli (Minimum set of jars required initially to run CLI tool)
│   │   ├── commons-lang3-3.5.jar
│   │   ├── slf4j-api-1.7.25.jar
│   │   └── slf4j-jdk14-1.7.25.jar
│   ├── platform (The JAR files which need to be copied into b7a unzipped platform)
│   │   ├── jcommander-1.60.jar
│   │   ├── org.wso2.micro.gateway.cli-2.6.1-SNAPSHOT.jar
│   │   ├── org.wso2.micro.gateway.core-2.6.1-SNAPSHOT.jar
│   │   └── toml4j-0.7.2.jar
│   └── runtime (The JAR files which need to be copied into b7a unzipped run time)
│       └── org.wso2.micro.gateway.core-2.6.1-SNAPSHOT.jar
├── platform.zip (Pure b7a platform)
└── runtime.zip (Pure b7a run time)

> This will also remove the dependency with ballerina used by CLI when encrypting and decrypting values

> This will also remove the b7a log dependency for the CLI. CLI will now use the java.util.File Handler as the default log handler
## Goals
> To make the patch process more smooth.

