### PR TITLE
Folder structure changes to execute at init cmd phase

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
@@ -89,4 +89,9 @@ public class GatewayCliConstants {
 
     public static final String API_SWAGGER = "swagger.json";
     public static final String API_OPENAPI_YAML = "openAPI.yaml";
+
+    public static final String PROJECT_GRPC_DEFINITIONS_DIR = "grpc_definitions";
+    public static final String PROJECT_GRPC_OPTIONS_DIR = "gen";
+    public static final String PROJECT_GRPC_OPTIONS_FILE = "wso2CustomOptions.proto";
+    public static final String RESOURCES_GRPC_DIR = "grpc";
 }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -223,11 +223,11 @@ public final class GatewayCmdUtils {
     }
 
     /**
-     * Get grpc folder location inside Resources Directory.
+     * Get grpc directory location inside Resources Directory.
      *
-     * @return grpc folder location
+     * @return grpc directory location
      */
-    public static String getGrpcFolderLocation() {
+    public static String getGrpcDirLocation() {
         return getResourceFolderLocation() + File.separator + GatewayCliConstants.RESOURCES_GRPC_DIR;
     }
 
@@ -303,7 +303,7 @@ public final class GatewayCmdUtils {
                 GatewayCliConstants.PROJECT_GRPC_OPTIONS_FILE;
         createFolderIfNotExist(grpcDefinitionsPath);
         createFolderIfNotExist(grpcCustomOptionDirPath);
-        FileUtils.copyFile(new File(getGrpcFolderLocation() + File.separator +
+        FileUtils.copyFile(new File(getGrpcDirLocation() + File.separator +
                         GatewayCliConstants.PROJECT_GRPC_OPTIONS_FILE), new File(grpcCustomOptionsFilePath));
 
         String projectServicesDirectory = projectDir + File.separator + GatewayCliConstants.PROJECT_SERVICES_DIR;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -303,8 +303,8 @@ public final class GatewayCmdUtils {
                 GatewayCliConstants.PROJECT_GRPC_OPTIONS_FILE;
         createFolderIfNotExist(grpcDefinitionsPath);
         createFolderIfNotExist(grpcCustomOptionDirPath);
-        FileUtils.copyFile(new File(getGrpcFolderLocation() + "/" + GatewayCliConstants.PROJECT_GRPC_OPTIONS_FILE),
-                new File(grpcCustomOptionsFilePath));
+        FileUtils.copyFile(new File(getGrpcFolderLocation() + File.separator +
+                        GatewayCliConstants.PROJECT_GRPC_OPTIONS_FILE), new File(grpcCustomOptionsFilePath));
 
         String projectServicesDirectory = projectDir + File.separator + GatewayCliConstants.PROJECT_SERVICES_DIR;
         String resourceServicesDirectory =

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -223,6 +223,15 @@ public final class GatewayCmdUtils {
     }
 
     /**
+     * Get grpc folder location inside Resources Directory.
+     *
+     * @return grpc folder location
+     */
+    public static String getGrpcFolderLocation() {
+        return getResourceFolderLocation() + File.separator + GatewayCliConstants.RESOURCES_GRPC_DIR;
+    }
+
+    /**
      * Get resources file directory path
      *
      * @return resources file directory path
@@ -286,6 +295,16 @@ public final class GatewayCmdUtils {
 
         String definitionsPath = projectDir + File.separator + GatewayCliConstants.PROJECT_API_DEFINITIONS_DIR;
         createFolderIfNotExist(definitionsPath);
+
+        String grpcDefinitionsPath = projectDir + File.separator + GatewayCliConstants.PROJECT_GRPC_DEFINITIONS_DIR;
+        String grpcCustomOptionDirPath = grpcDefinitionsPath + File.separator +
+                GatewayCliConstants.PROJECT_GRPC_OPTIONS_DIR;
+        String grpcCustomOptionsFilePath = grpcCustomOptionDirPath + File.separator +
+                GatewayCliConstants.PROJECT_GRPC_OPTIONS_FILE;
+        createFolderIfNotExist(grpcDefinitionsPath);
+        createFolderIfNotExist(grpcCustomOptionDirPath);
+        FileUtils.copyFile(new File(getGrpcFolderLocation() + "/" + GatewayCliConstants.PROJECT_GRPC_OPTIONS_FILE),
+                new File(grpcCustomOptionsFilePath));
 
         String projectServicesDirectory = projectDir + File.separator + GatewayCliConstants.PROJECT_SERVICES_DIR;
         String resourceServicesDirectory =

--- a/distribution/resources/grpc/wso2CustomOptions.proto
+++ b/distribution/resources/grpc/wso2CustomOptions.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+package org.wso2.apimgt.gateway.cli.protobuf;
+
+import "google/protobuf/descriptor.proto";
+
+//service level extensions
+extend google.protobuf.ServiceOptions {
+  Endpoints x_wso2_production_endpoints = 50001;
+  Endpoints x_wso2_sandbox_endpoints = 50002;
+  repeated Security x_wso2_security = 50003;
+  string x_wso2_throttling_tier = 50004;
+  string x_wso2_scopes = 50005;
+}
+
+//method level extensions
+extend google.protobuf.MethodOptions {
+  	string x_wso2_method_throttling_tier = 50006;
+  	string x_wso2_method_scopes = 50007;
+}
+
+
+//to define endpoints
+message Endpoints {
+	repeated Endpoint urls = 1;
+	EndpointType type = 2;
+}
+
+message Endpoint {
+	string url = 1;
+}
+
+enum EndpointType {
+	DEFAULT = 0;
+	FAILOVER = 1;
+}
+
+enum Security {
+	NONE = 0;
+	BASIC = 1;
+	OAUTH2 = 2;
+	JWT = 3;
+}

--- a/distribution/src/main/assembly/bin.xml
+++ b/distribution/src/main/assembly/bin.xml
@@ -41,6 +41,10 @@
             <directory>${basedir}/resources/tokenServices</directory>
             <outputDirectory>wso2am-micro-gw-toolkit-${project.version}/resources/services</outputDirectory>
         </fileSet>
+        <fileSet>
+            <directory>${basedir}/resources/grpc</directory>
+            <outputDirectory>wso2am-micro-gw-toolkit-${project.version}/resources/grpc</outputDirectory>
+        </fileSet>
         <!--create an empty temp folder-->
         <fileSet>
             <directory>${basedir}/resources/temp</directory>


### PR DESCRIPTION
### Purpose
Following changes are added to the folder structure.

- There is a directory called "grpc_definitions" at the root level of the project. This is the location where the developer should copy the grpc service definitions.
- The protobuf file containing the microgateway extensions is also saved inside the project under the location <project_dir>/grpc_definitions/gen/wso2CustomOptions.proto.

Fixes : #283 
