### PR TITLE
Fix #693 : Error when k8s environment variables used

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/templates/kubernetesDeployment.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/kubernetesDeployment.mustache
@@ -10,7 +10,7 @@
     livenessPort:{{containerConfig.kubernetes.kubernetesDeployment.livenessPort}}{{/if}}{{#if containerConfig.kubernetes.kubernetesDeployment.image}},
     image:"{{containerConfig.kubernetes.kubernetesDeployment.image}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesDeployment.imagePullPolicy}},
     imagePullPolicy:"{{containerConfig.kubernetes.kubernetesDeployment.imagePullPolicy}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesDeployment.env}},
-    env:"{{containerConfig.kubernetes.kubernetesDeployment.env}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesDeployment.buildImage}},
+    env:{{{containerConfig.kubernetes.kubernetesDeployment.env}}}{{/if}}{{#if containerConfig.kubernetes.kubernetesDeployment.buildImage}},
     buildImage:{{containerConfig.kubernetes.kubernetesDeployment.buildImage}}{{/if}}{{#if containerConfig.kubernetes.kubernetesDeployment.copyFiles.enable}},
     copyFiles:[
       {{#containerConfig.kubernetes.kubernetesDeployment.copyFiles.files}}


### PR DESCRIPTION
### Purpose
When environement varibles are used in deployment config toml under the "[kubernetes.kubernetesDeployment]" config it gives a build error. This fixes that error and enabled to pass values as environment variables when deploying in k8s

### Issues
Fixes #693 

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
K8s

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
