### PR TITLE
Create docker base image for micro-gw

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -70,6 +70,24 @@
                             <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>copy</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.wso2.am.microgw</groupId>
+                                    <artifactId>org.wso2.micro.gateway.core</artifactId>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${project.basedir}/../docker/runtime</outputDirectory>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,20 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2019, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------
+
+FROM ballerina/ballerina-runtime:0.990.4
+LABEL maintainer="dev@wso2.org"
+
+COPY runtime/ /ballerina/runtime/bre/lib/

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,9 @@
+# Micro-GW Docker Base Image
+
+## Building the image
+
+1. Build the distribution(product-microgateway/distribution) package using 'mvn clean install' which will copy the relevant jars to the runtime folder.
+Or manually copy the jar with relevant version from nexus: https://maven.wso2.org/nexus/content/groups/wso2-public/org/wso2/am/microgw/org.wso2.micro.gateway.core/ to the runtime folder
+1. Run the following command to build the base docker image. Command should be executed inside the docker folder
+
+```docker build --no-cache=true -t wso2/micro-gw:<version> .```


### PR DESCRIPTION
## Purpose
> With new ballerina version update we need to maintain a separate base image for micro gateway in order to add siddhi extension related jars

