### PR TITLE
Host name verification skip for throttle data publish for TM

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/gateway/endpoints/throttle_endpoint.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/endpoints/throttle_endpoint.bal
@@ -23,7 +23,12 @@ string throttleEndpointUrl = getConfigValue(THROTTLE_CONF_INSTANCE_ID, THROTTLE_
 string throttleEndpointbase64Header = getConfigValue(THROTTLE_CONF_INSTANCE_ID, THROTTLE_ENDPOINT_BASE64_HEADER,
     "admin:admin");
 
-http:Client throttleEndpoint = new(throttleEndpointUrl);
+http:Client throttleEndpoint = new(throttleEndpointUrl, config =
+    {cache: { enabled: false },
+        secureSocket:{
+            verifyHostname:getConfigBooleanValue(THROTTLE_CONF_INSTANCE_ID, ENABLE_HOSTNAME_VERIFICATION, true)
+        }
+    });
 
 public function publishThrottleEventToTrafficManager(RequestStreamDTO throttleEvent) {
 

--- a/distribution/resources/conf/micro-gw.conf
+++ b/distribution/resources/conf/micro-gw.conf
@@ -71,4 +71,5 @@ jmsConnectionProviderUrl= "amqp://admin:admin@carbon/carbon?brokerlist='tcp://lo
 jmsConnectionUsername = ""
 jmsConnectionPassword = ""
 throttleEndpointUrl = "https://localhost:9443/endpoints"
+verifyHostname=true
 throttleEndpointbase64Header = "admin:admin"


### PR DESCRIPTION
## Purpose
> Add host name verification skip when publishing to global TM.