### PR TITLE
Add http2 template to failover and load balance templates

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/templates/failoverEndpoint.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/failoverEndpoint.mustache
@@ -2,5 +2,5 @@ http:FailoverClient {{qualifiedServiceName}}_{{endpointUrlType}} = new({
     targets: [
     {{#endpoints}}    {url: {{#if isEtcdEnabled}}gateway:etcdSetup("{{name}}_{{endpointUrlType}}_endpoint_{{@index}}","{{name}}_{{endpointUrlType}}_{{@index}}_etcdKey","{{endpointUrl}}","{{etcdKey}}"){{else}}gateway:retrieveConfig("{{name}}_{{endpointUrlType}}_endpoint_{{@index}}", "{{endpointUrl}}"){{/if}} {{>secureSocket}} }{{#unless @last}},
     {{/unless}}{{/endpoints}}
-    ] {{>caching}}{{>basicAuth}}
+    ], {{>http2}}{{>caching}}{{>basicAuth}}
 });

--- a/components/micro-gateway-cli/src/main/resources/templates/failoverEndpointReInit.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/failoverEndpointReInit.mustache
@@ -6,5 +6,5 @@ targets: [
 {{#endpoints}}    {url: {{#if isEtcdEnabled}}<string> getUrlOfEtcdKeyForReInit{{cut qualifiedServiceName " "}}("{{name}}_{{endpointUrlType}}_endpoint_{{@index}}","{{name}}_{{endpointUrlType}}_{{@index}}_etcdKey","{{etcdKey}}", "{{endpointUrl}}") {{else}} <string>gateway:retrieveConfig("{{name}}_{{endpointUrlType}}_endpoint_{{@index}}", "{{endpointUrl}}") {{/if}} {{>secureSocket}} }{{#unless @last}},
 {{/unless}}{{/endpoints}}
 
-]
-{{>caching}}{{>basicAuth}} });
+],
+{{>http2}}{{>caching}}{{>basicAuth}} });

--- a/components/micro-gateway-cli/src/main/resources/templates/failoverResourceEndpoint.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/failoverResourceEndpoint.mustache
@@ -3,5 +3,5 @@ targets: [
 {{#endpoints}}    {url: {{#if isEtcdEnabled}}gateway:etcdSetup("{{name}}_{{endpointUrlType}}_endpoint_{{@index}}","{{name}}_{{endpointUrlType}}_{{@index}}_etcdKey","{{endpointUrl}}","{{etcdKey}}"){{else}}gateway:retrieveConfig("{{name}}_{{endpointUrlType}}_endpoint_{{@index}}", "{{endpointUrl}}") {{/if}} {{>secureSocket}} }
  {{#unless @last}},
 {{/unless}}{{/endpoints}}
-]{{>caching}}{{>basicAuth}}
+], {{>http2}}{{>caching}}{{>basicAuth}}
 });

--- a/components/micro-gateway-cli/src/main/resources/templates/lbEndpoint.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/lbEndpoint.mustache
@@ -2,6 +2,6 @@ http:LoadBalanceClient {{qualifiedServiceName}}_{{endpointUrlType}} = new({
     targets: [
 {{#endpoints}}    {url: {{#if isEtcdEnabled}}gateway:etcdSetup("{{name}}_{{endpointUrlType}}_endpoint_{{@index}}","{{name}}_{{endpointUrlType}}_{{@index}}_etcdKey","{{endpointUrl}}","{{etcdKey}}"){{else}}gateway:retrieveConfig("{{name}}_{{endpointUrlType}}_endpoint_{{@index}}", "{{endpointUrl}}"){{/if}} {{>secureSocket}} }{{#unless @last}},
     {{/unless}}{{/endpoints}}
-    ]
-    {{>caching}}{{>basicAuth}}
+    ],
+    {{>http2}}{{>caching}}{{>basicAuth}}
 });

--- a/components/micro-gateway-cli/src/main/resources/templates/lbEndpointReInit.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/lbEndpointReInit.mustache
@@ -6,5 +6,5 @@ targets: [
     {{#endpoints}}    {url: {{#if isEtcdEnabled}}<string> getUrlOfEtcdKeyForReInit{{cut qualifiedServiceName " "}}("{{name}}_{{endpointUrlType}}_endpoint_{{@index}}","{{name}}_{{endpointUrlType}}_{{@index}}_etcdKey","{{etcdKey}}", "{{endpointUrl}}")}{{else}} <string>gateway:retrieveConfig("{{name}}_{{endpointUrlType}}_endpoint_{{@index}}", "{{endpointUrl}}"){{>secureSocket}} }{{/if}}{{#unless @last}},
     {{/unless}}{{/endpoints}}
 
-]
-{{>caching}}{{>basicAuth}} });
+],
+{{>http2}}{{>caching}}{{>basicAuth}} });

--- a/components/micro-gateway-cli/src/main/resources/templates/lbResourceEndpoint.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/lbResourceEndpoint.mustache
@@ -3,6 +3,6 @@ targets: [
 {{#endpoints}}    {url: {{#if isEtcdEnabled}}gateway:etcdSetup("{{name}}_{{endpointUrlType}}_endpoint_{{@index}}","{{name}}_{{endpointUrlType}}_{{@index}}_etcdKey","{{endpointUrl}}","{{etcdKey}}"){{else}}gateway:retrieveConfig("{{name}}_{{endpointUrlType}}_endpoint_{{@index}}", "{{endpointUrl}}"){{/if}}
 {{>secureSocket}} }{{#unless @last}},
 {{/unless}}{{/endpoints}}
-]
-{{>caching}}{{>basicAuth}}
+],
+{{>http2}}{{>caching}}{{>basicAuth}}
 });


### PR DESCRIPTION
## Purpose
> Load balance and failover endpoints does not support http2 config during source generation. This PR fixes that issue

