### PR TITLE
remove hash check before extracting runtime and platform

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/SetupCmd.java
@@ -704,37 +704,28 @@ public class SetupCmd implements GatewayLauncherCmd {
             String runtimeExtractedPath = libPath + File.separator + GatewayCliConstants.CLI_RUNTIME;
             String platformExtractedPath =
                     GatewayCmdUtils.getCLILibPath() + File.separator + GatewayCliConstants.CLI_PLATFORM;
-            try {
-                boolean isChangesDetected = LibHashUtils.detectChangesInLibraries();
-                // Delete already extracted files if changes detected.
-                if (isChangesDetected) {
-                    Files.deleteIfExists(Paths.get(runtimeExtractedPath));
-                    Files.deleteIfExists(Paths.get(platformExtractedPath));
-                }
-            } catch (HashingException e) {
-                logger.error("Error while detecting changes in gateway libraries", e);
-            }
             if (!Files.exists(Paths.get(runtimeExtractedPath))) {
                 ZipUtils.unzip(runtimeExtractedPath + GatewayCliConstants.EXTENSION_ZIP, runtimeExtractedPath, false);
+                //copy balo to the runtime
+                GatewayCmdUtils.copyFolder(libPath + File.separator + baloPath,
+                        runtimeExtractedPath + File.separator + GatewayCliConstants.CLI_LIB + File.separator
+                                + GatewayCliConstants.CLI_REPO);
+                //copy gateway jars to runtime
+                GatewayCmdUtils.copyFolder(libPath + File.separator + GatewayCliConstants.CLI_GATEWAY + File.separator
+                        + GatewayCliConstants.CLI_RUNTIME, runtimeExtractedPath + File.separator + breLibPath);
             }
-            //Always copies the file to get the updated gateway balos and jars
-            //copy balo to the runtime
-            GatewayCmdUtils.copyFolder(libPath + File.separator + baloPath,
-                    runtimeExtractedPath + File.separator + GatewayCliConstants.CLI_LIB + File.separator
-                            + GatewayCliConstants.CLI_REPO);
-            //copy gateway jars to runtime
-            GatewayCmdUtils.copyFolder(libPath + File.separator + GatewayCliConstants.CLI_GATEWAY + File.separator
-                    + GatewayCliConstants.CLI_RUNTIME, runtimeExtractedPath + File.separator + breLibPath);
+
             if (!Files.exists(Paths.get(platformExtractedPath))) {
                 ZipUtils.unzip(platformExtractedPath + GatewayCliConstants.EXTENSION_ZIP, platformExtractedPath, true);
+                //copy balo to the platform
+                GatewayCmdUtils.copyFolder(libPath + File.separator + baloPath,
+                        platformExtractedPath + File.separator + GatewayCliConstants.CLI_LIB + File.separator
+                                + GatewayCliConstants.CLI_REPO);
+                //copy gateway jars to platform
+                GatewayCmdUtils.copyFolder(libPath + File.separator + GatewayCliConstants.CLI_GATEWAY + File.separator
+                        + GatewayCliConstants.CLI_PLATFORM, platformExtractedPath + File.separator + breLibPath);
             }
-            //copy balo to the platform
-            GatewayCmdUtils.copyFolder(libPath + File.separator + baloPath,
-                    platformExtractedPath + File.separator + GatewayCliConstants.CLI_LIB + File.separator
-                            + GatewayCliConstants.CLI_REPO);
-            //copy gateway jars to platform
-            GatewayCmdUtils.copyFolder(libPath + File.separator + GatewayCliConstants.CLI_GATEWAY + File.separator
-                    + GatewayCliConstants.CLI_PLATFORM, platformExtractedPath + File.separator + breLibPath);
+
         } catch (IOException e) {
             String message = "Error while unzipping platform and runtime while project setup";
             logger.error(message, e);


### PR DESCRIPTION
## Purpose
> Remove hash check calculation before extracting platform and run time. 
> Platform and run time will only be extracted if there is no already extracted folder.

