### PR TITLE
Add startup log for listening ports

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/gateway/endpoints/api_gateway_endpoint.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/endpoints/api_gateway_endpoint.bal
@@ -25,6 +25,7 @@ http:Client conditionRetrievalEndpoint = new (
         }
     }
 );
+
 http:Client keyValidationEndpoint = new (
     getConfigValue(KM_CONF_INSTANCE_ID, KM_SERVER_URL, "https://localhost:9443"),
     config =

--- a/components/micro-gateway-core/src/main/ballerina/gateway/listeners/api_gateway_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/listeners/api_gateway_listener.bal
@@ -49,7 +49,7 @@ public type APIGatewayListener object {
     public function __start() returns error? {
         error? gwListener = self.httpListener.__start();
 
-        io:println("[micro-gateway] " + self.listenerType + " listener active on port " + self.listenerPort);
+        log:printInfo(self.listenerType + " listener is active on port " + self.listenerPort);
         return gwListener;
     }
 

--- a/components/micro-gateway-core/src/main/ballerina/gateway/listeners/api_gateway_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/listeners/api_gateway_listener.bal
@@ -26,25 +26,31 @@ import ballerina/io;
 public type APIGatewayListener object {
     *AbstractListener;
 
+    private int listenerPort = 0;
+    private string listenerType = "HTTP";
     public http:Listener httpListener;
 
-
     public function __init(int port, http:ServiceEndpointConfiguration config) {
-        int port1 = 0;
         if ((config.secureSocket is ())) {
-            port1 = getConfigIntValue(LISTENER_CONF_INSTANCE_ID, LISTENER_CONF_HTTP_PORT, port);
+            self.listenerPort = getConfigIntValue(LISTENER_CONF_INSTANCE_ID, LISTENER_CONF_HTTP_PORT, port);
         } else {
-            port1 = getConfigIntValue(LISTENER_CONF_INSTANCE_ID, LISTENER_CONF_HTTPS_PORT, port);
+            self.listenerPort = getConfigIntValue(LISTENER_CONF_INSTANCE_ID, LISTENER_CONF_HTTPS_PORT, port);
+            self.listenerType = "HTTPS";
         }
         initiateGatewayConfigurations(config);
-        printDebug(KEY_GW_LISTNER, "Initialized gateway configurations for port:" + port1);
-        self.httpListener = new(port1, config = config);
-        printDebug(KEY_GW_LISTNER, "Successfully initialized APIGatewayListener for port:" + port1);
+        printDebug(KEY_GW_LISTNER, "Initialized gateway configurations for port:" + self.listenerPort);
+
+        self.httpListener = new(self.listenerPort, config = config);
+
+        printDebug(KEY_GW_LISTNER, "Successfully initialized APIGatewayListener for port:" + self.listenerPort);
     }
 
 
     public function __start() returns error? {
-        return self.httpListener.__start();
+        error? gwListener = self.httpListener.__start();
+
+        io:println("[micro-gateway] " + self.listenerType + " listener active on port " + self.listenerPort);
+        return gwListener;
     }
 
     public function __stop() returns error? {

--- a/components/micro-gateway-core/src/main/ballerina/gateway/listeners/api_gateway_secure_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/listeners/api_gateway_secure_listener.bal
@@ -42,7 +42,6 @@ public type APIGatewaySecureListener object {
 
 };
 
-
 function initiateGatewaySecureConfigurations(http:ServiceEndpointConfiguration config) {
     string keyStorePath = getConfigValue(LISTENER_CONF_INSTANCE_ID, LISTENER_CONF_KEY_STORE_PATH,
         "${ballerina.home}/bre/security/ballerinaKeystore.p12");


### PR DESCRIPTION
## Purpose
Add below logs to describe the usage of default gateway ports.
```
[micro-gateway] HTTPS listener started on port 9095
[micro-gateway] HTTP listener started on port 9090
```