### PR TITLE
removes swagger-to-ballerina-generator-0.990.5 jar

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/ToolkitLibExtractionUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/ToolkitLibExtractionUtils.java
@@ -67,7 +67,7 @@ public class ToolkitLibExtractionUtils {
                     + GatewayCliConstants.CLI_PLATFORM, destination + File.separator + breLibPath);
             //todo: remove this segment in next release
             new File(destination + File.separator + breLibPath + File.separator +
-                    "swagger-to-ballerina-generator-0.990.4.jar").delete();
+                    "swagger-to-ballerina-generator-0.990.5.jar").delete();
         }
     }
 }


### PR DESCRIPTION
## Purpose
> swagger parser related Jars are not updated with 0.9990.5 release [1]. Hence we have to remove the **swagger-to-ballerina-generator-0.990.5.jar** from code.
[1]. https://github.com/ballerina-platform/ballerina-lang/blob/v0.990.5/pom.xml#L2340 

