### PR TITLE
Token Revocation Feature

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
@@ -96,6 +96,9 @@ public class CodeGenerator {
         GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getFiltersFolderLocation() + File.separator
                         + GatewayCliConstants.GW_DIST_EXTENSION_FILTER,
                 projectSrcPath + File.separator + GatewayCliConstants.GW_DIST_EXTENSION_FILTER);
+        GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getFiltersFolderLocation() + File.separator
+                        + GatewayCliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION,
+                projectSrcPath + File.separator + GatewayCliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION);
 
     }
     /**
@@ -143,6 +146,9 @@ public class CodeGenerator {
                 projectSrcPath + File.separator + GatewayCliConstants.GW_DIST_EXTENSION_FILTER);
         GatewayCmdUtils.copyFolder(GatewayCmdUtils.getPoliciesFolderLocation(), projectSrcPath
                 + File.separator + GatewayCliConstants.GW_DIST_POLICIES);
+        GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getFiltersFolderLocation() + File.separator
+                        + GatewayCliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION,
+                projectSrcPath + File.separator + GatewayCliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION);
     }
 
     /**
@@ -245,6 +251,9 @@ public class CodeGenerator {
         GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getFiltersFolderLocation() + File.separator
                         + GatewayCliConstants.GW_DIST_EXTENSION_FILTER,
                 projectSrcPath + File.separator + GatewayCliConstants.GW_DIST_EXTENSION_FILTER);
+        GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getFiltersFolderLocation() + File.separator
+                        + GatewayCliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION,
+                projectSrcPath + File.separator + GatewayCliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION);
 
         for (File file : dir.listFiles()) {
             String filePath = file.getAbsolutePath();

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
@@ -67,6 +67,7 @@ public class GatewayCliConstants {
     public static final String GW_DIST_BAT_PATH = "distribution" + File.separator + GW_DIST_BIN + File.separator
             + GW_DIST_BAT;
     public static final String GW_DIST_EXTENSION_FILTER = "extension_filter.bal";
+    public static final String GW_DIST_TOKEN_REVOCATION_EXTENSION = "token_revocation_extension.bal";
     public static final String GW_DIST_CONF_FILE = "micro-gw.conf";
     public static final String K8S_DEPLOYMENT = "-deployment-";
     public static final String K8S_SERVICE = "-rest-";

--- a/components/micro-gateway-cli/src/main/resources/templates/jwtRevocation.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/jwtRevocation.mustache
@@ -1,0 +1,11 @@
+map<string> receivedRevokedTokenMap = gateway:getRevokedTokenMap();
+    boolean jmsListenerStarted = gateway:initiateTokenRevocationJmsListener();
+
+    boolean useDefault = gateway:getConfigBooleanValue(gateway:PERSISTENT_MESSAGE_INSTANCE_ID,
+    gateway:PERSISTENT_USE_DEFAULT, false);
+
+    if (useDefault){
+        future<()> initETCDRetriveal = start gateway:etcdRevokedTokenRetrieverTask();
+    } else {
+        initiatePersistentRevokedTokenRetrieval(receivedRevokedTokenMap);
+    }

--- a/components/micro-gateway-cli/src/main/resources/templates/main.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/main.mustache
@@ -7,4 +7,6 @@ public function main() {
     {{/each}}
 
     initThrottlePolicies();
+
+    {{>jwtRevocation}}
 }

--- a/components/micro-gateway-core/src/main/ballerina/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/constants/constants.bal
@@ -236,6 +236,21 @@
  public const string THROTTLE_ENDPOINT_URL = "throttleEndpointUrl";
  public const string THROTTLE_ENDPOINT_BASE64_HEADER = "throttleEndpointbase64Header";
 
+ public const string TOKEN_REVOCATION_CONF_INSTANCE_ID = "tokenRevocationConfig";
+ public const string TOKEN_REVOCATION_ENABLED = "enabledTokenRevocation";
+ public const string REALTIME_MESSAGE_INSTANCE_ID = "tokenRevocationConfig.realtime";
+ public const string REALTIME_MESSAGE_ENABLED = "enableRealtimeMessageRetrieval";
+ public const string REALTIME_JMS_CONNECTION_INITIAL_CONTEXT_FACTORY = "jmsConnectioninitialContextFactory";
+ public const string REALTIME_JMS_CONNECTION_PROVIDER_URL = "jmsConnectionProviderUrl";
+ public const string REALTIME_JMS_CONNECTION_USERNAME = "jmsConnectionUsername";
+ public const string REALTIME_JMS_CONNECTION_PASSWORD = "jmsConnectionPassword";
+ public const string PERSISTENT_MESSAGE_INSTANCE_ID = "tokenRevocationConfig.persistent";
+ public const string PERSISTENT_MESSAGE_ENABLED = "enablePersistentStorageRetrieval";
+ public const string PERSISTENT_USE_DEFAULT = "useDefault";
+ public const string PERSISTENT_MESSAGE_HOSTNAME = "hotsname";
+ public const string PERSISTENT_MESSAGE_USERNAME = "username";
+ public const string PERSISTENT_MESSAGE_PASSWORD = "password";
+
 // end of config constants
 
  public const string IS_THROTTLED = "isThrottled";
@@ -286,6 +301,9 @@
  const string KEY_UPLOAD_TASK = "UploadTimerTask";
  const string KEY_ROTATE_TASK = "RotateTimerTask";
  const string KEY_ETCD_UTIL = "EtcdUtil";
+ const string KEY_TOKEN_REVOCATION_ETCD_UTIL = "TokenRevocationETCDUtil";
+ const string KEY_TOKEN_REVOCATION_JMS = "TokenRevocationJMS";
+ const string KEY_JWT_AUTH_PROVIDER = "JWTAuthProvider";
 
 
  public int DEFAULT_LISTENER_TIMEOUT = 120000; //2 mins

--- a/components/micro-gateway-core/src/main/ballerina/gateway/endpoints/etcd_token_revocation_endpoint.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/endpoints/etcd_token_revocation_endpoint.bal
@@ -1,0 +1,31 @@
+// Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/http;
+import ballerina/config;
+
+http:Client etcdTokenRevocationEndpoint = new (
+    getConfigValue(PERSISTENT_MESSAGE_INSTANCE_ID, PERSISTENT_MESSAGE_HOSTNAME, "https://localhost:2379/v2/keys/jti/"), config = {
+        secureSocket: {
+            trustStore: {
+                path: getConfigValue(LISTENER_CONF_INSTANCE_ID, TRUST_STORE_PATH,
+                    "${ballerina.home}/bre/security/ballerinaTruststore.p12"),
+                password: getConfigValue(LISTENER_CONF_INSTANCE_ID, TRSUT_STORE_PASSWORD, "ballerina")
+            }
+        }
+    }
+);

--- a/components/micro-gateway-core/src/main/ballerina/gateway/endpoints/etcd_token_revocation_endpoint.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/endpoints/etcd_token_revocation_endpoint.bal
@@ -1,4 +1,4 @@
-// Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2019  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/components/micro-gateway-core/src/main/ballerina/gateway/jwt_authentication_handler.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/jwt_authentication_handler.bal
@@ -1,0 +1,92 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/log;
+import ballerina/auth;
+import ballerina/cache;
+import ballerina/config;
+import ballerina/runtime;
+import ballerina/time;
+import ballerina/io;
+
+public type JwtAuthenticationHandler object {
+
+    public string name;
+    public auth:JWTAuthProviderConfig jwtConfig;
+    public auth:JWTAuthProvider jwtAuthProvider;
+    public http:HttpJwtAuthnHandler jwtAuthnHandler;
+
+    public function canHandle(http:Request req) returns (boolean);
+    public function handle(http:Request req) returns (boolean);
+    public function __init(auth:JWTAuthProvider jwtAuthProvider, auth:JWTAuthProviderConfig jwtConfig) {
+        self.jwtAuthProvider = jwtAuthProvider;
+        self.jwtConfig = jwtConfig;
+        self.jwtAuthProvider = new(self.jwtConfig);
+        self.jwtAuthnHandler = new(self.jwtAuthProvider);
+        self.name = "jwt";
+    }
+};
+
+public function JwtAuthenticationHandler.canHandle(http:Request req) returns (boolean) {
+    return self.jwtAuthnHandler.canHandle(req);
+
+}
+
+public function JwtAuthenticationHandler.handle(http:Request req) returns (boolean) {
+    boolean handleVar;
+    handleVar = self.jwtAuthnHandler.handle(req);
+    if (handleVar) {
+        boolean isBlacklisted = false;
+        string jti = "";
+        string jwtToken = runtime:getInvocationContext().authContext.authToken;
+        var cachedJwt = trap <auth:CachedJwt>jwtCache.get(jwtToken);
+        if (cachedJwt is auth:CachedJwt) {
+            printDebug(KEY_JWT_AUTH_PROVIDER, "jwt found from the jwt cache");
+            internal:JwtPayload jwtPayloadFromCache = cachedJwt.jwtPayload;
+            jti = jwtPayloadFromCache.jti;
+            printDebug(KEY_JWT_AUTH_PROVIDER, "jti claim found in the jwt");
+        }
+
+        printDebug(KEY_JWT_AUTH_PROVIDER, "Checking for the JTI in the gateway invalid revoked token map.");
+        var status = retrieveFromRevokedTokenMap(jti);
+        if (status is boolean) {
+            if (status) {
+                printDebug(KEY_JWT_AUTH_PROVIDER, "JTI token found in the invalid token map.");
+                isBlacklisted = true;
+            } else {
+                printDebug(KEY_JWT_AUTH_PROVIDER, "JTI token not found in the invalid token map.");
+                isBlacklisted = false;
+            }
+
+        } else {
+            printDebug(KEY_JWT_AUTH_PROVIDER, "JTI token not found in the invalid token map.");
+            isBlacklisted = false;
+        }
+
+        if (isBlacklisted) {
+            printDebug(KEY_JWT_AUTH_PROVIDER, "JWT Authentication Handler returned with value : " + !isBlacklisted);
+            printDebug(KEY_JWT_AUTH_PROVIDER, "JWT Token is revoked");
+            return false;
+        } else {
+            return true;
+        }
+
+    } else {
+        return handleVar;
+    }
+}
+

--- a/components/micro-gateway-core/src/main/ballerina/gateway/jwt_authentication_handler.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/jwt_authentication_handler.bal
@@ -43,7 +43,6 @@ public type JwtAuthenticationHandler object {
 
 public function JwtAuthenticationHandler.canHandle(http:Request req) returns (boolean) {
     return self.jwtAuthnHandler.canHandle(req);
-
 }
 
 public function JwtAuthenticationHandler.handle(http:Request req) returns (boolean) {

--- a/components/micro-gateway-core/src/main/ballerina/gateway/jwt_authentication_handler.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/jwt_authentication_handler.bal
@@ -70,7 +70,6 @@ public function JwtAuthenticationHandler.handle(http:Request req) returns (boole
                 printDebug(KEY_JWT_AUTH_PROVIDER, "JTI token not found in the invalid token map.");
                 isBlacklisted = false;
             }
-
         } else {
             printDebug(KEY_JWT_AUTH_PROVIDER, "JTI token not found in the invalid token map.");
             isBlacklisted = false;

--- a/components/micro-gateway-core/src/main/ballerina/gateway/listeners/api_gateway_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/listeners/api_gateway_listener.bal
@@ -84,7 +84,6 @@ public function createAuthHandler(http:AuthProvider authProvider) returns http:H
         jwtConfig.trustStorePassword = authProvider.trustStore.password ?: "";
         jwtConfig.jwtCache = jwtCache;
         auth:JWTAuthProvider jwtAuthProvider = new(jwtConfig);
-        //http:HttpJwtAuthnHandler jwtAuthnHandler = new(jwtAuthProvider);
         JwtAuthenticationHandler jwtAuthenticationHandler = new(jwtAuthProvider, jwtConfig);
         return <JwtAuthenticationHandler>jwtAuthenticationHandler;
         //return jwtAuthnHandler;

--- a/components/micro-gateway-core/src/main/ballerina/gateway/listeners/api_gateway_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/listeners/api_gateway_listener.bal
@@ -86,7 +86,6 @@ public function createAuthHandler(http:AuthProvider authProvider) returns http:H
         auth:JWTAuthProvider jwtAuthProvider = new(jwtConfig);
         JwtAuthenticationHandler jwtAuthenticationHandler = new(jwtAuthProvider, jwtConfig);
         return <JwtAuthenticationHandler>jwtAuthenticationHandler;
-        //return jwtAuthnHandler;
     } else {
         // TODO: create other HttpAuthnHandlers
         error e = error( "Invalid auth scheme: " + authProvider.scheme);

--- a/components/micro-gateway-core/src/main/ballerina/gateway/listeners/api_gateway_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/listeners/api_gateway_listener.bal
@@ -56,7 +56,6 @@ public type APIGatewayListener object {
     }
 
 
-
 };
 
 public function createAuthHandler(http:AuthProvider authProvider) returns http:HttpAuthnHandler {
@@ -85,8 +84,10 @@ public function createAuthHandler(http:AuthProvider authProvider) returns http:H
         jwtConfig.trustStorePassword = authProvider.trustStore.password ?: "";
         jwtConfig.jwtCache = jwtCache;
         auth:JWTAuthProvider jwtAuthProvider = new(jwtConfig);
-        http:HttpJwtAuthnHandler jwtAuthnHandler = new(jwtAuthProvider);
-        return jwtAuthnHandler;
+        //http:HttpJwtAuthnHandler jwtAuthnHandler = new(jwtAuthProvider);
+        JwtAuthenticationHandler jwtAuthenticationHandler = new(jwtAuthProvider, jwtConfig);
+        return <JwtAuthenticationHandler>jwtAuthenticationHandler;
+        //return jwtAuthnHandler;
     } else {
         // TODO: create other HttpAuthnHandlers
         error e = error( "Invalid auth scheme: " + authProvider.scheme);

--- a/components/micro-gateway-core/src/main/ballerina/gateway/revoked_token_map.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/revoked_token_map.bal
@@ -1,0 +1,37 @@
+// Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+map<string> revokedTokenMap ={};
+
+public function getRevokedTokenMap() returns map<string>{
+    return revokedTokenMap;
+}
+
+public function addToRevokedTokenMap(map<string> revokedTokens) returns (boolean|()){
+    foreach var (revokedTokenKey,revokedTokenValue) in revokedTokens{
+        revokedTokenMap[<string>revokedTokenKey]=<string>revokedTokenValue;
+    }
+    return true;
+}
+
+public function retrieveFromRevokedTokenMap(string token) returns (boolean|()){
+    foreach var (revokedTokenKey,revokedTokenValue) in revokedTokenMap{
+        if(token==revokedTokenKey){
+            return true;
+        }
+    }
+    return false;
+}

--- a/components/micro-gateway-core/src/main/ballerina/gateway/revoked_token_map.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/revoked_token_map.bal
@@ -1,4 +1,4 @@
-// Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/components/micro-gateway-core/src/main/ballerina/gateway/services/token_revocation_event_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/services/token_revocation_event_listener.bal
@@ -1,0 +1,100 @@
+// Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+import ballerina/log;
+import ballerina/io;
+import ballerina/config;
+import ballerina/jms;
+import ballerina/http;
+
+
+string jmsConnectioninitialContextFactoryTokenRevocation = getConfigValue(REALTIME_MESSAGE_INSTANCE_ID,
+    REALTIME_JMS_CONNECTION_INITIAL_CONTEXT_FACTORY,
+    "bmbInitialContextFactory");
+string jmsConnectionProviderUrlTokenRevocation = getConfigValue(REALTIME_MESSAGE_INSTANCE_ID, REALTIME_JMS_CONNECTION_PROVIDER_URL,
+    "amqp://admin:admin@carbon/carbon?brokerlist='tcp://localhost:5672'");
+string jmsConnectionPasswordTokenRevocation = getConfigValue(REALTIME_MESSAGE_INSTANCE_ID, REALTIME_JMS_CONNECTION_PASSWORD, "");
+string jmsConnectionUsernameTokenRevocation = getConfigValue(REALTIME_MESSAGE_INSTANCE_ID, REALTIME_JMS_CONNECTION_USERNAME, "");
+
+service jmsTokenRevocationListener =
+service {
+    resource function onMessage(jms:TopicSubscriberCaller consumer, jms:Message message) {
+        printDebug(KEY_TOKEN_REVOCATION_JMS,"token revoked jms Message Received");
+        map<any>|error mapMessage=message.getMapMessageContent();
+        map<string> inputMap={};
+        if (mapMessage is map<any>) {
+            if (mapMessage.hasKey("revokedToken") && mapMessage.hasKey("ttl")) {
+                string revokedToken = <string>mapMessage["revokedToken"];
+                string ttl= <string>mapMessage["ttl"];
+                inputMap[revokedToken]=ttl;
+                var status= addToRevokedTokenMap(inputMap);
+                if(status is boolean){
+                    printDebug(KEY_TOKEN_REVOCATION_JMS, "Successfully added to revoked token map");
+                }else{
+                    printDebug(KEY_TOKEN_REVOCATION_JMS, "Error while ading revoked token to map");
+                }
+            }else{
+                printDebug(KEY_TOKEN_REVOCATION_JMS, "No keys named revokedToken and ttl");
+            }
+
+        } else {
+            printError(KEY_TOKEN_REVOCATION_JMS, "Error occurred while reading message");
+        }
+    }
+};
+
+# `startSubscriberService` function create jms connection, jms session and jms topic subscriber.
+# It binds the subscriber endpoint and jms listener
+#
+# + return - jms:TopicSubscriber for token Revocation
+public function startTokenRevocationSubscriberService() returns jms:TopicSubscriber {
+    // Initialize a JMS connectiontion with the provider.
+    jms:Connection jmsTokenRevocationConnection = new({
+            initialContextFactory: jmsConnectioninitialContextFactoryTokenRevocation,
+            providerUrl: jmsConnectionProviderUrlTokenRevocation,
+            username: jmsConnectionUsernameTokenRevocation,
+            password: jmsConnectionPasswordTokenRevocation
+        });
+    // Initialize a JMS session on top of the created connection.
+    jms:Session jmsTokenRevocationSession = new(jmsTokenRevocationConnection, {
+            acknowledgementMode: "AUTO_ACKNOWLEDGE"
+        });
+
+    jms:TopicSubscriber subscriberTokenRevocationEndpoint = new(jmsTokenRevocationSession, topicPattern = "jwtRevocation");
+    _ = subscriberTokenRevocationEndpoint.__attach(jmsTokenRevocationListener, {});
+    _ = subscriberTokenRevocationEndpoint.__start();
+    return subscriberTokenRevocationEndpoint;
+}
+
+# `initiateTokenRevocationJmsListener` function initialize jmslistener subscriber service if `enabledTokenRevocation`
+# is enabled
+#
+# + return - boolean value of jmslistener started or not
+public function initiateTokenRevocationJmsListener() returns boolean {
+    boolean enabledRealtimeMessage = getConfigBooleanValue(REALTIME_MESSAGE_INSTANCE_ID,
+        REALTIME_MESSAGE_ENABLED, false);
+
+    if (enabledRealtimeMessage) {
+        jms:TopicSubscriber topicTokenRevocationSubscriber = startTokenRevocationSubscriberService();
+        printInfo(KEY_TOKEN_REVOCATION_JMS , "subscriber service for token revocation is started");
+        return true;
+    }
+    return false;
+}
+
+
+

--- a/components/micro-gateway-core/src/main/ballerina/gateway/services/token_revocation_event_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/services/token_revocation_event_listener.bal
@@ -14,7 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-
 import ballerina/log;
 import ballerina/io;
 import ballerina/config;

--- a/components/micro-gateway-core/src/main/ballerina/gateway/services/token_revocation_event_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/services/token_revocation_event_listener.bal
@@ -21,7 +21,6 @@ import ballerina/config;
 import ballerina/jms;
 import ballerina/http;
 
-
 string jmsConnectioninitialContextFactoryTokenRevocation = getConfigValue(REALTIME_MESSAGE_INSTANCE_ID,
     REALTIME_JMS_CONNECTION_INITIAL_CONTEXT_FACTORY,
     "bmbInitialContextFactory");

--- a/components/micro-gateway-core/src/main/ballerina/gateway/services/token_revocation_event_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/services/token_revocation_event_listener.bal
@@ -1,4 +1,4 @@
-// Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/components/micro-gateway-core/src/main/ballerina/gateway/services/token_revocation_event_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/services/token_revocation_event_listener.bal
@@ -95,6 +95,3 @@ public function initiateTokenRevocationJmsListener() returns boolean {
     }
     return false;
 }
-
-
-

--- a/components/micro-gateway-core/src/main/ballerina/gateway/utils/token_revocation_etcd_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/utils/token_revocation_etcd_util.bal
@@ -8,7 +8,6 @@ import ballerina/io;
 import ballerina/internal;
 import ballerina/system;
 
-
 string etcdPasswordTokenRevocation = getConfigValue(PERSISTENT_MESSAGE_INSTANCE_ID, PERSISTENT_MESSAGE_PASSWORD, "");
 string etcdUsernameTokenRevocation = getConfigValue(PERSISTENT_MESSAGE_INSTANCE_ID, PERSISTENT_MESSAGE_USERNAME, "");
 

--- a/components/micro-gateway-core/src/main/ballerina/gateway/utils/token_revocation_etcd_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/utils/token_revocation_etcd_util.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/encoding;
 import ballerina/http;
 import ballerina/log;

--- a/components/micro-gateway-core/src/main/ballerina/gateway/utils/token_revocation_etcd_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/utils/token_revocation_etcd_util.bal
@@ -1,0 +1,120 @@
+import ballerina/encoding;
+import ballerina/http;
+import ballerina/log;
+import ballerina/auth;
+import ballerina/config;
+import ballerina/runtime;
+import ballerina/io;
+import ballerina/internal;
+import ballerina/system;
+
+
+string etcdPasswordTokenRevocation = getConfigValue(PERSISTENT_MESSAGE_INSTANCE_ID, PERSISTENT_MESSAGE_PASSWORD, "");
+string etcdUsernameTokenRevocation = getConfigValue(PERSISTENT_MESSAGE_INSTANCE_ID, PERSISTENT_MESSAGE_USERNAME, "");
+
+#value:"Query etcd by passing the revoked token and retrieves relevant value"
+# + return - string
+public function etcdRevokedTokenLookup(string tokenKey) returns string {
+    http:Request req = new;
+    string finalResponse = "";
+    boolean valueNotFound = false;
+    string payloadValue = "";
+
+    string key = etcdUsernameTokenRevocation + ":" + etcdPasswordTokenRevocation;
+    string encodedKey = encoding:encodeBase64(key.toByteArray(UTF_8));
+    string basicAuthHeader = BASIC_PREFIX_WITH_SPACE + encodedKey;
+    printDebug(KEY_TOKEN_REVOCATION_ETCD_UTIL, "Setting authorization header for etcd requests");
+    req.setHeader(AUTHORIZATION_HEADER, etcdToken);
+
+    var response = etcdTokenRevocationEndpoint->get(tokenKey, message = req);
+
+    if (response is http:Response) {
+        printError(KEY_ETCD_UTIL, "Http Response object obtained");
+        var msg = response.getJsonPayload();
+        if (msg is json) {
+            json jsonPayload = msg;
+            printDebug(KEY_TOKEN_REVOCATION_ETCD_UTIL, "etcd responded with a payload");
+            finalResponse = jsonPayload.node.value.toString();
+
+        } else {
+            printDebug(KEY_TOKEN_REVOCATION_ETCD_UTIL, "Error in retrieving json object");
+            valueNotFound = true;
+            printError(KEY_TOKEN_REVOCATION_ETCD_UTIL, msg.reason());
+        }
+    } else {
+        printDebug(KEY_TOKEN_REVOCATION_ETCD_UTIL, "Error object obtained");
+        valueNotFound = true;
+        printError(KEY_TOKEN_REVOCATION_ETCD_UTIL, response.reason());
+    }
+    return finalResponse;
+}
+
+#value:"Query all etcd revoked keys"
+# + return - string []
+public function etcdAllRevokedTokenLookup() returns map<string> {
+    http:Request req = new;
+    map<string> finalResponse = {};
+    string payloadValue;
+
+    string key = etcdUsernameTokenRevocation + ":" + etcdPasswordTokenRevocation;
+    string encodedKey = encoding:encodeBase64(key.toByteArray(UTF_8));
+    string basicAuthHeader = BASIC_PREFIX_WITH_SPACE + encodedKey;
+    printDebug(KEY_TOKEN_REVOCATION_ETCD_UTIL, "Setting authorization header for etcd requests");
+    req.setHeader(AUTHORIZATION_HEADER, basicAuthHeader);
+
+    var response = etcdTokenRevocationEndpoint->get("", message = req);
+
+    if (response is http:Response) {
+        printDebug(KEY_TOKEN_REVOCATION_ETCD_UTIL, "Http Response object obtained");
+        var msg = response.getJsonPayload();
+        if (msg is json) {
+            json jsonPayload = msg;
+            printDebug(KEY_TOKEN_REVOCATION_ETCD_UTIL, "etcd responded with a payload");
+            json nodes = jsonPayload.node.nodes;
+            int length = nodes.length();
+            int i = 0;
+            while (i < length) {
+                string revokedTokenReceived = nodes[i].key.toString();
+                string revokedTokenTTL = nodes[i].ttl.toString();
+                int tokenLength = revokedTokenReceived.length();
+                int lastIndexOfSlash = revokedTokenReceived.lastIndexOf("/") + 1;
+                string revokedToken = revokedTokenReceived.substring(lastIndexOfSlash, tokenLength);
+                finalResponse[revokedToken] = revokedTokenTTL;
+                i = i + 1;
+            }
+        } else {
+            printDebug(KEY_TOKEN_REVOCATION_ETCD_UTIL, "Error in retrieving json object");
+            printDebug(KEY_TOKEN_REVOCATION_ETCD_UTIL, msg.reason());
+        }
+    } else {
+        printDebug(KEY_TOKEN_REVOCATION_ETCD_UTIL, "Error object obtained");
+        printFullError(KEY_TOKEN_REVOCATION_ETCD_UTIL, response);
+    }
+    return finalResponse;
+}
+
+#value:"One Time Etcd Query. Trigger function of etcd revoked tokens retrieval task"
+#
+public function etcdRevokedTokenRetrieverTask() {
+    boolean enabledPersistentMessage = getConfigBooleanValue(PERSISTENT_MESSAGE_INSTANCE_ID,
+        PERSISTENT_MESSAGE_ENABLED, false);
+
+    if (enabledPersistentMessage) {
+        printInfo(KEY_ETCD_UTIL, "One time ETCD revoked token retriever task initiated");
+        map<string> response = etcdAllRevokedTokenLookup();
+        if (response.count() > 0) {
+            var status = addToRevokedTokenMap(response);
+            if (status is boolean) {
+                printDebug(KEY_TOKEN_REVOCATION_ETCD_UTIL, "Revoked tokens are successfully added to cache");
+            } else {
+                printDebug(KEY_TOKEN_REVOCATION_ETCD_UTIL, "Error in  adding revoked token to map");
+            }
+
+        } else {
+            printDebug(KEY_TOKEN_REVOCATION_ETCD_UTIL,
+                "No ETCD revoked tokens provided. Continuing ETCD revoked token retrieval call");
+        }
+    } else {
+        printDebug(KEY_TOKEN_REVOCATION_ETCD_UTIL, "ETCD retrieval task is disabled");
+    }
+}

--- a/distribution/resources/conf/micro-gw.conf
+++ b/distribution/resources/conf/micro-gw.conf
@@ -73,3 +73,17 @@ jmsConnectionPassword = ""
 throttleEndpointUrl = "https://localhost:9443/endpoints"
 verifyHostname=true
 throttleEndpointbase64Header = "admin:admin"
+
+[tokenRevocationConfig]
+  [tokenRevocationConfig.realtime]
+    enableRealtimeMessageRetrieval = true
+    jmsConnectioninitialContextFactory = "bmbInitialContextFactory"
+    jmsConnectionProviderUrl= "amqp://admin:admin@carbon/carbon?brokerlist='tcp://localhost:5672'"
+    jmsConnectionUsername = ""
+    jmsConnectionPassword = ""
+  [tokenRevocationConfig.persistent]
+    enablePersistentStorageRetrieval = true
+    useDefault = true
+    hostname = "https://127.0.0.1:2379/v2/keys/jti/"
+    username = "root"
+    password = "root"

--- a/distribution/resources/filters/token_revocation_extension.bal
+++ b/distribution/resources/filters/token_revocation_extension.bal
@@ -1,4 +1,4 @@
-// Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file   except

--- a/distribution/resources/filters/token_revocation_extension.bal
+++ b/distribution/resources/filters/token_revocation_extension.bal
@@ -1,0 +1,33 @@
+// Copyright (c)  WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file   except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/log;
+import ballerina/auth;
+import ballerina/config;
+import ballerina/runtime;
+import ballerina/system;
+import ballerina/time;
+import ballerina/io;
+import ballerina/reflect;
+import wso2/gateway;
+
+# This method can be used to add custom logic to add revoked token to the revoked token map.
+#
+function initiatePersistentRevokedTokenRetrieval(map<string> revokedTokenMapReceived) {
+
+}
+

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/common/MockETCDServer.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/common/MockETCDServer.java
@@ -1,0 +1,135 @@
+package org.wso2.micro.gateway.tests.common;
+
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsParameters;
+import com.sun.net.httpserver.HttpsServer;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.apimgt.gateway.cli.constants.TokenManagementConstants;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.security.KeyStore;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.TrustManagerFactory;
+
+public class MockETCDServer extends Thread {
+
+    private static final Logger log = LoggerFactory.getLogger(MockHttpServer.class);
+    private HttpsServer httpServer;
+    private String ETCDServerUrl;
+    private int ETCDServerPort;
+
+    public final static String ALL_KEYS_RESPONSE = "{    \"action\": \"get\",    \"node\": {       " +
+            " \"key\": \"/jti\",        \"dir\": true,        \"nodes\": [            {                " +
+            "\"key\": \"/jti/530ade9c-f831-4867-b465-54fbcb3d04bc\",               " +
+            " \"value\": \"bar\",              " +
+            "  \"modifiedIndex\": 27,                \"createdIndex\": 27            },            " +
+            "{                \"key\": \"/jti/cd132d9f-dc47-4ba1-a278-9c408fad27f1\",               " +
+            " \"value\": \"bar\",                \"modifiedIndex\": 34,              " +
+            "  \"createdIndex\": 34            },            {              " +
+            "  \"key\": \"/jti/1de9bb21-da04-4f68-967c-bbf422f3f8ec\",              " +
+            "  \"value\": \"bar\",                \"modifiedIndex\": 30,               " +
+            " \"createdIndex\": 30            }        ],        \"modifiedIndex\": 25,       " +
+            " \"createdIndex\": 25    }}";
+
+    public static void main(String[] args) {
+
+        MockETCDServer mockETCDServer = new MockETCDServer(2379);
+        mockETCDServer.start();
+    }
+
+    public MockETCDServer(int ETCDServerPort) {
+
+        this.ETCDServerPort = ETCDServerPort;
+    }
+    public void run() {
+        String etcdKeysBasePath = "/v2/keys/jti";
+
+        if (ETCDServerPort < 0) {
+            throw new RuntimeException("Server port is not defined");
+        }
+        try {
+            httpServer = HttpsServer.create(new InetSocketAddress(ETCDServerPort), 0);
+            httpServer.setHttpsConfigurator(new HttpsConfigurator(getSslContext()) {
+                public void configure(HttpsParameters params) {
+
+                    try {
+                        // initialise the SSL context
+                        SSLContext c = SSLContext.getDefault();
+                        SSLEngine engine = c.createSSLEngine();
+                        params.setNeedClientAuth(false);
+                        params.setCipherSuites(engine.getEnabledCipherSuites());
+                        params.setProtocols(engine.getEnabledProtocols());
+                        // get the default parameters
+                        SSLParameters defaultSSLParameters = c
+                                .getDefaultSSLParameters();
+                        params.setSSLParameters(defaultSSLParameters);
+                    } catch (Exception ex) {
+                        log.error("Failed to create HTTPS port");
+                    }
+                }
+            });
+            httpServer.createContext(etcdKeysBasePath, exchange -> {
+
+                byte[] response = ALL_KEYS_RESPONSE.getBytes();
+                exchange.getResponseHeaders().set(HttpHeaderNames.CONTENT_TYPE.toString(), TokenManagementConstants.CONTENT_TYPE_APPLICATION_JSON);
+                exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length);
+                exchange.getResponseBody().write(response);
+                exchange.close();
+            });
+            httpServer.start();
+            ETCDServerUrl = "http://localhost:" + ETCDServerPort;
+        } catch (IOException e) {
+            log.error("Error occurred while setting up mock server", e);
+        } catch (Exception e) {
+            log.error("Error occurred while setting up mock server", e);
+
+        }
+    }
+
+    public void stopIt() {
+
+        httpServer.stop(0);
+    }
+
+    public String getETCDServerUrl() {
+
+        return ETCDServerUrl;
+    }
+
+    public void setETCDServerUrl(String ETCDServerUrl) {
+
+        this.ETCDServerUrl = ETCDServerUrl;
+    }
+
+    private SSLContext getSslContext() throws Exception {
+
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+
+        // initialise the keystore
+        char[] password = "wso2carbon".toCharArray();
+        KeyStore ks = KeyStore.getInstance("JKS");
+        InputStream fis = Thread.currentThread().getContextClassLoader().getResourceAsStream("wso2carbon.jks");
+        ks.load(fis, password);
+
+        // setup the key manager factory
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+        kmf.init(ks, password);
+
+        // setup the trust manager factory
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+        tmf.init(ks);
+
+        // setup the HTTPS context and parameters
+        sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+        return sslContext;
+    }
+
+}

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/jwtRevocation/JWTRevocationSupportTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/jwtRevocation/JWTRevocationSupportTestCase.java
@@ -17,7 +17,9 @@
  */
 package org.wso2.micro.gateway.tests.jwtRevocation;
 
