### PR TITLE
Fix project structure related issues

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
@@ -167,11 +167,28 @@ public class BuildCmd implements GatewayLauncherCmd {
             CodeGenerationContext codeGenerationContext = new CodeGenerationContext();
             codeGenerationContext.setProjectName(projectName);
             GatewayCmdUtils.setCodeGenerationContext(codeGenerationContext);
+
+            initTarget(projectName);
         } catch (ConfigParserException e) {
             logger.error("Error occurred while parsing the configurations {}", configPath, e);
             throw new CLIInternalException("Error occurred while loading configurations.");
         } catch (IOException e) {
             throw new CLIInternalException("Error occured while reading the deployment configuration", e);
         }
+    }
+
+    /**
+     * Initializes the project build target directory.
+     *
+     * @param projectName Name of the micro gateway project.
+     * @throws IOException Error occurred while creating target directory structure.
+     */
+    private void initTarget(String projectName) throws IOException {
+        String projectDir = GatewayCmdUtils.getProjectDirectoryPath(projectName);
+        String targetDirPath = projectDir + File.separator + GatewayCliConstants.PROJECT_TARGET_DIR;
+        GatewayCmdUtils.createDirectory(targetDirPath, true);
+
+        String targetGenDir = targetDirPath + File.separator + GatewayCliConstants.PROJECT_GEN_DIR;
+        GatewayCmdUtils.createDirectory(targetGenDir, true);
     }
 }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
