### PR TITLE
 Feature to add token revocation JMS topic from config 

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/constants/constants.bal
@@ -244,6 +244,7 @@
  public const string REALTIME_JMS_CONNECTION_PROVIDER_URL = "jmsConnectionProviderUrl";
  public const string REALTIME_JMS_CONNECTION_USERNAME = "jmsConnectionUsername";
  public const string REALTIME_JMS_CONNECTION_PASSWORD = "jmsConnectionPassword";
+ public const string REALTIME_JMS_CONNECTION_TOPIC = "jmsConnectionTopic";
  public const string PERSISTENT_MESSAGE_INSTANCE_ID = "tokenRevocationConfig.persistent";
  public const string PERSISTENT_MESSAGE_ENABLED = "enablePersistentStorageRetrieval";
  public const string PERSISTENT_USE_DEFAULT = "useDefault";

--- a/components/micro-gateway-core/src/main/ballerina/gateway/services/throttle_event_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/services/throttle_event_listener.bal
@@ -60,7 +60,7 @@ service {
 # It binds the subscriber endpoint and jms listener
 #
 # + return - jms:TopicSubscriber for global throttling event publishing
-public function startSubscriberService() returns jms:TopicSubscriber {
+public function startSubscriberService() returns jms:TopicSubscriber|error {
     // Initialize a JMS connectiontion with the provider.
     jms:Connection jmsConnection = new({
             initialContextFactory: jmsConnectionInitialContextFactory,
@@ -88,9 +88,14 @@ public function initiateThrottlingJmsListener() returns boolean {
         GLOBAL_TM_EVENT_PUBLISH_ENABLED, false);
 
     if (enabledGlobalTMEventPublishing) {
-        jms:TopicSubscriber topicSubscriber = startSubscriberService();
-        log:printInfo("subscriber service for global throttling is started");
-        return true;
+        jms:TopicSubscriber|error topicSubscriber = trap startSubscriberService();
+        if (topicSubscriber is jms:TopicSubscriber) {
+            log:printInfo("subscriber service for global throttling is started");
+            return true;
+        } else {
+            log:printError("Error while starting subscriber service for global throttling");
+            return false;
+        }
     }
     return false;
 }

--- a/components/micro-gateway-core/src/main/ballerina/gateway/services/token_revocation_event_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/services/token_revocation_event_listener.bal
@@ -60,7 +60,7 @@ service {
 # It binds the subscriber endpoint and jms listener
 #
 # + return - jms:TopicSubscriber for token Revocation
-public function startTokenRevocationSubscriberService() returns jms:TopicSubscriber {
+public function startTokenRevocationSubscriberService() returns jms:TopicSubscriber|error {
     // Initialize a JMS connectiontion with the provider.
     jms:Connection jmsTokenRevocationConnection = new({
             initialContextFactory: jmsConnectioninitialContextFactoryTokenRevocation,
@@ -88,9 +88,14 @@ public function initiateTokenRevocationJmsListener() returns boolean {
         REALTIME_MESSAGE_ENABLED, false);
 
     if (enabledRealtimeMessage) {
-        jms:TopicSubscriber topicTokenRevocationSubscriber = startTokenRevocationSubscriberService();
-        printInfo(KEY_TOKEN_REVOCATION_JMS , "subscriber service for token revocation is started");
-        return true;
+        jms:TopicSubscriber|error topicTokenRevocationSubscriber = trap startTokenRevocationSubscriberService();
+        if (topicTokenRevocationSubscriber is jms:TopicSubscriber) {
+            printInfo(KEY_TOKEN_REVOCATION_JMS , "subscriber service for token revocation is started");
+            return true;
+        } else {
+            printError(KEY_TOKEN_REVOCATION_JMS , "Error while starting subscriber service for token revocation");
+            return false;
+        }
     }
     return false;
 }

--- a/components/micro-gateway-core/src/main/ballerina/gateway/services/token_revocation_event_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/services/token_revocation_event_listener.bal
@@ -27,6 +27,7 @@ string jmsConnectionProviderUrlTokenRevocation = getConfigValue(REALTIME_MESSAGE
     "amqp://admin:admin@carbon/carbon?brokerlist='tcp://localhost:5672'");
 string jmsConnectionPasswordTokenRevocation = getConfigValue(REALTIME_MESSAGE_INSTANCE_ID, REALTIME_JMS_CONNECTION_PASSWORD, "");
 string jmsConnectionUsernameTokenRevocation = getConfigValue(REALTIME_MESSAGE_INSTANCE_ID, REALTIME_JMS_CONNECTION_USERNAME, "");
+string tokenRevocationJMSTopic = getConfigValue(REALTIME_MESSAGE_INSTANCE_ID, REALTIME_JMS_CONNECTION_TOPIC, "tokenRevocation");
 
 service jmsTokenRevocationListener =
 service {
@@ -72,7 +73,7 @@ public function startTokenRevocationSubscriberService() returns jms:TopicSubscri
             acknowledgementMode: "AUTO_ACKNOWLEDGE"
         });
 
-    jms:TopicSubscriber subscriberTokenRevocationEndpoint = new(jmsTokenRevocationSession, topicPattern = "jwtRevocation");
+    jms:TopicSubscriber subscriberTokenRevocationEndpoint = new(jmsTokenRevocationSession, topicPattern = tokenRevocationJMSTopic);
     _ = subscriberTokenRevocationEndpoint.__attach(jmsTokenRevocationListener, {});
     _ = subscriberTokenRevocationEndpoint.__start();
     return subscriberTokenRevocationEndpoint;

--- a/distribution/resources/conf/micro-gw.conf
+++ b/distribution/resources/conf/micro-gw.conf
@@ -77,6 +77,7 @@ throttleEndpointbase64Header = "admin:admin"
 [tokenRevocationConfig]
   [tokenRevocationConfig.realtime]
     enableRealtimeMessageRetrieval = false
+    jmsConnectionTopic = "tokenRevocation"
     jmsConnectioninitialContextFactory = "bmbInitialContextFactory"
     jmsConnectionProviderUrl= "amqp://admin:admin@carbon/carbon?brokerlist='tcp://localhost:5672'"
     jmsConnectionUsername = ""


### PR DESCRIPTION
## Purpose

- Previously JMS topic was hardcoded as "jwtRevocation", this PR will add the functionality to read topic from the micro-gw.conf config file.

## Goals

- JMS listener will be able read the token revocation topic from config

## User stories

- User should be able to change the token revocation topic name from the config.

## Documentation

- doc has impact

## Related PRs

- Token Revocation Feature #420 