### PR TITLE
Avoid use of extenal ballerina installation

### DIFF
--- a/distribution/resources/bin/gateway.bat
+++ b/distribution/resources/bin/gateway.bat
@@ -44,9 +44,7 @@ if %verbose%==T echo GWHOME environment variable is set to %GWHOME%
 REM Check if path to runtime executable is available
 set last=""
 for %%a in (%*) do set last=%%a
-echo %last%
 if %last%=="" set isInvalidPath=T
-echo %last%
 if not exist %last% set isInvalidPath=T
 if "%isInvalidPath%"=="T" (
 	echo Path to executable balx file is invalid

--- a/distribution/resources/bin/micro-gw
+++ b/distribution/resources/bin/micro-gw
@@ -254,28 +254,25 @@ fi
 
 #execute build command
 if [ "$IS_BUILD_COMMAND" = true ] && [ "$CMD_PRO_NAME_VAL" != "" ] && [ "$MICRO_GW_PROJECT_DIR" != "" ]; then
-
-  # ----- Execute The Build Command without --compiled flag (1st phase) -----------------------------------------
-
-  $JAVACMD \
-    -Xms256m -Xmx1024m \
-    -XX:+HeapDumpOnOutOfMemoryError \
-    -XX:HeapDumpPath="$MICROGW_HOME/heap-dump.hprof" \
-    $JAVA_OPTS \
-    -classpath "$CLI_CLASSPATH" \
-    -Djava.security.egd=file:/dev/./urandom \
-    -Dballerina.home=$BALLERINA_HOME \
-    -Djava.util.logging.config.class="org.wso2.apimgt.gateway.cli.logging.CLILogConfigReader" \
-    -Djava.util.logging.manager="org.wso2.apimgt.gateway.cli.logging.CLILogManager" \
-    -Dfile.encoding=UTF8 \
-    -Dtemplates.dir.path="$MICROGW_HOME/resources/templates" \
-    -Dcli.home=$MICROGW_HOME \
-    -DVERBOSE_ENABLED=$VERBOSE_ENABLED \
-    org.wso2.apimgt.gateway.cli.cmd.Main "$@"
+    # ----- Execute the micro-gw build command (1st phase) -----
+    $JAVACMD \
+        -Xms256m -Xmx1024m \
+        -XX:+HeapDumpOnOutOfMemoryError \
+        -XX:HeapDumpPath="$MICROGW_HOME/heap-dump.hprof" \
+        $JAVA_OPTS \
+        -classpath "$CLI_CLASSPATH" \
+        -Djava.security.egd=file:/dev/./urandom \
+        -Dballerina.home=$BALLERINA_HOME \
+        -Djava.util.logging.config.class="org.wso2.apimgt.gateway.cli.logging.CLILogConfigReader" \
+        -Djava.util.logging.manager="org.wso2.apimgt.gateway.cli.logging.CLILogManager" \
+        -Dfile.encoding=UTF8 \
+        -Dtemplates.dir.path="$MICROGW_HOME/resources/templates" \
+        -Dcli.home=$MICROGW_HOME \
+        -DVERBOSE_ENABLED=$VERBOSE_ENABLED \
+        org.wso2.apimgt.gateway.cli.cmd.Main "$@"
 
     exit_code=$?
-    if [ $exit_code -eq 0 ]
-    then
+    if [ $exit_code -eq 0 ]; then
         # Ballerina path is updated as ballerina platform is extracted
         BALLERINA_HOME="$MICROGW_HOME/lib/platform"
         export BALLERINA_HOME=$BALLERINA_HOME
@@ -289,7 +286,6 @@ if [ "$IS_BUILD_COMMAND" = true ] && [ "$CMD_PRO_NAME_VAL" != "" ] && [ "$MICRO_
         if $cygwin; then
             [ -n "$BALLERINA_HOME" ] && BALLERINA_HOME=`cygpath --unix "$BALLERINA_HOME"`
             BALLERINA_HOME=`cygpath --absolute --windows "$BALLERINA_HOME"`
-
         fi
 
         update_cli_classpath
@@ -312,25 +308,23 @@ if [ "$IS_BUILD_COMMAND" = true ] && [ "$CMD_PRO_NAME_VAL" != "" ] && [ "$MICRO_
                 printf "${RED}${BOLD}BUILD FAILED${NC}\n"
             fi
         popd > /dev/null
-     else
-        exit $exit_code
-     fi
+    fi
+    exit $exit_code
 else
-  $JAVACMD \
-      -Xms256m -Xmx1024m \
-      -XX:+HeapDumpOnOutOfMemoryError \
-      -XX:HeapDumpPath="$MICROGW_HOME/heap-dump.hprof" \
-      $JAVA_OPTS \
-      -classpath "$CLI_CLASSPATH" \
-      -Djava.security.egd=file:/dev/./urandom \
-      -Dballerina.home=$BALLERINA_HOME \
-      -Djava.util.logging.config.class="org.wso2.apimgt.gateway.cli.logging.CLILogConfigReader" \
-      -Djava.util.logging.manager="org.wso2.apimgt.gateway.cli.logging.CLILogManager" \
-      -Dfile.encoding=UTF8 \
-      -Dtemplates.dir.path="$MICROGW_HOME/resources/templates" \
-      -Dcli.home=$MICROGW_HOME \
-      -DVERBOSE_ENABLED=$VERBOSE_ENABLED \
-      org.wso2.apimgt.gateway.cli.cmd.Main "$@"
-
+    $JAVACMD \
+        -Xms256m -Xmx1024m \
+        -XX:+HeapDumpOnOutOfMemoryError \
+        -XX:HeapDumpPath="$MICROGW_HOME/heap-dump.hprof" \
+        $JAVA_OPTS \
+        -classpath "$CLI_CLASSPATH" \
+        -Djava.security.egd=file:/dev/./urandom \
+        -Dballerina.home=$BALLERINA_HOME \
+        -Djava.util.logging.config.class="org.wso2.apimgt.gateway.cli.logging.CLILogConfigReader" \
+        -Djava.util.logging.manager="org.wso2.apimgt.gateway.cli.logging.CLILogManager" \
+        -Dfile.encoding=UTF8 \
+        -Dtemplates.dir.path="$MICROGW_HOME/resources/templates" \
+        -Dcli.home=$MICROGW_HOME \
+        -DVERBOSE_ENABLED=$VERBOSE_ENABLED \
+        org.wso2.apimgt.gateway.cli.cmd.Main "$@"
 fi
 

--- a/distribution/resources/bin/micro-gw.bat
+++ b/distribution/resources/bin/micro-gw.bat
@@ -51,7 +51,7 @@ REM set BALLERINA_HOME
 SET BALLERINA_HOME=%MICROGW_HOME%\lib\platform
 if NOT EXIST %BALLERINA_HOME% SET BALLERINA_HOME="%MICROGW_HOME%\lib"
 
-SET PATH=%PATH%;%BALLERINA_HOME%\bin\
+SET PATH=%BALLERINA_HOME%\bin\;%PATH%
 if %verbose%==T ECHO BALLERINA_HOME environment variable is set to %BALLERINA_HOME%
 if %verbose%==T ECHO MICROGW_HOME environment variable is set to %MICROGW_HOME%
 
@@ -125,9 +125,8 @@ goto :end
             if ERRORLEVEL 1 (EXIT /B %ERRORLEVEL%)
             REM Set ballerina home again as the platform is extracted at this point.
             SET BALLERINA_HOME=%MICROGW_HOME%\lib\platform
-            SET PATH=%PATH%;%BALLERINA_HOME%\bin\
+            SET PATH=%BALLERINA_HOME%\bin\;%PATH%
             if %verbose%==T ECHO BALLERINA_HOME environment variable is set to %BALLERINA_HOME%
-            ECHO MICRO_GW_PROJECT_DIR:  "%CURRENT_D%"
             PUSHD "%CURRENT_D%"
             PUSHD "%MICRO_GW_PROJECT_DIR%\target\gen"
                 if %verbose%==T ECHO current dir %CD%


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
If ballerina is already installed in host machine, that version of ballerina was used to execute ballerina commands ignoring the embedded ballerina version. This PR will fix it.
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #810 

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
MacOs
Windows server 2012 R2

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
