### PR TITLE
Fix test failures due to missing build time flag siddhi

### DIFF
--- a/tests/src/test/java/org/wso2/micro/gateway/tests/common/CLIExecutor.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/common/CLIExecutor.java
@@ -102,7 +102,7 @@ public class CLIExecutor {
         homeDirectory = path + File.separator + project;
 
         String[] cmdArray = new String[]{"bash", balCommand, "build"};
-        String[] args2 = new String[]{"src", "-o", project, "--experimental"};
+        String[] args2 = new String[]{"src", "-o", project, "--experimental", "--siddhiruntime"};
         String[] cmdArgs = Stream.concat(Arrays.stream(cmdArray), Arrays.stream(args2)).toArray(String[]::new);
         Process process = Runtime.getRuntime().exec(cmdArgs, null, new File(homeDirectory));
 
@@ -139,7 +139,7 @@ public class CLIExecutor {
         homeDirectory = path + File.separator + project;
 
         String[] cmdArray = new String[] { "bash", balCommand, "build" };
-        String[] args2 = new String[] { "src", "-o", project, "--experimental" };
+        String[] args2 = new String[] { "src", "-o", project, "--experimental", "--siddhiruntime"};
         String[] cmdArgs = Stream.concat(Arrays.stream(cmdArray), Arrays.stream(args2)).toArray(String[]::new);
         Process process = Runtime.getRuntime().exec(cmdArgs, null, new File(homeDirectory));
 


### PR DESCRIPTION
## Purpose
> Fixes the test failure in swagger based approach due to missing "siddhiruntime"  flag during the build process