### PR TITLE
Skip deploying product to nexus

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -162,6 +162,15 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Skip deploying the product zip to nexus -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
## Purpose
Currently during every release, product zip file is getting deployed to nexus. This is not required
Fix for #426