### PR TITLE
Fix #701 : Analytics error when http port is used

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/gateway/filters/authn_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/filters/authn_filter.bal
@@ -44,7 +44,8 @@ public type AuthnFilter object {
             int startingTime = getCurrentTime();
             context.attributes[REQUEST_TIME] = startingTime;
             checkOrSetMessageID(context);
-            boolean result = doAuthnFilterRequest(caller, request, context, self.oauthAuthenticator, self.authnHandlerChain);
+            setHostHeaderToFilterContext(request, context);
+            boolean result = doAuthnFilterRequest(caller, request, untaint context, self.oauthAuthenticator, self.authnHandlerChain);
             setLatency(startingTime, context, SECURITY_LATENCY_AUTHN);
             return result;
         } else {

--- a/components/micro-gateway-core/src/main/ballerina/gateway/filters/mutualSSL_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/filters/mutualSSL_filter.bal
@@ -26,16 +26,7 @@ public type MutualSSLFilter object {
     public function filterRequest(http:Caller caller, http:Request request, http:FilterContext context) returns boolean {
         int startingTime = getCurrentTime();
         checkOrSetMessageID(context);
-        printDebug(KEY_AUTHN_FILTER, "Setting hostname to populate the throttle analytics");
-        if (request.hasHeader(HOST_HEADER_NAME)) {
-            context.attributes[HOSTNAME_PROPERTY] = request.getHeader(HOST_HEADER_NAME);
-            printDebug(KEY_AUTHN_FILTER, "Hostname attribute of the filter context is set to : " +
-            <string>context.attributes[HOSTNAME_PROPERTY]);
-        } else {
-            context.attributes[HOSTNAME_PROPERTY] = "localhost";
-            printDebug(KEY_AUTHN_FILTER, "Hostname attribute of the filter context is set to : " +
-                       <string>context.attributes[HOSTNAME_PROPERTY]);
-        }
+        setHostHeaderToFilterContext(request, context);
         if(request.mutualSslHandshake["status"] == PASSED) {
             return doMTSLFilterRequest(caller, request, context);
         }

--- a/components/micro-gateway-core/src/main/ballerina/gateway/utils/utils.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/utils/utils.bal
@@ -532,3 +532,21 @@ public function decodeValueToBase10(string value) returns string {
     }
     return decodedValue;
 }
+
+# Extracts host header from request and set it to the filter context
+public function setHostHeaderToFilterContext(http:Request request, http:FilterContext context) {
+    if(context.attributes[HOSTNAME_PROPERTY] == ()) {
+        printDebug(KEY_AUTHN_FILTER, "Setting hostname to filter context");
+        if (request.hasHeader(HOST_HEADER_NAME)) {
+            context.attributes[HOSTNAME_PROPERTY] = request.getHeader(HOST_HEADER_NAME);
+
+        } else {
+            context.attributes[HOSTNAME_PROPERTY] = "localhost";
+        }
+        printDebug(KEY_UTILS, "Hostname attribute of the filter context is set to : " +
+                    <string>context.attributes[HOSTNAME_PROPERTY]);
+    } else {
+        printDebug(KEY_UTILS, "Hostname attribute of the filter context is already set to : " +
+                            <string>context.attributes[HOSTNAME_PROPERTY]);
+    }
+}


### PR DESCRIPTION
### Purpose
There is an issue when analytics is enabled and http port is used. This is due to not setting the host name to filter context

### Issues

Fixes #701

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
Mac-OS

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