@@ -105,7 +105,7 @@ public class BuildCmd implements GatewayLauncherCmd {
             GatewayCmdUtils
                     .createGenDirectoryStructure(GatewayCmdUtils.getProjectTargetGenDirectoryPath(projectName));
             policyGenerator.generate(GatewayCmdUtils.getProjectGenSrcDirectoryPath(projectName) + File.separator
-                    + GatewayCliConstants.POLICY_DIR, projectName);
+                    + GatewayCliConstants.GEN_POLICIES_DIR, projectName);
             GatewayCmdUtils.copyAndReplaceFolder(GatewayCmdUtils.getProjectInterceptorsDirectoryPath(projectName),
                     GatewayCmdUtils.getProjectGenSrcInterceptorsDirectoryPath(projectName));
             GatewayCmdUtils.copyFolder(GatewayCmdUtils.getProjectDirectoryPath(projectName) + File.separator
@@ -146,7 +146,6 @@ public class BuildCmd implements GatewayLauncherCmd {
     //todo: implement this method properly
     private void init(String projectName, String configPath, String deploymentConfig) {
         try {
-
             Path configurationFile = Paths.get(configPath);
             if (Files.exists(configurationFile)) {
                 Config config = TOMLConfigParser.parse(configPath, Config.class);

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GatewayCliConstants.java
@@ -51,7 +51,6 @@ public class GatewayCliConstants {
     public static final String CLI_GATEWAY = "gateway";
     public static final String CLI_BALO = "balo";
     public static final String CLI_BRE = "bre";
-    public static final String POLICY_DIR = "policies";
     public static final String EXTENSION_ZIP = ".zip";
     public static final String EXTENSION_JAR = ".jar";
     public static final String EXTENSION_BAL = ".bal";
@@ -76,7 +75,8 @@ public class GatewayCliConstants {
     public static final String SYS_PROP_CURRENT_DIR = "current.dir";
     public static final String SYS_PROP_SECURITY = "security";
     public static final String MICRO_GW = "micro-gw";
-    
+    public static final String KEEP_FILE = ".keep";
+
     public static final String LOGGING_PROPERTIES_FILENAME = "logging.properties";
     public static final Pattern SYS_PROP_PATTERN = Pattern.compile("\\$\\{([^}]*)}");
 

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -693,9 +693,11 @@ public class GatewayCmdUtils {
         if (!dir.exists() && !dir.isDirectory()) {
             boolean created = dir.mkdir();
             if (created) {
-                logger.trace("Directory: {} created. ", path);
+                logger.debug("Directory: {} created. ", path);
             } else {
-                throw new CLIInternalException("Failed to create directory: " + path);
+                String errMsg = "Failed to create directory: " + path;
+                logger.error(errMsg);
+                throw new CLIInternalException(errMsg);
             }
         }
 
@@ -717,16 +719,20 @@ public class GatewayCmdUtils {
         if (overwrite && file.exists() && file.isFile()) {
             boolean isDeleted = file.delete();
             if (!isDeleted) {
-                throw new CLIInternalException("Failed to overwrite file: " + filePath);
+                String errMsg = "Failed to overwrite file: " + filePath;
+                logger.error(errMsg);
+                throw new CLIInternalException(errMsg);
             }
         }
 
         if (!file.exists() && !file.isFile()) {
             boolean isCreated = file.createNewFile();
             if (isCreated) {
-                logger.trace("File: {} created.", filePath);
+                logger.debug("File: {} created.", filePath);
             } else {
-                throw new CLIInternalException("Failed to create file: " + filePath);
+                String errMsg = "Failed to create file: " + filePath;
+                logger.error(errMsg);
+                throw new CLIInternalException(errMsg);
             }
         }
 
@@ -741,8 +747,7 @@ public class GatewayCmdUtils {
      * @throws IOException error while writing content to file
      */
     public static void writeContent(String content, File file) throws IOException {
-        FileWriter writer = null;
-        writer = new FileWriter(file);
+        FileWriter writer = new FileWriter(file);
         writer.write(content);
         writer.flush();
     }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -259,6 +259,7 @@ public class GatewayCmdUtils {
 
         String interceptorsPath = projectDir + File.separator + GatewayCliConstants.PROJECT_INTERCEPTORS_DIR;
         createDirectory(interceptorsPath, false);
+        createFile(interceptorsPath, GatewayCliConstants.KEEP_FILE, true);
 
         String extensionsPath = projectDir + File.separator + GatewayCliConstants.PROJECT_EXTENSIONS_DIR;
         createDirectory(extensionsPath, false);
@@ -281,7 +282,7 @@ public class GatewayCmdUtils {
                 getResourceFolderLocation() + File.separator + GatewayCliConstants.PROJECT_SERVICES_DIR;
         copyFolder(resourceServicesDirectory, projectServicesDirectory);
 
-        createFileIfNotExist(projectDir.getPath(), GatewayCliConstants.PROJECT_POLICIES_FILE);
+        createFile(projectDir.getPath(), GatewayCliConstants.PROJECT_POLICIES_FILE, true);
 
         String policyResPath = getDefinitionsLocation() + File.separator + GatewayCliConstants.GW_DIST_POLICIES_FILE;
         File policyResFile = new File(policyResPath);
@@ -687,7 +688,8 @@ public class GatewayCmdUtils {
      * @param path folder path
      * @param overwrite if `true` existing directory will be removed
      *                  and new directory will be created in {@code path}.
-     * @return File object for the created folder
+     * @return created directory
+     * @throws IOException Failed delete or create the directory in {@code path}
      */
     public static File createDirectory(String path, boolean overwrite) throws IOException {
         File dir = new File(path);
@@ -708,6 +710,37 @@ public class GatewayCmdUtils {
     }
 
     /**
+     * Create new file in a given location.
+     *
+     * @param path location of the new file.
+     * @param overwrite if `true` existing file with the same name will be replaced.
+     * @param fileName name of the new file.
+     * @return created file
+     * @throws IOException Failed delete or create the file in {@code path}
+     */
+    public static File createFile(String path, String fileName, boolean overwrite) throws IOException {
+        String filePath = path + File.separator + fileName;
+        File file = new File(filePath);
+        if (overwrite && file.exists() && file.isFile()) {
+            boolean isDeleted = file.delete();
+            if (!isDeleted) {
+                throw new CLIInternalException("Failed to overwrite file: " + filePath);
+            }
+        }
+
+        if (!file.exists() && !file.isFile()) {
+            boolean isCreated = file.createNewFile();
+            if (isCreated) {
+                logger.trace("File: {} created.", filePath);
+            } else {
+                throw new CLIInternalException("Failed to create file: " + filePath);
+            }
+        }
+
+        return file;
+    }
+
+    /**
      * Write content to a specified file
      *
      * @param content content to be written
@@ -719,31 +752,6 @@ public class GatewayCmdUtils {
         writer = new FileWriter(file);
         writer.write(content);
         writer.flush();
-    }
-
-    /**
-     * Creates file if not exist
-     *
-     * @param path     folder path
-     * @param fileName name of the file
-     */
-    private static void createFileIfNotExist(String path, String fileName) {
-        String filePath = path + File.separator + fileName;
-        File file = new File(filePath);
-        if (!file.exists()) {
-            try {
-                boolean created = file.createNewFile();
-                if (created) {
-                    logger.trace("File: {} created. ", path);
-                } else {
-                    logger.error("Failed to create file: {} ", path);
-                    throw new CLIInternalException("Error occurred while setting up the workspace structure");
-                }
-            } catch (IOException e) {
-                logger.error("Failed to create file: {} ", path, e);
-                throw new CLIInternalException("Error occurred while setting up the workspace structure");
-            }
-        }
     }
 
     /**

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -264,13 +264,6 @@ public class GatewayCmdUtils {
         String extensionsPath = projectDir + File.separator + GatewayCliConstants.PROJECT_EXTENSIONS_DIR;
         createDirectory(extensionsPath, false);
 
-        String targetDirPath = projectDir + File.separator + GatewayCliConstants.PROJECT_TARGET_DIR;
-        createDirectory(targetDirPath, false);
-
-        String targetGenDirPath = projectDir + File.separator + GatewayCliConstants.PROJECT_TARGET_DIR + File.separator
-                + GatewayCliConstants.PROJECT_GEN_DIR;
-        createDirectory(targetGenDirPath, false);
-
         String confDirPath = projectDir + File.separator + GatewayCliConstants.PROJECT_CONF_DIR;
         createDirectory(confDirPath, false);
 

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -255,26 +255,26 @@ public class GatewayCmdUtils {
      * @param projectName name of the project
      */
     public static void createProjectStructure(String projectName) throws IOException {
-        File projectDir = createFolderIfNotExist(getUserDir() + File.separator + projectName);
+        File projectDir = createDirectory(getUserDir() + File.separator + projectName, false);
 
         String interceptorsPath = projectDir + File.separator + GatewayCliConstants.PROJECT_INTERCEPTORS_DIR;
-        createFolderIfNotExist(interceptorsPath);
+        createDirectory(interceptorsPath, false);
 
         String extensionsPath = projectDir + File.separator + GatewayCliConstants.PROJECT_EXTENSIONS_DIR;
-        createFolderIfNotExist(extensionsPath);
+        createDirectory(extensionsPath, false);
 
         String targetDirPath = projectDir + File.separator + GatewayCliConstants.PROJECT_TARGET_DIR;
-        createFolderIfNotExist(targetDirPath);
+        createDirectory(targetDirPath, false);
 
         String targetGenDirPath = projectDir + File.separator + GatewayCliConstants.PROJECT_TARGET_DIR + File.separator
                 + GatewayCliConstants.PROJECT_GEN_DIR;
-        createFolderIfNotExist(targetGenDirPath);
+        createDirectory(targetGenDirPath, false);
 
         String confDirPath = projectDir + File.separator + GatewayCliConstants.PROJECT_CONF_DIR;
-        createFolderIfNotExist(confDirPath);
+        createDirectory(confDirPath, false);
 
         String definitionsPath = projectDir + File.separator + GatewayCliConstants.PROJECT_API_DEFINITIONS_DIR;
-        createFolderIfNotExist(definitionsPath);
+        createDirectory(definitionsPath, false);
 
         String projectServicesDirectory = projectDir + File.separator + GatewayCliConstants.PROJECT_SERVICES_DIR;
         String resourceServicesDirectory =
@@ -397,7 +397,7 @@ public class GatewayCmdUtils {
      */
     public static void storeResourceHashesFileContent(String content, String projectName) throws IOException {
         String tempDirPath = getProjectTempFolderLocation(projectName);
-        createFolderIfNotExist(tempDirPath);
+        createDirectory(tempDirPath, false);
 
         String resourceHashesFileLocation = getResourceHashHolderFileLocation(projectName);
         File pathFile = new File(resourceHashesFileLocation);
@@ -685,20 +685,26 @@ public class GatewayCmdUtils {
      * Creates a new folder if not exists
      *
      * @param path folder path
+     * @param overwrite if `true` existing directory will be removed
+     *                  and new directory will be created in {@code path}.
      * @return File object for the created folder
      */
-    private static File createFolderIfNotExist(String path) {
-        File folder = new File(path);
-        if (!folder.exists() && !folder.isDirectory()) {
-            boolean created = folder.mkdir();
+    public static File createDirectory(String path, boolean overwrite) throws IOException {
+        File dir = new File(path);
+        if (overwrite && dir.exists() && dir.isDirectory()) {
+            FileUtils.deleteDirectory(dir);
+        }
+
+        if (!dir.exists() && !dir.isDirectory()) {
+            boolean created = dir.mkdir();
             if (created) {
                 logger.trace("Directory: {} created. ", path);
             } else {
-                logger.error("Failed to create directory: {} ", path);
-                throw new CLIInternalException("Error occurred while setting up the workspace structure");
+                throw new CLIInternalException("Failed to create directory: " + path);
             }
         }
-        return folder;
+
+        return dir;
     }
 
     /**
@@ -888,10 +894,10 @@ public class GatewayCmdUtils {
         FileUtils.deleteDirectory(new File(genDirPath));
         Files.createDirectory(genPath);
         String genSrcPath = genDirPath + File.separator + GatewayCliConstants.GEN_SRC_DIR;
-        createFolderIfNotExist(genSrcPath);
+        createDirectory(genSrcPath, false);
 
         String genPoliciesPath = genSrcPath + File.separator + GatewayCliConstants.GEN_POLICIES_DIR;
-        createFolderIfNotExist(genPoliciesPath);
+        createDirectory(genPoliciesPath, false);
     }
 
     /**


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
1. Creating target directory on initializing a project causes issues in CICD integration. Therefore target directory will be created at the build time of a project.
1. By default Interceptor directory of e mgw project is an empty directory. If such a project is committed into a VCS (git, svn, etc...) other devs building the same project will get build errors since empty directories doesn't get committed to VCS.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #714 
FIxes #715 

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
- MacOS

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
