### PR TITLE
runtime: Fix issue in gateway sh

### DIFF
--- a/distribution/resources/bin/gateway
+++ b/distribution/resources/bin/gateway
@@ -91,7 +91,7 @@ if [ ! -d "$GWHOME/runtime" ]; then
     $PRGDIR/tools
     if [ $? -eq 0 ]; then
         cp $GWHOME/lib/gateway/*.jar $GWHOME/runtime/bre/lib/
-        cp -r $GWHOME/lib/gateway/balo/wso2/ $GWHOME/runtime/lib/repo/
+        cp -r $GWHOME/lib/gateway/balo/wso2 $GWHOME/runtime/lib/repo/
     fi
 fi
 


### PR DESCRIPTION
## Purpose
Trailing `/` in `cp` command's source path behave differently in mac and linux