-import io.ballerina.messaging.broker.EmbeddedBroker;
+//uncomment when running this test case only
+//import io.ballerina.messaging.broker.EmbeddedBroker;
+
 import io.netty.handler.codec.http.HttpHeaderNames;
 import org.apache.commons.codec.binary.Base64;
 import org.json.JSONObject;
@@ -66,7 +68,6 @@ public class JWTRevocationSupportTestCase extends BaseTestCase {
     private String jwtTokenProd;
     private String jti = "2f3c1e3a-fe4c-4cd4-b049-156e3c63fc5d";
     private MockETCDServer mockETCDServer;
-    private EmbeddedBroker broker;
     private MessageConsumer consumer;
 
     @BeforeClass
@@ -115,9 +116,10 @@ public class JWTRevocationSupportTestCase extends BaseTestCase {
 
         //prepareConfigValues();
 
+        //uncomment to run this test case only
         //Initialize the JMS message broker
-        broker = new EmbeddedBroker();
-        startMessageBroker();
+        //broker = new EmbeddedBroker();
+        //startMessageBroker();
 
         //generate apis with CLI and start the micro gateway server
         CLIExecutor cliExecutor;
@@ -235,9 +237,10 @@ public class JWTRevocationSupportTestCase extends BaseTestCase {
         }
     }
 
-    private void startMessageBroker() throws Exception {
-        broker.start();
-    }
+    //uncomment to run this test case only
+//    private void startMessageBroker() throws Exception {
+//        broker.start();
+//    }
 
     /**
      * Method to publish a messege to JwtRevocation topic

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/jwtRevocation/JWTRevocationSupportTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/jwtRevocation/JWTRevocationSupportTestCase.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.micro.gateway.tests.jwtRevocation;
+
+import io.ballerina.messaging.broker.EmbeddedBroker;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.apache.commons.codec.binary.Base64;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.micro.gateway.tests.common.BaseTestCase;
+import org.wso2.micro.gateway.tests.common.CLIExecutor;
+import org.wso2.micro.gateway.tests.common.KeyValidationInfo;
+import org.wso2.micro.gateway.tests.common.MockAPIPublisher;
+import org.wso2.micro.gateway.tests.common.MockETCDServer;
+import org.wso2.micro.gateway.tests.common.MockHttpServer;
+import org.wso2.micro.gateway.tests.common.model.API;
+import org.wso2.micro.gateway.tests.common.model.ApplicationDTO;
+import org.wso2.micro.gateway.tests.context.ServerInstance;
+import org.wso2.micro.gateway.tests.context.Utils;
+import org.wso2.micro.gateway.tests.util.ClientHelper;
+import org.wso2.micro.gateway.tests.util.HttpClientRequest;
+import org.wso2.micro.gateway.tests.util.HttpResponse;
+import org.wso2.micro.gateway.tests.util.TestConstant;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.MapMessage;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.jms.Topic;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * JWT Revocation Test Class
+ */
+public class JWTRevocationSupportTestCase extends BaseTestCase {
+
+    private String jwtTokenProd;
+    private String jti = "2f3c1e3a-fe4c-4cd4-b049-156e3c63fc5d";
+    private MockETCDServer mockETCDServer;
+    private EmbeddedBroker broker;
+    private MessageConsumer consumer;
+
+    @BeforeClass
+    public void start() throws Exception {
+        initializeEtcdServer();
+
+        String balPath, configPath = "";
+        String label = "apimTestLabel";
+        String project = "apimTestProject";
+        //get mock APIM Instance
+        MockAPIPublisher pub = MockAPIPublisher.getInstance();
+        API api = new API();
+        api.setName("PizzaShackAPI");
+        api.setContext("/pizzashack");
+        api.setProdEndpoint(getMockServiceURLHttp("/echo/prod"));
+        api.setSandEndpoint(getMockServiceURLHttp("/echo/sand"));
+        api.setVersion("1.0.0");
+        api.setProvider("admin");
+        //Register API with label
+        pub.addApi(label, api);
+
+        //Define application info
+        ApplicationDTO application = new ApplicationDTO();
+        application.setName("jwtApp");
+        application.setTier("Unlimited");
+        application.setId((int) (Math.random() * 1000));
+
+        //Register a production token with key validation info
+        KeyValidationInfo info = new KeyValidationInfo();
+        info.setApi(api);
+        info.setApplication(application);
+        info.setAuthorized(true);
+        info.setKeyType(TestConstant.KEY_TYPE_PRODUCTION);
+        info.setSubscriptionTier("Unlimited");
+
+        //Generate the relevant JWT tokens
+        jwtTokenProd = getJWT(api, application, "Unlimited", TestConstant.KEY_TYPE_PRODUCTION, 3600);
+
+        //Extract the JWT token
+        int firstDotSeparatorIndex = jwtTokenProd.indexOf('.');
+        int secondSeparatorIndex = jwtTokenProd.indexOf('.', firstDotSeparatorIndex + 1);
+        String JWTToken = jwtTokenProd.substring(firstDotSeparatorIndex + 1, secondSeparatorIndex);
+        byte[] decodedJwt = Base64.decodeBase64(JWTToken.getBytes());
+        JSONObject jsonObject = new JSONObject(new String(decodedJwt));
+        jti = jsonObject.get("jti").toString();
+
+        //prepareConfigValues();
+
+        //Initialize the JMS message broker
+        broker = new EmbeddedBroker();
+        startMessageBroker();
+
+        //generate apis with CLI and start the micro gateway server
+        CLIExecutor cliExecutor;
+
+        //Initialize the Micro-Gateway Server
+        microGWServer = ServerInstance.initMicroGwServer();
+        String cliHome = microGWServer.getServerHome();
+
+        boolean isOpen = Utils.isPortOpen(MOCK_SERVER_PORT);
+        Assert.assertFalse(isOpen, "Port: " + MOCK_SERVER_PORT + " already in use.");
+        mockHttpServer = new MockHttpServer(MOCK_SERVER_PORT);
+        mockHttpServer.start();
+        cliExecutor = CLIExecutor.getInstance();
+        cliExecutor.setCliHome(cliHome);
+        cliExecutor.generatePassingFlag(label, project, "");
+
+        balPath = CLIExecutor.getInstance().getLabelBalx(project);
+        try {
+            configPath = getClass().getClassLoader().getResource("confs" + File.separator + "default-test-config.conf")
+                    .getPath();
+        } catch (NullPointerException e) {
+            Assert.fail("Should not throw any exceptions" + e);
+        }
+
+        String ballerinaLogging = "b7a.log.level=TRACE";
+
+        //Starting the Micro-Gateway Server
+        String[] args = { "--config", configPath, "-e", ballerinaLogging };
+        microGWServer.startMicroGwServer(balPath, args);
+
+        //Send Extracted JTI to the jwtRevocation Topic
+        publishMessage();
+
+    }
+
+    /**
+     * Method to start the mock ETCD server
+     */
+    private void initializeEtcdServer() {
+        int MOCK_ETCD_PORT = 2379;
+        boolean isOpen = Utils.isPortOpen(MOCK_ETCD_PORT);
+        Assert.assertFalse(isOpen, "Port: " + MOCK_ETCD_PORT + " already in use.");
+        mockETCDServer = new MockETCDServer(MOCK_ETCD_PORT);
+        mockETCDServer.start();
+    }
+
+    @Test(description = "Test to check retireving all revoked keys from ETCD server")
+    public void testEtcdAllRevokedTokenLookup()
+            throws Exception {
+
+        //test etcd all keys endpoint
+        String requestUrl = "https://localhost:2379/v2/keys/jti";
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), "application/json");
+        HttpResponse response = HttpClientRequest.doGet(requestUrl, headers);
+        Utils.assertResult(response, MockETCDServer.ALL_KEYS_RESPONSE, 200);
+        if (response.getResponseCode() != 200) {
+            retryPolicy(MockETCDServer.ALL_KEYS_RESPONSE, 200);
+        }
+
+    }
+
+    @Test(description = "Test to check revoked token response")
+    public void testRevokedTokenResponse() throws Exception {
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
+        HttpResponse response = HttpClientRequest.doGet(getServiceURLHttp("pizzashack/1.0.0/menu"), headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), 401, "Unauthorized");
+        Assert.assertTrue(
+                response.getData().contains("Invalid Credentials. Make sure you have given the correct access token"),
+                "Invalid Credentials");
+
+    }
+
+    @Test(description = "Test to check the msessage content of JMS JWT revoked message")
+    public void testJMSRevocationTopicMessage() throws Exception {
+
+        //test JMS message
+        createSubscriberJMSConnection();
+        publishMessage();
+        Message message = consumer.receive();
+        if (message instanceof TextMessage) {
+            TextMessage textMessage = (TextMessage) message;
+            assertEquals(textMessage.getText(), jti);
+        } else if (message instanceof MapMessage) {
+            MapMessage mapMessage = (MapMessage) message;
+            assertEquals(mapMessage.getString("revokedToken"), jti);
+        }
+    }
+
+    /**
+     * Method to retry ETCD all jti request
+     * @param responseData Expected resoponse data
+     * @param responseCode Expected resoponse code
+     * @throws Exception Error while sending GET request
+     */
+    private void retryPolicy(String responseData, int responseCode) throws Exception {
+        boolean testPassed = false;
+        for (int retries = 0; retries < 5; retries++) {
+            Utils.delay(1000);
+            String requestUrl = "https://localhost:2379/v2/keys/jti";
+            Map<String, String> headers = new HashMap<>();
+            headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), "application/json");
+            HttpResponse response = HttpClientRequest.doGet(requestUrl, headers);
+            if (response.getData().equals(responseData) && response.getResponseCode() == responseCode) {
+                testPassed = true;
+                break;
+            }
+        }
+
+        if (!testPassed) {
+            Assert.fail();
+        }
+    }
+
+    private void startMessageBroker() throws Exception {
+        broker.start();
+    }
+
+    /**
+     * Method to publish a messege to JwtRevocation topic
+     * @throws NamingException Error thrown while handling initial context
+     * @throws JMSException Error thrown while creating JMS connection
+     */
+    private void publishMessage() throws NamingException, JMSException {
+
+        String topicName = "jwtRevocation";
+        InitialContext initialContext = ClientHelper.getInitialContextBuilder("admin", "admin", "localhost", "5672")
+                .withTopic(topicName).build();
+        ConnectionFactory connectionFactory = (ConnectionFactory) initialContext
+                .lookup(ClientHelper.CONNECTION_FACTORY);
+        Connection connection = connectionFactory.createConnection();
+        connection.start();
+        Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        Topic topic = (Topic) initialContext.lookup(topicName);
+        MessageProducer producer = session.createProducer(topic);
+        MapMessage message = session.createMapMessage();
+        message.setString("revokedToken", jti);
+        message.setString("ttl", "3600");
+        producer.send(message);
+        connection.close();
+    }
+
+    /**
+     * Method to create a subscriber for jwtRevocation topic
+     * @throws JMSException Error thrown while creating JMS connection
+     * @throws NamingException Error thrown while handling initial context
+     */
+    private void createSubscriberJMSConnection() throws JMSException, NamingException {
+
+        String topicName = "jwtRevocation";
+        InitialContext initialContext = ClientHelper.getInitialContextBuilder("admin", "admin", "localhost", "5672")
+                .withTopic(topicName).build();
+        ConnectionFactory connectionFactory = (ConnectionFactory) initialContext
+                .lookup(ClientHelper.CONNECTION_FACTORY);
+        Connection connection = connectionFactory.createConnection();
+        connection.start();
+        Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        Topic topic = (Topic) initialContext.lookup(topicName);
+        consumer = session.createDurableSubscriber(topic, "jwtRevocation");
+    }
+
+    @AfterClass
+    public void stop() throws Exception {
+        //Stop all the mock servers
+        microGWServer.stopServer(true);
+        mockETCDServer.stopIt();
+        mockHttpServer.stopIt();
+        super.finalize();
+
+    }
+}

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/jwtRevocation/JWTRevocationSupportTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/jwtRevocation/JWTRevocationSupportTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/tests/src/test/resources/confs/default-test-config.conf
+++ b/tests/src/test/resources/confs/default-test-config.conf
@@ -72,4 +72,20 @@ sslVerifyClient="not_require"
 ["b7a.users.generalUser1"]
 password="5BAA61E4C9B93F3F0682250B6CF8331B7EE68FD8"
 
