### PR TITLE
Support for add endpoints by reference in the open API definitions

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/OpenAPIConstants.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/OpenAPIConstants.java
@@ -4,6 +4,8 @@ public class OpenAPIConstants {
     public static final String BASEPATH = "x-mgw-basePath";
     public static final String REQUEST_INTERCEPTOR = "x-mgw-request-interceptor";
     public static final String RESPONSE_INTERCEPTOR = "x-mgw-response-interceptor";
+    public static final String ENDPOINTS = "x-mgw-endpoints";
+    public static final String ENDPOINTS_REFERENCE = "#/x-mgw-endpoints/";
     public static final String PRODUCTION_ENDPOINTS = "x-mgw-production-endpoints";
     public static final String SANDBOX_ENDPOINTS = "x-mgw-sandbox-endpoints";
     public static final String CORS = "x-mgw-cors";

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/mgwcodegen/MgwEndpointListDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/mgwcodegen/MgwEndpointListDTO.java
@@ -13,6 +13,7 @@ public class MgwEndpointListDTO {
     private EndpointType type = null;
     private List<MgwEndpointDTO> endpoints = null;
     private EndpointUrlTypeEnum endpointUrlType = null;
+    private String name = null;
 
     public APIEndpointSecurityDTO getSecurityConfig() {
         return securityConfig;
@@ -44,5 +45,13 @@ public class MgwEndpointListDTO {
 
     public void setEndpointUrlType(EndpointUrlTypeEnum endpointUrlType) {
         this.endpointUrlType = endpointUrlType;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/route/EndpointListRouteDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/route/EndpointListRouteDTO.java
@@ -17,7 +17,7 @@ public class EndpointListRouteDTO {
     private APIEndpointSecurityDTO securityConfig = null;
     private EndpointType type = null;
     private List<String> endpoints = null;
-
+    private String name;
 
     @JsonProperty("securityConfig")
     public APIEndpointSecurityDTO getSecurityConfig() {
@@ -44,6 +44,14 @@ public class EndpointListRouteDTO {
 
     public void setEndpoints(List<String> endpoints) {
         this.endpoints = endpoints;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     //todo: add "add endpoint" method

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/template/service/BallerinaOperation.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/template/service/BallerinaOperation.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Wraps the {@link Operation} from swagger models to provide iterable child models.
@@ -69,9 +70,10 @@ public class BallerinaOperation implements BallerinaOpenAPIObject<BallerinaOpera
             return getDefaultValue();
         }
 
-        // OperationId with spaces will cause trouble in ballerina code.
-        // Replacing it with '_' so that we can identify there was a ' ' when doing bal -> swagger
-        this.operationId = getTrimmedOperationId(operation.getOperationId());
+        // OperationId with spaces with special characters will cause errors in ballerina code.
+        // Replacing it with uuid so that we can identify there was a ' ' when doing bal -> swagger
+        operation.setOperationId(UUID.randomUUID().toString().replaceAll("-", "_"));
+        this.operationId = operation.getOperationId();
         this.tags = operation.getTags();
         this.summary = operation.getSummary();
         this.description = operation.getDescription();

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/OpenAPICodegenUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/OpenAPICodegenUtils.java
@@ -880,7 +880,6 @@ public class OpenAPICodegenUtils {
         });
     }
 
-
     /**
      * store the endpoint extensions which are used as references
      *

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/RouteUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/RouteUtils.java
@@ -460,6 +460,8 @@ public class RouteUtils {
             prod.setEndpointUrlType(EndpointUrlTypeEnum.PROD);
             setEndpointType(prodEpListDTO, prod);
             setEndpointUrls(prodEpListDTO, prod);
+            prod.setSecurityConfig(prodEpListDTO.getSecurityConfig());
+            prod.setName(prodEpListDTO.getName());
         }
 
         if (sandEpListDTO != null) {
@@ -467,6 +469,8 @@ public class RouteUtils {
             sandbox.setEndpointUrlType(EndpointUrlTypeEnum.SAND);
             setEndpointType(sandEpListDTO, sandbox);
             setEndpointUrls(sandEpListDTO, sandbox);
+            sandbox.setSecurityConfig(sandEpListDTO.getSecurityConfig());
+            sandbox.setName(sandEpListDTO.getName());
         }
 
         endpointConfigDTO.setProdEndpointList(prod);

--- a/components/micro-gateway-cli/src/main/resources/templates/basicAuth.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/basicAuth.mustache
@@ -1,6 +1,6 @@
-{{#api.endpointSecurity}}{{#equals api.endpointSecurity.type "basic"}},
+{{#securityConfig}}{{#equals securityConfig.type "basic"}},
     auth: {
         scheme: "Basic",
-        username: gateway:retrieveConfig("{{api.id}}_{{endpointUrlType}}_basic_username", "{{api.endpointSecurity.username}}"),
+        username: gateway:retrieveConfig("{{api.id}}_{{endpointUrlType}}_basic_username", "{{securityConfig.username}}"),
         password: gateway:retrieveConfig("{{api.id}}_{{endpointUrlType}}_basic_password", "")
-    }{{/equals}}{{/api.endpointSecurity}}
+    }{{/equals}}{{/securityConfig}}

--- a/components/micro-gateway-cli/src/main/resources/templates/basicAuth.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/basicAuth.mustache
@@ -1,6 +1,6 @@
 {{#securityConfig}}{{#equals securityConfig.type "basic"}},
     auth: {
         scheme: "Basic",
-        username: gateway:retrieveConfig("{{api.id}}_{{endpointUrlType}}_basic_username", "{{securityConfig.username}}"),
-        password: gateway:retrieveConfig("{{api.id}}_{{endpointUrlType}}_basic_password", "")
+        username: gateway:retrieveConfig("{{name}}_{{endpointUrlType}}_basic_username", "{{securityConfig.username}}"),
+        password: gateway:retrieveConfig("{{name}}_{{endpointUrlType}}_basic_password", "")
     }{{/equals}}{{/securityConfig}}

--- a/components/micro-gateway-cli/src/main/resources/templates/basicResourceAuth.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/basicResourceAuth.mustache
@@ -1,6 +1,0 @@
-{{#securityConfig}}{{#equals securityConfig.type "basic"}},
-    auth: {
-        scheme: "Basic",
-        username: gateway:retrieveConfig("{{name}}_{{endpointUrlType}}_basic_username", "{{securityConfig.username}}"),
-        password: gateway:retrieveConfig("{{name}}_{{endpointUrlType}}_basic_password", "")
-    }{{/equals}}{{/securityConfig}}

--- a/components/micro-gateway-cli/src/main/resources/templates/basicResourceAuth.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/basicResourceAuth.mustache
@@ -1,0 +1,6 @@
+{{#securityConfig}}{{#equals securityConfig.type "basic"}},
+    auth: {
+        scheme: "Basic",
+        username: gateway:retrieveConfig("{{name}}_{{endpointUrlType}}_basic_username", "{{securityConfig.username}}"),
+        password: gateway:retrieveConfig("{{name}}_{{endpointUrlType}}_basic_password", "")
+    }{{/equals}}{{/securityConfig}}

--- a/components/micro-gateway-cli/src/main/resources/templates/failoverEndpoint.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/failoverEndpoint.mustache
@@ -1,6 +1,6 @@
 http:FailoverClient {{qualifiedServiceName}}_{{endpointUrlType}} = new({
     targets: [
-    {{#endpoints}}    {url: gateway:retrieveConfig("{{api.id}}_{{endpointUrlType}}_endpoint_{{@index}}", "{{endpointUrl}}")}{{#unless @last}},
+    {{#endpoints}}    {url: gateway:retrieveConfig("{{name}}_{{endpointUrlType}}_endpoint_{{@index}}", "{{endpointUrl}}")}{{#unless @last}},
     {{/unless}}{{/endpoints}}
     ]{{>basicAuth}}
 });

--- a/components/micro-gateway-cli/src/main/resources/templates/failoverResourceEndpoint.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/failoverResourceEndpoint.mustache
@@ -3,5 +3,5 @@ targets: [
 {{#endpoints}}    {url: gateway:retrieveConfig("{{name}}_{{endpointUrlType}}_endpoint_{{@index}}", "{{endpointUrl}}")
 }{{#unless @last}},
 {{/unless}}{{/endpoints}}
-]{{>basicResourceAuth}}
+]{{>basicAuth}}
 });

--- a/components/micro-gateway-cli/src/main/resources/templates/failoverResourceEndpoint.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/failoverResourceEndpoint.mustache
@@ -1,6 +1,7 @@
 http:FailoverClient {{operationId}}_{{endpointUrlType}} = new({
 targets: [
-{{#endpoints}}    {url: gateway:retrieveConfig("{{operationId}}_{{endpointUrlType}}_endpoint_{{@index}}", "{{endpointUrl}}")}{{#unless @last}},
+{{#endpoints}}    {url: gateway:retrieveConfig("{{name}}_{{endpointUrlType}}_endpoint_{{@index}}", "{{endpointUrl}}")
+}{{#unless @last}},
 {{/unless}}{{/endpoints}}
-]{{>basicAuth}}
+]{{>basicResourceAuth}}
 });

--- a/components/micro-gateway-cli/src/main/resources/templates/httpEndpoint.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/httpEndpoint.mustache
@@ -1,4 +1,4 @@
 http:Client {{qualifiedServiceName}}_{{endpointUrlType}} = new (
-    {{#if etcd.etcdEnabled}}gateway:etcdSetup("{{api.id}}_{{endpointUrlType}}_endpoint_0","{{api.id}}_{{endpointUrlType}}_etcdKey","{{endpoints.0.endpointUrl}}"){{else}}gateway:retrieveConfig("{{api.id}}_{{endpointUrlType}}_endpoint_0","{{endpoints.0.endpointUrl}}"){{/if}},
+    {{#if etcd.etcdEnabled}}gateway:etcdSetup("{{name}}_{{endpointUrlType}}_endpoint_0","{{name}}_{{endpointUrlType}}_etcdKey","{{endpoints.0.endpointUrl}}"){{else}}gateway:retrieveConfig("{{name}}_{{endpointUrlType}}_endpoint_0","{{endpoints.0.endpointUrl}}"){{/if}},
     config = { {{>http2}}{{>caching}}{{>basicAuth}}
 });

--- a/components/micro-gateway-cli/src/main/resources/templates/httpResourceEndpoint.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/httpResourceEndpoint.mustache
@@ -1,5 +1,5 @@
 http:Client {{operationId}}_{{endpointUrlType}} = new (
 {{#if etcd.etcdEnabled}}gateway:etcdSetup("{{name}}_{{endpointUrlType}}_endpoint_0",
-"{{operationId}}_{{endpointUrlType}}_etcdKey","{{endpoints.0.endpointUrl}}"){{else}}gateway:retrieveConfig("{{operationId}}_{{endpointUrlType}}_endpoint_0","{{endpoints.0.endpointUrl}}"){{/if}},
-config = { {{>http2}}{{>caching}}{{>basicResourceAuth}}
+"{{name}}_{{endpointUrlType}}_etcdKey","{{endpoints.0.endpointUrl}}"){{else}}gateway:retrieveConfig("{{name}}_{{endpointUrlType}}_endpoint_0","{{endpoints.0.endpointUrl}}"){{/if}},
+config = { {{>http2}}{{>caching}}{{>basicAuth}}
 });

--- a/components/micro-gateway-cli/src/main/resources/templates/httpResourceEndpoint.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/httpResourceEndpoint.mustache
@@ -1,4 +1,5 @@
 http:Client {{operationId}}_{{endpointUrlType}} = new (
-{{#if etcd.etcdEnabled}}gateway:etcdSetup("{{operationId}}_{{endpointUrlType}}_endpoint_0","{{operationId}}_{{endpointUrlType}}_etcdKey","{{endpoints.0.endpointUrl}}"){{else}}gateway:retrieveConfig("{{operationId}}_{{endpointUrlType}}_endpoint_0","{{endpoints.0.endpointUrl}}"){{/if}},
-config = { {{>http2}}{{>caching}}{{>basicAuth}}
+{{#if etcd.etcdEnabled}}gateway:etcdSetup("{{name}}_{{endpointUrlType}}_endpoint_0",
+"{{operationId}}_{{endpointUrlType}}_etcdKey","{{endpoints.0.endpointUrl}}"){{else}}gateway:retrieveConfig("{{operationId}}_{{endpointUrlType}}_endpoint_0","{{endpoints.0.endpointUrl}}"){{/if}},
+config = { {{>http2}}{{>caching}}{{>basicResourceAuth}}
 });

--- a/components/micro-gateway-cli/src/main/resources/templates/lbEndpoint.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/lbEndpoint.mustache
@@ -1,6 +1,6 @@
 http:LoadBalanceClient {{qualifiedServiceName}}_{{endpointUrlType}} = new({
     targets: [
-    {{#endpoints}}    {url: gateway:retrieveConfig("{{api.id}}_{{endpointUrlType}}_endpoint_{{@index}}", "{{endpointUrl}}")}{{#unless @last}},
+    {{#endpoints}}    {url: gateway:retrieveConfig("{{name}}_{{endpointUrlType}}_endpoint_{{@index}}", "{{endpointUrl}}")}{{#unless @last}},
     {{/unless}}{{/endpoints}}
     ]
     {{>caching}}{{>basicAuth}}

--- a/components/micro-gateway-cli/src/main/resources/templates/lbResourceEndpoint.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/lbResourceEndpoint.mustache
@@ -4,5 +4,5 @@ targets: [
 }{{#unless @last}},
 {{/unless}}{{/endpoints}}
 ]
-{{>caching}}{{>basicResourceAuth}}
+{{>caching}}{{>basicAuth}}
 });

--- a/components/micro-gateway-cli/src/main/resources/templates/lbResourceEndpoint.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/lbResourceEndpoint.mustache
@@ -1,7 +1,8 @@
 http:LoadBalanceClient {{operationId}}_{{endpointUrlType}} = new({
 targets: [
-{{#endpoints}}    {url: gateway:retrieveConfig("{{operationId}}_{{endpointUrlType}}_endpoint_{{@index}}", "{{endpointUrl}}")}{{#unless @last}},
+{{#endpoints}}    {url: gateway:retrieveConfig("{{name}}_{{endpointUrlType}}_endpoint_{{@index}}", "{{endpointUrl}}")
+}{{#unless @last}},
 {{/unless}}{{/endpoints}}
 ]
-{{>caching}}{{>basicAuth}}
+{{>caching}}{{>basicResourceAuth}}
 });

--- a/samples/endpoint_by_reference_sample.yaml
+++ b/samples/endpoint_by_reference_sample.yaml
@@ -1,0 +1,188 @@
+---
+openapi: 3.0.0
+servers:
+- url: https://petstore.swagger.io/v2
+- url: http://petstore.swagger.io/v2
+info:
+  description: 'This is a sample server Petstore server.  You can find out more about
+    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For
+    this sample, you can use the api key `special-key` to test the authorization filters.'
+  version: 1.0.0
+  title: Swagger Petstore New
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+tags:
+- name: pet
+  description: Everything about your Pets
+  externalDocs:
+    description: Find out more
+    url: http://swagger.io
+- name: store
+  description: Access to Petstore orders
+- name: user
+  description: Operations about user
+  externalDocs:
+    description: Find out more about our store
+    url: http://swagger.io
+x-mgw-basePath: /petstore/v1
+x-mgw-production-endpoints: "#/x-mgw-endpoints/myEndpoint"
+paths:
+  "/pet/findByStatus":
+    get:
+      tags:
+      - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      x-mgw-production-endpoints: "#/x-mgw-endpoints/myEndpoint3"
+      parameters:
+      - name: status
+        in: query
+        description: Status values that need to be considered for filter
+        required: true
+        explode: true
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - available
+            - pending
+            - sold
+            default: available
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+        '400':
+          description: Invalid status value
+  "/pet/{petId}":
+    get:
+      tags:
+      - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+      - name: petId
+        in: path
+        description: ID of pet to return
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+components:
+  schemas:
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Category
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      required:
+      - name
+      - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          "$ref": "#/components/schemas/Category"
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            "$ref": "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+          - available
+          - pending
+          - sold
+      xml:
+        name: Pet
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/Pet"
+        application/xml:
+          schema:
+            "$ref": "#/components/schemas/Pet"
+      description: Pet object that needs to be added to the store
+      required: true
+x-mgw-endpoints:
+ - myEndpoint:
+    urls:
+    - https://petstore.swagger.io/v2
+    - https://petstore.swagger.io/v5
+    securityConfig:
+      type: basic
+      username: roshan
+ - myEndpoint3:
+    urls:
+    - https://petstore.swagger.io/v3
+    - https://petstore.swagger.io/v4
+    securityConfig:
+      type: basic
+      username: rajith
+
+

--- a/samples/endpoint_by_reference_sample.yaml
+++ b/samples/endpoint_by_reference_sample.yaml
@@ -185,4 +185,3 @@ x-mgw-endpoints:
       type: basic
       username: rajith
 
-


### PR DESCRIPTION
## Purpose
> Support to provide endpoints by reference

`
x-mgw-endpoints:
 - myEndpoint:
    urls:
    - https://petstore.swagger.io/v2
    securityConfig:
      type: basic
      username: roshan
 - myEndpoint3:
    urls:
    - https://petstore.swagger.io/v3
    securityConfig:
      type: basic
      username: rajith
`
We can define endpoint like above and refer them in API level or resource level as below

`x-mgw-production-endpoints: "#/x-mgw-endpoints/myEndpoint"`
