### PR TITLE
improves the interceptor error message

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/OpenAPICodegenUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/OpenAPICodegenUtils.java
@@ -684,7 +684,7 @@ public class OpenAPICodegenUtils {
             if (path != null && operation != null) {
                 errorMsg += "under path:'" + path + "' operation:'" + operation + "' ";
             }
-            errorMsg += "is not available in any function in the " + GatewayCliConstants.PROJECT_INTERCEPTORS_DIR +
+            errorMsg += "is not available as a function name in the " + GatewayCliConstants.PROJECT_INTERCEPTORS_DIR +
                     " directory.";
             throw new CLIRuntimeException(errorMsg);
         }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/OpenAPICodegenUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/OpenAPICodegenUtils.java
@@ -684,7 +684,7 @@ public class OpenAPICodegenUtils {
             if (path != null && operation != null) {
                 errorMsg += "under path:'" + path + "' operation:'" + operation + "' ";
             }
-            errorMsg += "is not available as a function name in the " + GatewayCliConstants.PROJECT_INTERCEPTORS_DIR +
+            errorMsg += "is not available as a function in the " + GatewayCliConstants.PROJECT_INTERCEPTORS_DIR +
                     " directory.";
             throw new CLIRuntimeException(errorMsg);
         }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/OpenAPICodegenUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/OpenAPICodegenUtils.java
@@ -684,7 +684,8 @@ public class OpenAPICodegenUtils {
             if (path != null && operation != null) {
                 errorMsg += "under path:'" + path + "' operation:'" + operation + "' ";
             }
-            errorMsg += "is not available in the " + GatewayCliConstants.PROJECT_INTERCEPTORS_DIR + " directory.";
+            errorMsg += "is not available in any function in the " + GatewayCliConstants.PROJECT_INTERCEPTORS_DIR +
+                    " directory.";
             throw new CLIRuntimeException(errorMsg);
         }
     }


### PR DESCRIPTION
### Purpose
The interceptor(.bal) name wouldn't be the same as a function name and also they should be exactly mapped to functions in the swagger definition.
If a function name of the swagger definition doesn't map to the interceptor function name, It gives an error like
"The interceptor 'validateRequest' mentioned in openAPI definition:'/Users/hasunie/RD/MC/tst/intercept/api_definitions/openapi.yaml' under path:'/store/order/{orderId}' operation:'get' is not available in the interceptors directory"

Please find the artefacts:
Interceptors directory structure
Interceptors

validateRequest.bal
validateResponse.bal
Swagger difinition:

```yaml
paths:
 "/pet/findByStatus":
  get:
   tags:
    - pet
   summary: Finds Pets by status
   description: Multiple status values can be provided with comma separated strings
   operationId: findPetsByStatus
   x-wso2-request-interceptor: validateRequest
   x-wso2-response-interceptor: validateResponse
```
Interceptors:
validateRequest.bal:
```go
import ballerina/io;
import ballerina/http;

public function validateRequest (http:Caller caller, http:Request req) {
    req.setHeader("RequesteHeader","header");
}
```

Hence the validateRequest interceptor exists in interceptors directory, Error message should be changes as
"The interceptor 'validateRequest' mentioned in openAPI definition:'/Users/hasunie/RD/MC/tst/intercept/api_definitions/openapi.yaml' under path:'/store/order/{orderId}' operation:'get' is not available in any function in interceptors directory"


### Issues
related to #664 

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
