### PR TITLE
Fix: returning 0 as exit code for runtime exceptions during build process

### DIFF
--- a/distribution/resources/bin/micro-gw
+++ b/distribution/resources/bin/micro-gw
@@ -269,7 +269,8 @@ if [ "$IS_BUILD_COMMAND" = true ] && [ "$CMD_PRO_NAME_VAL" != "" ] && [ "$MICRO_
     -DVERBOSE_ENABLED=$VERBOSE_ENABLED \
     org.wso2.apimgt.gateway.cli.cmd.Main "$@"
 
-    if [ $? -eq 0 ]
+    exit_code=$?
+    if [ $exit_code -eq 0 ]
     then
         # Ballerina path is updated as ballerina platform is extracted
         BALLERINA_HOME="$MICROGW_HOME/lib/platform"
@@ -286,7 +287,7 @@ if [ "$IS_BUILD_COMMAND" = true ] && [ "$CMD_PRO_NAME_VAL" != "" ] && [ "$MICRO_
             BALLERINA_HOME=`cygpath --absolute --windows "$BALLERINA_HOME"`
 
         fi
-        
+
         update_cli_classpath
         MICRO_GW_LABEL_PROJECT_DIR="$MICRO_GW_PROJECT_DIR/$CMD_PRO_NAME_VAL"
         pushd $MICRO_GW_LABEL_PROJECT_DIR/target/gen > /dev/null
@@ -297,6 +298,8 @@ if [ "$IS_BUILD_COMMAND" = true ] && [ "$CMD_PRO_NAME_VAL" != "" ] && [ "$MICRO_
             # build the ballerina source code for the label
             ballerina build src/ -o $MICRO_GW_LABEL_PROJECT_DIR/target/$CMD_PRO_NAME_VAL.balx --offline --experimental --siddhiruntime
         popd > /dev/null
+     else
+        exit $exit_code
      fi
 else
   $JAVACMD \

--- a/distribution/resources/bin/micro-gw.bat
+++ b/distribution/resources/bin/micro-gw.bat
@@ -118,10 +118,11 @@ goto :end
 			ECHO "Incorrect project name `%project_name:\=%` or Workspace not initialized, Run setup befor building the project!"
 			goto :EOF
 
-		if ERRORLEVEL 1 goto :end
+        if ERRORLEVEL 1 (EXIT /B %ERRORLEVEL%)
 
         :continueBuild
             call :passToJar
+            if ERRORLEVEL 1 (EXIT /B %ERRORLEVEL%)
             REM set ballerina home again as the platform is extracted at this point.
             SET BALLERINA_HOME=%MICROGW_HOME%\lib\platform
             SET PATH=%PATH%;%BALLERINA_HOME%\bin\
@@ -194,8 +195,8 @@ goto end
 	REM Jump to GW-CLI exec location when running the jar
 	CD %MICROGW_HOME%
 	"%JAVA_HOME%\bin\java" %JAVACMD% org.wso2.apimgt.gateway.cli.cmd.Main %originalArgs%
-	if "%ERRORLEVEL%"=="121" goto runJava
-	if ERRORLEVEL 1 goto :end
+	if ERRORLEVEL 121 goto runJava
+	if ERRORLEVEL 1 (EXIT /B %ERRORLEVEL%)
 :end
 goto endlocal
 


### PR DESCRIPTION

### Purpose
Fix the bug due to returning zero as the exit value when a runtime exception occured during the build process.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #699 

### Automation tests
 - Unit tests added: No
 - Integration tests added:No

### Tested environments
Mac OS

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)

