### PR TITLE
Add CLI message for distribution initialization

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/ToolkitLibExtractionUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/ToolkitLibExtractionUtils.java
@@ -23,6 +23,7 @@ import org.wso2.apimgt.gateway.cli.exception.CLIInternalException;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -31,6 +32,7 @@ import java.nio.file.Paths;
  */
 public class ToolkitLibExtractionUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(ToolkitLibExtractionUtils.class);
+    private static final PrintStream OUT = System.out;
 
     /**
      * Extracts the platform and runtime and copy related jars and balos to extracted runtime and platform.
@@ -54,6 +56,7 @@ public class ToolkitLibExtractionUtils {
     private static void extractBallerinaDist(String destination, String libPath, String birPath, String breLibPath,
                                              Boolean isAddToClasspath) throws IOException {
         if (!Files.exists(Paths.get(destination))) {
+            OUT.println("Initializing Toolkit...");
             ZipUtils.unzip(destination + CliConstants.EXTENSION_ZIP, destination,
                     isAddToClasspath);
 

--- a/components/micro-gateway-tools/src/main/go/tools/distribution.go
+++ b/components/micro-gateway-tools/src/main/go/tools/distribution.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+    "fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -19,6 +20,7 @@ func main() {
 	}
 
 	if _, existsErr := os.Stat(destPath); os.IsNotExist(existsErr) {
+	    fmt.Println("Initializing Runtime...")
 		err := util.Unzip(runtimePath, destPath)
 		if err != nil {
 			log.Fatal(err)

--- a/distribution/resources/bin/gateway
+++ b/distribution/resources/bin/gateway
@@ -89,7 +89,7 @@ fi
 
 # Extract ballerina runtime
 if [ ! -d "$GWHOME/runtime" ]; then
-    $PRGDIR/tools
+    $PRGDIR/tools 2>&1 | tee -a $GWHOME/logs/microgateway.log
     if [ $? -eq 0 ]; then
         cp $GWHOME/lib/gateway/*.jar $GWHOME/runtime/bre/lib/
     fi
@@ -111,7 +111,7 @@ if [ "$CMD" = "start" ]; then
   rm -f file $GWHOME/bin/gateway.pid
   # using nohup sh to avoid erros in solaris OS.TODO
   nohup $SHELL <<EOF &
-    $BALLERINA_HOME/bin/ballerina run $args --api.usage.data.path=$GWHOME/api-usage-data --b7a.http.accesslog.path=$GWHOME/logs/access_logs --b7a.config.file=$GWHOME/conf/micro-gw.conf 2>&1  | tee -a $GWHOME/logs/microgateway.log
+    $BALLERINA_HOME/bin/ballerina run $args --api.usage.data.path=$GWHOME/api-usage-data --b7a.http.accesslog.path=$GWHOME/logs/access_logs --b7a.config.file=$GWHOME/conf/micro-gw.conf 2>&1 | tee -a $GWHOME/logs/microgateway.log
 EOF
   SESS_PID=$!
   #getting the process id of the child process which spawn by the parent process
@@ -152,7 +152,7 @@ elif [ "$CMD" = "restart" ]; then
   rm -f file $GWHOME/bin/gateway.pid
   # using nohup sh to avoid erros in solaris OS.TODO
   nohup $SHELL <<EOF &
-   $BALLERINA_HOME/bin/ballerina run $args --api.usage.data.path=$GWHOME/api-usage-data --b7a.http.accesslog.path=$GWHOME/logs/access_logs --b7a.config.file=$GWHOME/conf/micro-gw.conf 2>&1  | tee -a $GWHOME/logs/microgateway.log
+   $BALLERINA_HOME/bin/ballerina run $args --api.usage.data.path=$GWHOME/api-usage-data --b7a.http.accesslog.path=$GWHOME/logs/access_logs --b7a.config.file=$GWHOME/conf/micro-gw.conf 2>&1 | tee -a $GWHOME/logs/microgateway.log
 EOF
   SESS_PID=$!
   PROCESS_ID=""
@@ -174,5 +174,5 @@ EOF
 fi
 
 # run the balx created for ${label} APIs and redirect stderr to stdout and append stdout to $GWHOME/logs/microgateway.log
-$BALLERINA_HOME/bin/ballerina run  "$@" --api.usage.data.path=$GWHOME/api-usage-data --b7a.http.accesslog.path=$GWHOME/logs/access_logs --b7a.config.file=$GWHOME/conf/micro-gw.conf 2>&1  | tee -a $GWHOME/logs/microgateway.log
+$BALLERINA_HOME/bin/ballerina run  "$@" --api.usage.data.path=$GWHOME/api-usage-data --b7a.http.accesslog.path=$GWHOME/logs/access_logs --b7a.config.file=$GWHOME/conf/micro-gw.conf 2>&1 | tee -a $GWHOME/logs/microgateway.log
 

--- a/distribution/resources/bin/gateway.bat
+++ b/distribution/resources/bin/gateway.bat
@@ -55,6 +55,7 @@ if "%isInvalidPath%"=="T" (
 
 REM Extract ballerina runtime
 if not exist %GW_HOME%\runtime\ (
+    REM TODO: Evaluate the use of powershell `tee` here
     call "%PRGDIR%\tools.exe"
     if ERRORLEVEL 0 (
         xcopy /y "%GWHOME%\lib\gateway\*.jar" "%GWHOME%\runtime\bre\lib\" >nul


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
First run of gateway and toolkit commands take some time due to dist initialization steps (ballerina installation). This can cause confusion in low performing hardwares. We can avoid this confusion by providing a message saying that distribution is initializing. This message will be shown only on first run.

Runtime:
<img width="590" alt="image" src="https://user-images.githubusercontent.com/2655553/65135320-58cc3800-da23-11e9-997d-b2b3a37fc36f.png">

Toolkit:
<img width="473" alt="image" src="https://user-images.githubusercontent.com/2655553/65135495-a9439580-da23-11e9-9889-87f8e01c0dbd.png">
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #645 

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
MacOS

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