+[tokenRevocationConfig]
+  enabledTokenRevocation = true
+  [tokenRevocationConfig.realtime]
+    enableRealtimeMessageRetrieval = true
+    customImplementationEnabled = false
+    jmsConnectioninitialContextFactory = "bmbInitialContextFactory"
+    jmsConnectionProviderUrl= "amqp://admin:admin@carbon/carbon?brokerlist='tcp://localhost:5672'"
+    jmsConnectionUsername = ""
+    jmsConnectionPassword = ""
+  [tokenRevocationConfig.persistent]
+    enablePersistentStorageRetrieval = true
+    customImplementationEnabled = false
+    hostname = "http://127.0.0.1:2379/v2/keys/jti/"
+    username = "root"
+    password = "root"
+
 

--- a/tests/src/test/resources/testng.xml
+++ b/tests/src/test/resources/testng.xml
@@ -28,12 +28,13 @@
 
     <test name="micro-gw-services" preserve-order="true" parallel="false">
         <classes>
+            <class name="org.wso2.micro.gateway.tests.jwtRevocation.JWTRevocationSupportTestCase" />
             <class name="org.wso2.micro.gateway.tests.services.AuthenticationFailureTestCase" />
             <class name="org.wso2.micro.gateway.tests.services.MutualSSLTestCase" />
