### PR TITLE
Fix the issue of running java command twice during build command

### DIFF
--- a/distribution/resources/bin/micro-gw.bat
+++ b/distribution/resources/bin/micro-gw.bat
@@ -134,17 +134,7 @@ goto :end
                 if EXIST "%TARGET_DIR%\*.balx"  DEL /F "%TARGET_DIR%\*.balx"
                 call ballerina build src -o %TARGET_DIR%\%project_name:\=%.balx --offline --experimental --siddhiruntime
             POPD
-
-            if %verbose%==T ECHO Ballerina build completed
-            SET originalArgs=%originalArgs% --compiled
-
-            REM Check for a debug param by looping through the remaining args list
-            :checkDebug
-                SHIFT
-                if ""%1""=="""" goto passToJar
-                if ""%1""==""--java.debug""  goto commandDebug
-            goto checkDebug
-goto :passToJar
+goto :end
 
 :commandDebug
 	if %verbose%==T ECHO Running commandDebug


### PR DESCRIPTION
### Purpose
Fix the issue of running java command twice during the build command when executed in windows.

### Issues
Fixes #660

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
Windows 10

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
