### PR TITLE
Fix assembly syntax issue in Windows

### DIFF
--- a/components/micro-gateway-core/assembly/balo.xml
+++ b/components/micro-gateway-core/assembly/balo.xml
@@ -26,7 +26,7 @@
     <fileSets>
         <fileSet>
             <directory>${project.build.directory}/generated-balo</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory/>
             <includes>
                 <include>**</include>
             </includes>

--- a/components/micro-gateway-core/assembly/bin.xml
+++ b/components/micro-gateway-core/assembly/bin.xml
@@ -26,7 +26,7 @@
     <fileSets>
         <fileSet>
             <directory>src/main/ballerina</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory/>
             <includes>
                 <include>**</include>
             </includes>

--- a/components/micro-gateway-tools/assembly/bin.xml
+++ b/components/micro-gateway-tools/assembly/bin.xml
@@ -24,7 +24,7 @@
     <fileSets>
         <fileSet>
             <directory>${project.build.directory}/go-tools</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory/>
             <includes>
                 <include>**</include>
             </includes>

--- a/distribution/src/main/assembly/ballerina_runtimes/runtime_zip.xml
+++ b/distribution/src/main/assembly/ballerina_runtimes/runtime_zip.xml
@@ -28,14 +28,14 @@
     <fileSets>
         <fileSet>
             <directory>${basedir}/target/ballerina/ballerina-runtime-${ballerina.platform.version}</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory/>
         </fileSet>
     </fileSets>
 
     <files>
         <file>
             <source>${basedir}/resources/ballerinaTruststore.p12</source>
-            <outputDirectory>/bre/security/</outputDirectory>
+            <outputDirectory>bre/security/</outputDirectory>
         </file>
     </files>
 </assembly>

--- a/distribution/src/main/assembly/platform_zip.xml
+++ b/distribution/src/main/assembly/platform_zip.xml
@@ -27,14 +27,14 @@
     <fileSets>
         <fileSet>
         <directory>${basedir}/target/ballerina/ballerina-${ballerina.platform.version}</directory>
-        <outputDirectory>/</outputDirectory>
+        <outputDirectory/>
         </fileSet>
     </fileSets>
 
     <files>
         <file>
             <source>${basedir}/resources/ballerinaTruststore.p12</source>
-            <outputDirectory>/bre/security/</outputDirectory>
+            <outputDirectory>bre/security/</outputDirectory>
         </file>
     </files>
 


### PR DESCRIPTION
### Purpose
To fix the assembly syntax issue (when running inside Windows) occurred due to starting output directory names with a forward slash.

### Issues
Related to #665

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
Windows 10

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