-            <class name="org.wso2.micro.gateway.tests.jwtRevocation.JWTRevocationSupportTestCase" />
             <class name="org.wso2.micro.gateway.tests.services.HTTP2RequestsWithHTTP1BackEndTestCase" />
             <class name="org.wso2.micro.gateway.tests.services.HTTP2RequestsWithHTTP2BackEndTestCase" />
             <class name="org.wso2.micro.gateway.tests.services.PreRequisites" />
+
         </classes>
     </test>
 
@@ -41,6 +42,7 @@
         <classes>
             <!-- DistributedThrottlingTestCase should be the first since it starts message broker -->
             <class name="org.wso2.micro.gateway.tests.toolkit.DistributedThrottlingTestCase"/>
+
             <class name="org.wso2.micro.gateway.tests.toolkit.APIInvokeWithOAuth2andBasicAuthTestCase"/>
             <class name="org.wso2.micro.gateway.tests.toolkit.APIInvokeWithBasicAuthTestCase"/>
             <class name="org.wso2.micro.gateway.tests.toolkit.APIInvokeWithOAuthTestCase"/>

--- a/tests/src/test/resources/testng.xml
+++ b/tests/src/test/resources/testng.xml
@@ -30,6 +30,7 @@
         <classes>
             <class name="org.wso2.micro.gateway.tests.services.AuthenticationFailureTestCase" />
             <class name="org.wso2.micro.gateway.tests.services.MutualSSLTestCase" />
