### PR TITLE
moving extension filter and token_revocation_extension out of generated sources

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/Main.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/Main.java
@@ -54,7 +54,7 @@ public class Main {
             logger.error(MICRO_GW + ": Error occurred while executing command.", e);
             Runtime.getRuntime().exit(1);
         } catch (CLIInternalException e) {
-            outStream.println(MICRO_GW + ":" + " + INTERNAL_ERROR_MESSAGE" + " - " + e.getMessage());
+            outStream.println(MICRO_GW + ":" + INTERNAL_ERROR_MESSAGE + " - " + e.getMessage());
             logger.error(e.getMessage(), e);
             Runtime.getRuntime().exit(1);
         } catch (CLIRuntimeException e) {

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/Main.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/Main.java
@@ -39,7 +39,7 @@ public class Main {
     private static final String JC_UNKNOWN_OPTION_PREFIX = "Unknown option:";
     private static final String JC_EXPECTED_A_VALUE_AFTER_PARAMETER_PREFIX = "Expected a value after parameter";
     private static final String INTERNAL_ERROR_MESSAGE = "Internal error occurred while executing command.";
-    private static final String MICRO_GW = "micro-gw";
+    private static final String MICRO_GW = "micro-gw: ";
 
     private static PrintStream outStream = System.err;
 
@@ -51,19 +51,19 @@ public class Main {
             optionalInvokedCmd.ifPresent(GatewayLauncherCmd::execute);
         } catch (CliLauncherException e) {
             outStream.println(e.getMessages());
-            logger.error(MICRO_GW + ": Error occurred while executing command.", e);
+            logger.error(MICRO_GW + "Error occurred while executing command.", e);
             Runtime.getRuntime().exit(1);
         } catch (CLIInternalException e) {
-            outStream.println(MICRO_GW + ":" + INTERNAL_ERROR_MESSAGE + " - " + e.getMessage());
+            outStream.println(MICRO_GW + INTERNAL_ERROR_MESSAGE + " - " + e.getMessage());
             logger.error(e.getMessage(), e);
             Runtime.getRuntime().exit(1);
         } catch (CLIRuntimeException e) {
-            outStream.println(MICRO_GW + ": " + e.getTerminalMsg());
+            outStream.println(MICRO_GW + e.getTerminalMsg());
             logger.error(e.getMessage(), e);
             Runtime.getRuntime().exit(e.getExitCode());
         } catch (Exception e) {
             //Use generic exception to catch all the runtime exception
-            outStream.println(MICRO_GW + ": " + INTERNAL_ERROR_MESSAGE);
+            outStream.println(MICRO_GW + INTERNAL_ERROR_MESSAGE);
             logger.error(INTERNAL_ERROR_MESSAGE, e);
             Runtime.getRuntime().exit(1);
         }
@@ -139,7 +139,7 @@ public class Main {
             Map<String, JCommander> commanderMap;
             String parsedCmdName;
             if (args.length != 0) {
-                cmdParser.setProgramName(MICRO_GW);
+                cmdParser.setProgramName(GatewayCliConstants.MICRO_GW);
                 cmdParser.parse(args);
                 parsedCmdName = cmdParser.getParsedCommand();
 

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
@@ -65,7 +65,6 @@ public class CodeGenerator {
             throws IOException, BallerinaServiceGenException {
 
         String projectSrcPath = GatewayCmdUtils.getProjectGenSrcDirectoryPath((projectName));
-        String projectGenPath = GatewayCmdUtils.getProjectGenDirectoryPath(projectName);
         BallerinaService definitionContext;
 
         List<GenSrcFile> genFiles = new ArrayList<>();
@@ -96,11 +95,13 @@ public class CodeGenerator {
         genFiles.add(generateMainBal(serviceList));
         genFiles.add(generateCommonEndpoints());
         CodegenUtils.writeGeneratedSources(genFiles, Paths.get(projectSrcPath), overwrite);
-        GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getFiltersFolderLocation() + File.separator
-                        + GatewayCliConstants.GW_DIST_EXTENSION_FILTER,
+
+        GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getProjectExtensionsDirectoryPath(projectName)
+                        + File.separator + GatewayCliConstants.GW_DIST_EXTENSION_FILTER,
                 projectSrcPath + File.separator + GatewayCliConstants.GW_DIST_EXTENSION_FILTER);
-        GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getFiltersFolderLocation() + File.separator
-                        + GatewayCliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION,
+
+        GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getProjectExtensionsDirectoryPath(projectName)
+                        + File.separator + GatewayCliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION,
                 projectSrcPath + File.separator + GatewayCliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION);
 
     }
@@ -148,11 +149,11 @@ public class CodeGenerator {
         genFiles.add(generateMainBal(serviceList));
         genFiles.add(generateCommonEndpoints());
         CodegenUtils.writeGeneratedSources(genFiles, Paths.get(projectSrcPath), overwrite);
-        GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getFiltersFolderLocation() + File.separator
-                        + GatewayCliConstants.GW_DIST_EXTENSION_FILTER,
+        GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getProjectExtensionsDirectoryPath(projectName)
+                        + File.separator + GatewayCliConstants.GW_DIST_EXTENSION_FILTER,
                 projectSrcPath + File.separator + GatewayCliConstants.GW_DIST_EXTENSION_FILTER);
-        GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getFiltersFolderLocation() + File.separator
-                        + GatewayCliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION,
+        GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getProjectExtensionsDirectoryPath(projectName)
+                        + File.separator + GatewayCliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION,
                 projectSrcPath + File.separator + GatewayCliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION);
     }
 

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
@@ -28,6 +28,7 @@ public class GatewayCliConstants {
     public static final String PROJECT_INTERCEPTORS_DIR = "interceptors";
     public static final String PROJECT_GRPC_SERVICE_DIR = "grpc_service";
     public static final String PROJECT_GRPC_CLIENT_DIR = "client";
+    public static final String PROJECT_EXTENSIONS_DIR = "extensions";
     public static final String PROJECT_LOGS_DIR = "logs";
     public static final String PROJECT_API_USAGE_DIR = "api-usage-data";
     public static final String PROJECT_API_DEFINITIONS_DIR = "api_definitions";

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
@@ -90,6 +90,7 @@ public class GatewayCliConstants {
     public static final String SYS_PROP_USER_DIR = "user.dir";
     public static final String SYS_PROP_CURRENT_DIR = "current.dir";
     public static final String SYS_PROP_SECURITY = "security";
+    public static final String MICRO_GW = "micro-gw";
 
     public static final String LOGGING_PROPERTIES_FILENAME = "logging.properties";
     public static final Pattern SYS_PROP_PATTERN = Pattern.compile("\\$\\{([^}]*)}");

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -298,6 +298,9 @@ public class GatewayCmdUtils {
         String interceptorsPath = projectDir + File.separator + GatewayCliConstants.PROJECT_INTERCEPTORS_DIR;
         createFolderIfNotExist(interceptorsPath);
 
+        String extensionsPath = projectDir + File.separator + GatewayCliConstants.PROJECT_EXTENSIONS_DIR;
+        createFolderIfNotExist(extensionsPath);
+
         String targetDirPath = projectDir + File.separator + GatewayCliConstants.PROJECT_TARGET_DIR;
         createFolderIfNotExist(targetDirPath);
 
@@ -317,6 +320,28 @@ public class GatewayCmdUtils {
         File policyResFile = new File(policyResPath);
         File policesFile = new File(projectDir + File.separator + GatewayCliConstants.PROJECT_POLICIES_FILE);
 
+        String extensionResPath = getFiltersFolderLocation() + File.separator +
+                GatewayCliConstants.GW_DIST_EXTENSION_FILTER;
+        File extensionResFile = new File(extensionResPath);
+        File extensionFile = new File(extensionsPath + File.separator +
+                GatewayCliConstants.GW_DIST_EXTENSION_FILTER);
+
+        String tokenRevocationResPath = getFiltersFolderLocation() + File.separator +
+                GatewayCliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION;
+        File tokenRevocationResFile = new File(tokenRevocationResPath);
+        File tokenRevocationFile = new File(extensionsPath + File.separator +
+                GatewayCliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION);
+
+        if (Files.exists(extensionResFile.toPath())) {
+            FileUtils.copyFile(extensionResFile, extensionFile);
+        } else {
+            throw new CLIRuntimeException("Extension filter not found in CLI_HOME");
+        }
+        if (Files.exists(tokenRevocationResFile.toPath())) {
+            FileUtils.copyFile(tokenRevocationResFile, tokenRevocationFile);
+        } else {
+            throw new CLIRuntimeException("Token revocation extension not Found in CLI_HOME");
+        }
         if (Files.exists(policyResFile.toPath())) {
             FileUtils.copyFile(policyResFile, policesFile);
         } else {
@@ -638,6 +663,16 @@ public class GatewayCmdUtils {
     public static String getProjectGenSrcDirectoryPath(String projectName) {
         return getProjectDirectoryPath(projectName) + File.separator
                 + GatewayCliConstants.PROJECT_GEN_DIR + File.separator + GatewayCliConstants.GEN_SRC_DIR;
+    }
+
+    /**
+     * Returns path to the /extensions of a given project in the current working directory
+     *
+     * @param projectName name of the project
+     * @return path to the /extensions of a given project in the current working directory
+     */
+    public static String getProjectExtensionsDirectoryPath(String projectName) {
+        return getProjectDirectoryPath(projectName) + File.separator + GatewayCliConstants.PROJECT_EXTENSIONS_DIR;
     }
 
     /**


### PR DESCRIPTION
## Purpose
> extension_filter.bal and token_revocation_extension.bal are given as extensions for API developers. So these files should be outside the generated sources and should be in the project root.
Hence created a new folder called extensions and copied both extension_filter.bal and token_revocation_extension.bal files and refer the extension folder to the generated source.
