### PR TITLE
Fix the bug when there is an executable path including a space in windows

### DIFF
--- a/distribution/resources/bin/gateway
+++ b/distribution/resources/bin/gateway
@@ -56,7 +56,7 @@ fi
 args=""
 for c in $*
 do
-    if [ "$c" = "--debug" ] || [ "$c" = "-debug" ] || [ "$c" = "debug" ]; then
+    if [ "$c" = "--debug" ]; then
           CMD="--debug"
           continue
     elif [ "$CMD" = "--debug" ]; then

--- a/distribution/resources/bin/gateway.bat
+++ b/distribution/resources/bin/gateway.bat
@@ -67,30 +67,29 @@ REM The path of executable should be provided as \"<path>\" to avoid ballerina w
 REM BAL_ARGS variable is used to store formatted string
 set BAL_ARGS=
 :formatAndValidateCmdArgs
-if "%~1"=="-e" (
-	set "BAL_ARGS=%BAL_ARGS% %1 %2=%3"
-	shift
-	shift
-	shift
-	goto :formatAndValidateCmdArgs
-) else (
-	if "%~2"=="" (
-	    set "BAL_ARGS=%BAL_ARGS% \"%~1\""
-        goto :callBallerina
-	) else (
+    if "%~1"=="-e" (
+        set "BAL_ARGS=%BAL_ARGS% %1 %2=%3"
+        shift
+        shift
+        shift
+        goto :formatAndValidateCmdArgs
+    ) else (
+        if "%~2"=="" (
+            set "BAL_ARGS=%BAL_ARGS% \"%~1\""
+            goto :callBallerina
+        ) else (
             if "%~1"=="--debug" (
                 set "BAL_ARGS=%BAL_ARGS% %1 %2"
-                shift
-                shift
-                goto :formatAndValidateCmdArgs
+                    shift
+                    shift
+                    goto :formatAndValidateCmdArgs
             ) else (
-				echo %~1
-                echo %*
-                echo "Provided set of arguments are invalid."
-                goto end
+                    echo %*
+                    echo "Provided set of arguments are invalid."
+                    goto end
             )
-	)
-)
+        )
+    )
 
 REM Slurp the command line arguments. This loop allows for an unlimited number
 REM of arguments (up to the command line limit, anyway).

--- a/distribution/resources/bin/gateway.bat
+++ b/distribution/resources/bin/gateway.bat
@@ -33,7 +33,7 @@ SET JAVA_XMS_VALUE="256m"
 SET JAVA_XMX_VALUE="512m"
 
 REM Get the location of this(gateway.bat) file
-SET PRGDIR=%~sdp0
+SET PRGDIR=%~dp0
 SET GWHOME=%PRGDIR%..
 REM  set BALLERINA_HOME
 set BALLERINA_HOME=%GWHOME%\runtime
@@ -62,15 +62,42 @@ if not exist %GW_HOME%\runtime\ (
     )
 )
 
+REM Needs to identify the ballerina arguments and the last argument which is the path of executable.
+REM The path of executable should be provided as \"<path>\" to avoid ballerina when the path includes a space.
+REM BAL_ARGS variable is used to store formatted string
+set BAL_ARGS=
+:formatAndValidateCmdArgs
+if "%~1"=="-e" (
+	set "BAL_ARGS=%BAL_ARGS% %1 %2=%3"
+	shift
+	shift
+	shift
+	goto :formatAndValidateCmdArgs
+) else (
+	if "%~2"=="" (
+	    set "BAL_ARGS=%BAL_ARGS% \"%~1\""
+        goto :callBallerina
+	) else (
+            if "%~1"=="--debug" (
+                set "BAL_ARGS=%BAL_ARGS% %1 %2"
+                shift
+                shift
+                goto :formatAndValidateCmdArgs
+            ) else (
+				echo %~1
+                echo %*
+                echo "Provided set of arguments are invalid."
+                goto end
+            )
+	)
+)
+
 REM Slurp the command line arguments. This loop allows for an unlimited number
 REM of arguments (up to the command line limit, anyway).
 :setupArgs
 	if %verbose%==T echo [%date% %time%] DEBUG: Processing argument : `%1`