+            <class name="org.wso2.micro.gateway.tests.jwtRevocation.JWTRevocationSupportTestCase" />
             <class name="org.wso2.micro.gateway.tests.services.HTTP2RequestsWithHTTP1BackEndTestCase" />
             <class name="org.wso2.micro.gateway.tests.services.HTTP2RequestsWithHTTP2BackEndTestCase" />
             <class name="org.wso2.micro.gateway.tests.services.PreRequisites" />


### PR DESCRIPTION
Github issue #298 

## Purpose

- Integrating the logic for Microgateway to handle the revoked tokens and then verify each request with these revoked tokens.

## Goals

- Providing Microgateway with the capability to check the revoked JWT tokens.

## Approach

- Implementing realtime revoke token retrieval service using JMS listener.
- Implementing persistent revoke token retrieval service using ETCD.
- Adding a separate JWT handler by wrapping current ballerina JWT handler to implement the logic to check revoked tokens.
- Adding extension to handle any custom persistent revoke token retrieval service instead of using default ETCD.

## User stories

- When an API request comes, first the revokedTokenMap map is read for the particular token, and if the token is found, user will be unauthorized to access the requested resource.
- When an API request comes, first the revokedTokenMap map is read for the particular token, and if the token is not found, user will be given access to the requested resource.
- Each time when a Microgateway spin up, all the revoked tokens should be taken from ETCD and store in the revokedTokenMap map.
- Each time token is revoked, JMS listener should listen to the jwtRevocation topic and retrieve the each revoked token and add to the revokedTokenMap map.

## Documentation

- doc has impact

## Automation tests
 - Integration tests
   JWTRevocationSupportTestCase - test case to check the user stories.

## Test environment

- JDK version - jdk1.8.0_191
- Ballerina version - 0.990.4
- Operating systems - Mac OS Mojave 10.14.2 