### PR TITLE
Fix #743 : Define k8s service names in deployment toml file

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/config/Kubernetes.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/config/Kubernetes.java
@@ -27,6 +27,9 @@ public class Kubernetes {
     private KubernetesPersistentVolumeClaim kubernetesPersistentVolumeClaim;
     private KubernetesSecret kubernetesSecret;
     private KubernetesService kubernetesService;
+    private KubernetesService kubernetesServiceHttps;
+    private KubernetesService kubernetesServiceHttp;
+    private KubernetesService kubernetesServiceToken;
 
     public KubernetesConfigMap getKubernetesConfigMap() {
         return kubernetesConfigMap;
@@ -98,5 +101,29 @@ public class Kubernetes {
 
     public void setSecureKubernetesIngress(SecureKubernetesIngress secureKubernetesIngress) {
         this.secureKubernetesIngress = secureKubernetesIngress;
+    }
+
+    public KubernetesService getKubernetesServiceHttps() {
+        return kubernetesServiceHttps;
+    }
+
+    public void setKubernetesServiceHttps(KubernetesService kubernetesServiceHttps) {
+        this.kubernetesServiceHttps = kubernetesServiceHttps;
+    }
+
+    public KubernetesService getKubernetesServiceToken() {
+        return kubernetesServiceToken;
+    }
+
+    public void setKubernetesServiceToken(KubernetesService kubernetesServiceToken) {
+        this.kubernetesServiceToken = kubernetesServiceToken;
+    }
+
+    public KubernetesService getKubernetesServiceHttp() {
+        return kubernetesServiceHttp;
+    }
+
+    public void setKubernetesServiceHttp(KubernetesService kubernetesServiceHttp) {
+        this.kubernetesServiceHttp = kubernetesServiceHttp;
     }
 }

--- a/components/micro-gateway-cli/src/main/resources/default-deployment-config.toml
+++ b/components/micro-gateway-cli/src/main/resources/default-deployment-config.toml
@@ -51,6 +51,24 @@
     #labels = ''
     #serviceType = ''
     #port = ''
+  #[kubernetes.kubernetesServiceHttps]
+      #enable = false
+      #name = ''
+      #labels = ''
+      #serviceType = ''
+      #port = ''
+  #[kubernetes.kubernetesServiceHttp]
+      #enable = false
+      #name = ''
+      #labels = ''
+      #serviceType = ''
+      #port = ''
+  #[kubernetes.kubernetesServiceToken]
+      #enable = false
+      #name = ''
+      #labels = ''
+      #serviceType = ''
+      #port = ''
   [kubernetes.kubernetesIngress]
     enable = false
     #name = ''

--- a/components/micro-gateway-cli/src/main/resources/templates/kubernetesService.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/kubernetesService.mustache
@@ -1,4 +1,3 @@
-{{#if containerConfig.kubernetes.kubernetesService.enable}}
 @kubernetes:Service {
     {{#if containerConfig.kubernetes.kubernetesService.name}}
     name:"{{containerConfig.kubernetes.kubernetesService.name}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesService.labels}},
@@ -6,12 +5,3 @@
     serviceType:"{{containerConfig.kubernetes.kubernetesService.serviceType}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesService.port}},
     port:{{containerConfig.kubernetes.kubernetesService.port}}{{/if}}
 }
-{{else if containerConfig.kubernetes.kubernetesServiceHttp.enable}}
-@kubernetes:Service {
-    {{#if containerConfig.kubernetes.kubernetesServiceHttp.name}}
-    name:"{{containerConfig.kubernetes.kubernetesServiceHttp.name}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesServiceHttp.labels}},
-    labels:"{{containerConfig.kubernetes.kubernetesServiceHttp.labels}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesServiceHttp.serviceType}},
-    serviceType:"{{containerConfig.kubernetes.kubernetesServiceHttp.serviceType}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesServiceHttp.port}},
-    port:{{containerConfig.kubernetes.kubernetesServiceHttp.port}}{{/if}}
-}
-{{/if}}

--- a/components/micro-gateway-cli/src/main/resources/templates/kubernetesServiceHttp.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/kubernetesServiceHttp.mustache
@@ -1,0 +1,11 @@
+{{#if containerConfig.kubernetes.kubernetesService.enable}}
+{{>kubernetesService}}
+{{else if containerConfig.kubernetes.kubernetesServiceHttp.enable}}
+@kubernetes:Service {
+    {{#if containerConfig.kubernetes.kubernetesServiceHttp.name}}
+    name:"{{containerConfig.kubernetes.kubernetesServiceHttp.name}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesServiceHttp.labels}},
+    labels:"{{containerConfig.kubernetes.kubernetesServiceHttp.labels}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesServiceHttp.serviceType}},
+    serviceType:"{{containerConfig.kubernetes.kubernetesServiceHttp.serviceType}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesServiceHttp.port}},
+    port:{{containerConfig.kubernetes.kubernetesServiceHttp.port}}{{/if}}
+}
+{{/if}}

--- a/components/micro-gateway-cli/src/main/resources/templates/kubernetesServiceHttps.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/kubernetesServiceHttps.mustache
@@ -1,11 +1,5 @@
 {{#if containerConfig.kubernetes.kubernetesService.enable}}
-@kubernetes:Service {
-    {{#if containerConfig.kubernetes.kubernetesService.name}}
-    name:"{{containerConfig.kubernetes.kubernetesService.name}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesService.labels}},
-    labels:"{{containerConfig.kubernetes.kubernetesService.labels}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesService.serviceType}},
-    serviceType:"{{containerConfig.kubernetes.kubernetesService.serviceType}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesService.port}},
-    port:{{containerConfig.kubernetes.kubernetesService.port}}{{/if}}
-}
+{{>kubernetesService}}
 {{else if containerConfig.kubernetes.kubernetesServiceHttps.enable}}
 @kubernetes:Service {
     {{#if containerConfig.kubernetes.kubernetesServiceHttps.name}}

--- a/components/micro-gateway-cli/src/main/resources/templates/kubernetesServiceHttps.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/kubernetesServiceHttps.mustache
@@ -6,12 +6,12 @@
     serviceType:"{{containerConfig.kubernetes.kubernetesService.serviceType}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesService.port}},
     port:{{containerConfig.kubernetes.kubernetesService.port}}{{/if}}
 }
-{{else if containerConfig.kubernetes.kubernetesServiceHttp.enable}}
+{{else if containerConfig.kubernetes.kubernetesServiceHttps.enable}}
 @kubernetes:Service {
-    {{#if containerConfig.kubernetes.kubernetesServiceHttp.name}}
-    name:"{{containerConfig.kubernetes.kubernetesServiceHttp.name}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesServiceHttp.labels}},
-    labels:"{{containerConfig.kubernetes.kubernetesServiceHttp.labels}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesServiceHttp.serviceType}},
-    serviceType:"{{containerConfig.kubernetes.kubernetesServiceHttp.serviceType}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesServiceHttp.port}},
-    port:{{containerConfig.kubernetes.kubernetesServiceHttp.port}}{{/if}}
+    {{#if containerConfig.kubernetes.kubernetesServiceHttps.name}}
+    name:"{{containerConfig.kubernetes.kubernetesServiceHttps.name}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesServiceHttps.labels}},
+    labels:"{{containerConfig.kubernetes.kubernetesServiceHttps.labels}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesServiceHttps.serviceType}},
+    serviceType:"{{containerConfig.kubernetes.kubernetesServiceHttps.serviceType}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesServiceHttps.port}},
+    port:{{containerConfig.kubernetes.kubernetesServiceHttps.port}}{{/if}}
 }
 {{/if}}

--- a/components/micro-gateway-cli/src/main/resources/templates/kubernetesServiceToken.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/kubernetesServiceToken.mustache
@@ -6,12 +6,12 @@
     serviceType:"{{containerConfig.kubernetes.kubernetesService.serviceType}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesService.port}},
     port:{{containerConfig.kubernetes.kubernetesService.port}}{{/if}}
 }
-{{else if containerConfig.kubernetes.kubernetesServiceHttp.enable}}
+{{else if containerConfig.kubernetes.kubernetesServiceToken.enable}}
 @kubernetes:Service {
-    {{#if containerConfig.kubernetes.kubernetesServiceHttp.name}}
-    name:"{{containerConfig.kubernetes.kubernetesServiceHttp.name}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesServiceHttp.labels}},
-    labels:"{{containerConfig.kubernetes.kubernetesServiceHttp.labels}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesServiceHttp.serviceType}},
-    serviceType:"{{containerConfig.kubernetes.kubernetesServiceHttp.serviceType}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesServiceHttp.port}},
-    port:{{containerConfig.kubernetes.kubernetesServiceHttp.port}}{{/if}}
+    {{#if containerConfig.kubernetes.kubernetesServiceToken.name}}
+    name:"{{containerConfig.kubernetes.kubernetesServiceToken.name}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesServiceToken.labels}},
+    labels:"{{containerConfig.kubernetes.kubernetesServiceToken.labels}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesServiceToken.serviceType}},
+    serviceType:"{{containerConfig.kubernetes.kubernetesServiceToken.serviceType}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesServiceToken.port}},
+    port:{{containerConfig.kubernetes.kubernetesServiceToken.port}}{{/if}}
 }
 {{/if}}

--- a/components/micro-gateway-cli/src/main/resources/templates/kubernetesServiceToken.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/kubernetesServiceToken.mustache
@@ -1,11 +1,5 @@
 {{#if containerConfig.kubernetes.kubernetesService.enable}}
-@kubernetes:Service {
-    {{#if containerConfig.kubernetes.kubernetesService.name}}
-    name:"{{containerConfig.kubernetes.kubernetesService.name}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesService.labels}},
-    labels:"{{containerConfig.kubernetes.kubernetesService.labels}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesService.serviceType}},
-    serviceType:"{{containerConfig.kubernetes.kubernetesService.serviceType}}"{{/if}}{{#if containerConfig.kubernetes.kubernetesService.port}},
-    port:{{containerConfig.kubernetes.kubernetesService.port}}{{/if}}
-}
+{{>kubernetesService}}
 {{else if containerConfig.kubernetes.kubernetesServiceToken.enable}}
 @kubernetes:Service {
     {{#if containerConfig.kubernetes.kubernetesServiceToken.name}}

--- a/components/micro-gateway-cli/src/main/resources/templates/listeners.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/listeners.mustache
@@ -44,7 +44,7 @@ http:ServiceEndpointConfiguration secureServiceEndpointConfiguration = { {{>http
 
 {{>docker}}
 {{>secureKubernetesIngress}}
-{{>kubernetesService}}
+{{>kubernetesServiceHttps}}
 listener gateway:APIGatewaySecureListener apiSecureListener = new(9095, secureServiceEndpointConfiguration);
 
 http:ServiceEndpointConfiguration serviceEndpointConfiguration = { {{>http2}},
@@ -58,7 +58,7 @@ listener gateway:APIGatewayListener apiListener = new(9090, serviceEndpointConfi
 
 
 {{>secureKubernetesIngress}}
-{{>kubernetesService}}
+{{>kubernetesServiceToken}}
 listener http:Listener tokenListenerEndpoint = new (
     {{#if containerConfig.kubernetes.secureKubernetesIngress.enable}}
         9096, config = {
@@ -87,6 +87,17 @@ listener http:Listener tokenListenerEndpoint = new (
                     gateway:LISTENER_CONF_KEY_STORE_PASSWORD, "ballerina")
             }
         }
+    {{else if containerConfig.kubernetes.kubernetesServiceToken.enable}}
+            9096, config = {
+            host: gateway:getConfigValue(gateway:LISTENER_CONF_INSTANCE_ID, gateway:LISTENER_CONF_HOST, "localhost"),
+            secureSocket: {
+                keyStore: {
+                    path: gateway:getConfigValue(gateway:LISTENER_CONF_INSTANCE_ID, gateway:LISTENER_CONF_KEY_STORE_PATH,
+                        "${ballerina.home}/bre/security/ballerinaKeystore.p12"),
+                    password: gateway:getConfigValue(gateway:LISTENER_CONF_INSTANCE_ID,
+                        gateway:LISTENER_CONF_KEY_STORE_PASSWORD, "ballerina")
+                }
+            }
     {{else}}
         gateway:getConfigIntValue(gateway:LISTENER_CONF_INSTANCE_ID, gateway:TOKEN_LISTENER_PORT, 9096), config = {
         host: gateway:getConfigValue(gateway:LISTENER_CONF_INSTANCE_ID, gateway:LISTENER_CONF_HOST, "localhost"),

--- a/components/micro-gateway-cli/src/main/resources/templates/listeners.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/listeners.mustache
@@ -53,7 +53,7 @@ http:ServiceEndpointConfiguration serviceEndpointConfiguration = { {{>http2}},
                                                                  };
 
 {{>kubernetesIngress}}
-{{>kubernetesService}}
+{{>kubernetesServiceHttp}}
 listener gateway:APIGatewayListener apiListener = new(9090, serviceEndpointConfiguration);
 
 


### PR DESCRIPTION
### Purpose
With this PR, we can define k8s service names for the port 9090, 9095, and 9096 seperately. So it will not generate random names when building the project.
We can define the deployment-config.toml as below to specify three k8s services

```toml
[kubernetes.kubernetesServiceHttps]
      enable = true
      name = "mgw-https"
      #labels = ''
      #serviceType = ''
      #port = ''
  [kubernetes.kubernetesServiceHttp]
      enable = true
      name = "mgw-http"
      #labels = ''
      #serviceType = ''
      #port = ''
  [kubernetes.kubernetesServiceToken]
      enable = true
      name = "mgw-token"
      #labels = ''
      #serviceType = ''
      #port = '
```

And this also supports the existing behaviour , where only one service is defined. Then k8s artifacts will be generated with random k8s service name for the ports 9090, 9095 and 9096

```toml
[kubernetes.kubernetesService]
      enable = true
      #name = ""
      #labels = ''
      #serviceType = ''
      #port = '
```

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #743 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
In GKE k8s cluster

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
