### PR TITLE
Fix config value name for JWT token revocation with etcd 3.0.x

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/constants/constants.bal
@@ -254,7 +254,7 @@
  public const string PERSISTENT_MESSAGE_INSTANCE_ID = "tokenRevocationConfig.persistent";
  public const string PERSISTENT_MESSAGE_ENABLED = "enablePersistentStorageRetrieval";
  public const string PERSISTENT_USE_DEFAULT = "useDefault";
- public const string PERSISTENT_MESSAGE_HOSTNAME = "hotsname";
+ public const string PERSISTENT_MESSAGE_HOSTNAME = "hostname";
  public const string PERSISTENT_MESSAGE_USERNAME = "username";
  public const string PERSISTENT_MESSAGE_PASSWORD = "password";
 

--- a/components/micro-gateway-core/src/main/ballerina/gateway/utils/token_revocation_etcd_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/utils/token_revocation_etcd_util.bal
@@ -44,7 +44,7 @@ public function etcdRevokedTokenLookup(string tokenKey) returns string {
     var response = etcdTokenRevocationEndpoint->get(tokenKey, message = req);
 
     if (response is http:Response) {
-        printError(KEY_ETCD_UTIL, "Http Response object obtained");
+        printError(KEY_TOKEN_REVOCATION_ETCD_UTIL, "Http Response object obtained");
         var msg = response.getJsonPayload();
         if (msg is json) {
             json jsonPayload = msg;

--- a/components/micro-gateway-core/src/main/ballerina/gateway/utils/token_revocation_etcd_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/utils/token_revocation_etcd_util.bal
@@ -115,7 +115,7 @@ public function etcdRevokedTokenRetrieverTask() {
         PERSISTENT_MESSAGE_ENABLED, false);
 
     if (enabledPersistentMessage) {
-        printInfo(KEY_ETCD_UTIL, "One time ETCD revoked token retriever task initiated");
+        printInfo(KEY_TOKEN_REVOCATION_ETCD_UTIL, "One time ETCD revoked token retriever task initiated");
         map<string> response = etcdAllRevokedTokenLookup();
         if (response.count() > 0) {
             var status = addToRevokedTokenMap(response);

--- a/components/micro-gateway-core/src/main/ballerina/gateway/utils/token_revocation_etcd_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/utils/token_revocation_etcd_util.bal
@@ -28,7 +28,7 @@ string etcdPasswordTokenRevocation = getConfigValue(PERSISTENT_MESSAGE_INSTANCE_
 string etcdUsernameTokenRevocation = getConfigValue(PERSISTENT_MESSAGE_INSTANCE_ID, PERSISTENT_MESSAGE_USERNAME, "");
 
 #value:"Query etcd by passing the revoked token and retrieves relevant value"
-# + return - string
+# + return - string 
 public function etcdRevokedTokenLookup(string tokenKey) returns string {
     http:Request req = new;
     string finalResponse = "";

--- a/components/micro-gateway-core/src/main/ballerina/gateway/utils/token_revocation_etcd_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/utils/token_revocation_etcd_util.bal
@@ -28,7 +28,7 @@ string etcdPasswordTokenRevocation = getConfigValue(PERSISTENT_MESSAGE_INSTANCE_
 string etcdUsernameTokenRevocation = getConfigValue(PERSISTENT_MESSAGE_INSTANCE_ID, PERSISTENT_MESSAGE_USERNAME, "");
 
 #value:"Query etcd by passing the revoked token and retrieves relevant value"
-# + return - string 
+# + return - string
 public function etcdRevokedTokenLookup(string tokenKey) returns string {
     http:Request req = new;
     string finalResponse = "";
@@ -90,7 +90,7 @@ public function etcdAllRevokedTokenLookup() returns map<string> {
             int i = 0;
             while (i < length) {
                 string revokedTokenReceived = nodes[i].key.toString();
-                string revokedTokenTTL = nodes[i].ttl.toS   tring();
+                string revokedTokenTTL = nodes[i].ttl.toString();
                 int tokenLength = revokedTokenReceived.length();
                 int lastIndexOfSlash = revokedTokenReceived.lastIndexOf("/") + 1;
                 string revokedToken = revokedTokenReceived.substring(lastIndexOfSlash, tokenLength);

--- a/components/micro-gateway-core/src/main/ballerina/gateway/utils/token_revocation_etcd_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/utils/token_revocation_etcd_util.bal
@@ -90,7 +90,7 @@ public function etcdAllRevokedTokenLookup() returns map<string> {
             int i = 0;
             while (i < length) {
                 string revokedTokenReceived = nodes[i].key.toString();
-                string revokedTokenTTL = nodes[i].ttl.toString();
+                string revokedTokenTTL = nodes[i].ttl.toS   tring();
                 int tokenLength = revokedTokenReceived.length();
                 int lastIndexOfSlash = revokedTokenReceived.lastIndexOf("/") + 1;
                 string revokedToken = revokedTokenReceived.substring(lastIndexOfSlash, tokenLength);

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -143,7 +143,6 @@
             <artifactId>andes-client</artifactId>
             <version>3.2.85</version>
         </dependency>
-        </dependency>
         <dependency>
             <groupId>io.ballerina.messaging</groupId>
             <artifactId>broker-launcher</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -143,6 +143,7 @@
             <artifactId>andes-client</artifactId>
             <version>3.2.85</version>
         </dependency>
+        </dependency>
         <dependency>
             <groupId>io.ballerina.messaging</groupId>
             <artifactId>broker-launcher</artifactId>


### PR DESCRIPTION
### Purpose
This PR addresses the following.

- JWT token revocation etcd URL doesn't work if changed from the default value.
- Some debug logs have the wrong key. This is confusing as the logs are printed from a different bal file, but the logs print a different name.


### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #680 

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
