### PR TITLE
Fix #652: K8s push docker image

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/templates/kubernetesDeployment.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/kubernetesDeployment.mustache
@@ -22,8 +22,9 @@
     ]{{/if}}{{#if containerConfig.kubernetes.kubernetesDeployment.dockerHost}},
     dockerHost:"{{containerConfig.kubernetes.kubernetesDeployment.dockerHost}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesDeployment.dockerCertPath}},
     dockerCertPath:"{{containerConfig.kubernetes.kubernetesDeployment.dockerCertPath}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesDeployment.push}},
-    push:{{containerConfig.kubernetes.kubernetesDeployment.push}}{{/if}}{{#if containerConfig.kubernetes.kubernetesDeployment.password}},
-    password:"{{containerConfig.kubernetes.kubernetesDeployment.password}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesDeployment.baseImage}},
+    push:{{containerConfig.kubernetes.kubernetesDeployment.push}},
+    username:"$env{DOCKER_USERNAME}",
+    password:"$env{DOCKER_PASSWORD}"{{/if}}{{#if containerConfig.kubernetes.kubernetesDeployment.baseImage}},
     baseImage:"{{containerConfig.kubernetes.kubernetesDeployment.baseImage}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesDeployment.singleYAML}},
     singleYAML:{{containerConfig.kubernetes.kubernetesDeployment.singleYAML}}{{/if}}
 }


### PR DESCRIPTION
### Purpose
With this fix users can directly push the builded docker image using the k8s deployment config.
User have to specify the "push" value to true as below in the "kubernetes.kubernetesDeployment" config of deployment-config.toml

`    buildImage = true
    push = true`

And the user name and password needed to be set as environment variables in order to push the docker image to private registry.

`
export DOCKER_USERNAME=<docker_username>
export DOCKER_PASSWORD=<docker_password>
`
Then users need to execute the build command .

`micro-gw build <project_name> -d <deployment-config.toml_file_path>`
### Issues
Fix : https://github.com/wso2/product-microgateway/issues/652

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
mac os , with k8s

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