-	if ""%1""=="""" goto :callBallerina
-
+	if ""%1""=="""" goto :formatAndValidateCmdArgs
 	if ""%1""==""--debug""    goto commandDebug
-	if ""%1""==""-debug""   goto commandDebug
-	if ""%1""==""debug""  goto commandDebug
 	shift
 goto setupArgs
 
@@ -81,7 +108,7 @@ goto setupArgs
 	set DEBUG_PORT=%1
 	if "%DEBUG_PORT%"=="" goto noDebugPort
 	echo Please start the remote debugging client to continue...
-goto :callBallerina
+goto :formatAndValidateCmdArgs
 
 :noDebugPort
 	echo Please specify the debug port after the ballerina debug option
@@ -109,7 +136,7 @@ goto end
 		echo [%date% %time%] WARN: Can't find powershell in the system!
 		echo [%date% %time%] WARN: STDERR and STDOUT will be piped to %GWHOME%\logs\microgateway.log
 		REM To append to existing logs used `>>` to redirect STDERR to STDOUT used `2>&1`
-		"%GWHOME%\runtime\bin\ballerina" run -e api.usage.data.path=%usage_data_path%  -e b7a.http.accesslog.path=%unix_style_path% --config "%GWHOME%\conf\micro-gw.conf" "%*" >> "%GWHOME%\logs\microgateway.log" 2>&1
+		"%GWHOME%\runtime\bin\ballerina" run -e api.usage.data.path=%usage_data_path%  -e b7a.http.accesslog.path=%unix_style_path% --config "%GWHOME%\conf\micro-gw.conf" %BAL_ARGS% >> "%GWHOME%\logs\microgateway.log" 2>&1
 	) else (
 		REM Change Java heap Xmx and Xmx values
 		powershell -Command "(Get-Content \"%GWHOME%\runtime\bin\ballerina.bat\") | Foreach-Object {$_ -replace 'Xms.*?m','Xms%JAVA_XMS_VALUE% '} | Foreach-Object {$_ -replace 'Xmx.*?m','Xmx%JAVA_XMX_VALUE% '} | Set-Content \"%GWHOME%\runtime\bin\ballerina_1.bat\""
@@ -127,10 +154,10 @@ goto end
 		echo [%date% %time%] Starting Micro-Gateway
 		IF !PSVersion! LEQ 3 (
 			echo [%date% %time%] Starting Micro-Gateway >>  .\logs\microgateway.log
-			call powershell ".\runtime\bin\ballerina run -e api.usage.data.path=\"%usage_data_path%\" -e b7a.http.accesslog.path=\"%unix_style_path%\" --config .\conf\micro-gw.conf \"%*\" | out-file -encoding ASCII -filepath .\logs\microgateway.log -Append"
+			call powershell ".\runtime\bin\ballerina run -e api.usage.data.path=\"%usage_data_path%\" -e b7a.http.accesslog.path=\"%unix_style_path%\" --config .\conf\micro-gw.conf %BAL_ARGS% | out-file -encoding ASCII -filepath .\logs\microgateway.log -Append"
 		 ) else (
 			REM For powershell version 4 or above , We can use `tee` command for output to both file stream and stdout (Ref: https://en.wikipedia.org/wiki/PowerShell#PowerShell_4.0)
-			call powershell ".\runtime\bin\ballerina run -e api.usage.data.path=\"%usage_data_path%\" -e b7a.http.accesslog.path=\"%unix_style_path%\" --config .\conf\micro-gw.conf \"%*\" | tee -Append .\logs\microgateway.log"
+			call powershell ".\runtime\bin\ballerina run -e api.usage.data.path=\"%usage_data_path%\" -e b7a.http.accesslog.path=\"%unix_style_path%\" --config .\conf\micro-gw.conf %BAL_ARGS% | tee -Append .\logs\microgateway.log"
 		)
 	)
 :end


### PR DESCRIPTION
### Purpose
To resolve the issue when a parameter is provided using "-e" during the gateway start.
In addition, the executable path should be provided with double-quotes. 
>ex: gateway "pathToExecutable"

### Issues
Fixes #721

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
Windows 10

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
