### PR TITLE
Add product version to filter properties

### DIFF
--- a/distribution/resources/updates/product.txt
+++ b/distribution/resources/updates/product.txt
@@ -1,1 +1,1 @@
-wso2am-micro-gw-2.6.0
+${product.name}-${product.version}

--- a/distribution/src/main/assembly/bin.xml
+++ b/distribution/src/main/assembly/bin.xml
@@ -108,6 +108,8 @@
         <file>
             <source>${basedir}/resources/updates/product.txt</source>
             <outputDirectory>wso2am-micro-gw-${pom.version}/updates</outputDirectory>
+            <filtered>true</filtered>
+            <fileMode>644</fileMode>
         </file>
     </files>
 

--- a/distribution/src/main/assembly/filter.properties
+++ b/distribution/src/main/assembly/filter.properties
@@ -1,3 +1,3 @@
-product.name=WSO2 Micro Gateway
+product.name=wso2am-micro-gw
 product.key=MICRO-GW
-product.version=1.0.0
+product.version=2.7.0


### PR DESCRIPTION
## Purpose
Fixes: #243
Implement a feasible solution for identifying product version while distribution update. `filter.properties` file should be updated for every release.