### PR TITLE
Use all src in extensions dir for build

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
@@ -113,7 +113,7 @@ public class BuildCmd implements GatewayLauncherCmd {
                             + GatewayCliConstants.PROJECT_SERVICES_DIR);
             codeGenerator.generate(projectName, true);
 
-            //Initializing the ballerina project and creating .bal folder.
+            //Initializing the ballerina project and creating .ballerina folder.
             InitHandler.initialize(Paths.get(GatewayCmdUtils.getProjectTargetGenDirectoryPath(projectName)), null,
                     new ArrayList<>(), null);
         } catch (IOException e) {

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
@@ -101,15 +101,7 @@ public class CodeGenerator {
         genFiles.add(generateMainBal(serviceList));
         genFiles.add(generateCommonEndpoints());
         CodegenUtils.writeGeneratedSources(genFiles, Paths.get(projectSrcPath), overwrite);
-
-        GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getProjectExtensionsDirectoryPath(projectName)
-                        + File.separator + GatewayCliConstants.GW_DIST_EXTENSION_FILTER,
-                projectSrcPath + File.separator + GatewayCliConstants.GW_DIST_EXTENSION_FILTER);
-
-        GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getProjectExtensionsDirectoryPath(projectName)
-                        + File.separator + GatewayCliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION,
-                projectSrcPath + File.separator + GatewayCliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION);
-
+        GatewayCmdUtils.copyFolder(GatewayCmdUtils.getProjectExtensionsDirectoryPath(projectName), projectSrcPath);
     }
 
 
@@ -170,15 +162,7 @@ public class CodeGenerator {
         genFiles.add(generateOpenAPIJsonConstantsBal(serviceList));
         genFiles.add(generateCommonEndpoints());
         CodegenUtils.writeGeneratedSources(genFiles, Paths.get(projectSrcPath), overwrite);
-        GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getProjectExtensionsDirectoryPath(projectName)
-                        + File.separator + GatewayCliConstants.GW_DIST_EXTENSION_FILTER,
-                projectSrcPath + File.separator + GatewayCliConstants.GW_DIST_EXTENSION_FILTER);
-        GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getProjectExtensionsDirectoryPath(projectName)
-                        + File.separator + GatewayCliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION,
-                projectSrcPath + File.separator + GatewayCliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION);
-        GatewayCmdUtils.copyFilesToSources(GatewayCmdUtils.getProjectExtensionsDirectoryPath(projectName)
-                        + File.separator + GatewayCliConstants.GW_DIST_START_UP_EXTENSION,
-                projectSrcPath + File.separator + GatewayCliConstants.GW_DIST_START_UP_EXTENSION);
+        GatewayCmdUtils.copyFolder(GatewayCmdUtils.getProjectExtensionsDirectoryPath(projectName), projectSrcPath);
     }
 
     /**


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
If any custom extensions are provided inside project's extensions directory, those will be copied to target directory as sources for building the project. This make it possible to add additional filters to a specific project. However to make this useful, user will have to update the listeners.bal in TOOLKIT resources.
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #764

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
- MacOS
- 3.0.2-SNAPSHOT toolkit
- 3.0.1 runtime

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
