### PR TITLE
Add ignore config for spotbugs in jenkins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -368,26 +368,28 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-<!--            <plugin>-->
-<!--                <groupId>com.github.spotbugs</groupId>-->
-<!--                <artifactId>spotbugs-maven-plugin</artifactId>-->
-<!--                <version>${maven.spotbugsplugin.version}</version>-->
-<!--                <configuration>-->
-<!--                    <effort>Max</effort>-->
-<!--                    <threshold>Low</threshold>-->
-<!--                    <xmlOutput>true</xmlOutput>-->
-<!--                    <spotbugsXmlOutputDirectory>${project.build.directory}/spotbugs</spotbugsXmlOutputDirectory>-->
-<!--                </configuration>-->
-<!--                <executions>-->
-<!--                    <execution>-->
-<!--                        <id>analyze-compile</id>-->
-<!--                        <phase>compile</phase>-->
-<!--                        <goals>-->
-<!--                            <goal>check</goal>-->
-<!--                        </goals>-->
-<!--                    </execution>-->
-<!--                </executions>-->
-<!--            </plugin>-->
+            <!-- start - jenkins exclusion -->
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>${maven.spotbugsplugin.version}</version>
+                <configuration>
+                    <effort>Max</effort>
+                    <threshold>Low</threshold>
+                    <xmlOutput>true</xmlOutput>
+                    <spotbugsXmlOutputDirectory>${project.build.directory}/spotbugs</spotbugsXmlOutputDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>analyze-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- end - jenkins exclusion -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>


### PR DESCRIPTION
# Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
Jenkins build is failing due to incompatible jenkins/spotbugs versions. This has to be fixed in the jenkins server by a jenkins upgrade. Util that is completed this temporary fix is added to support a jenkins prebuild script which will remove spotbugs plugin definition from pom file before the build.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #696

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
