### PR TITLE
Fix #827 - NPE when open API used without wso2 extensions

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
@@ -88,7 +88,7 @@ public class BuildCmd implements GatewayLauncherCmd {
                 throw new CLIRuntimeException("Project " + projectName + " does not exist.");
             }
             // Some times user might run the command from different directory other than the directory where the project
-            // exists. In those cases we need to ask the users to
+            // exists. In those cases we need to ask the users to run the command in directory where project directory exists
             if (!projectAbsolutePath.equalsIgnoreCase(projectCanonicalPath)) {
                 throw new CLIRuntimeException(
                         "Current directory: '" + GatewayCmdUtils.getUserDir() + "' should have a project with name: '"

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
@@ -80,23 +80,33 @@ public class BuildCmd implements GatewayLauncherCmd {
 
         String projectName = this.projectName.replaceAll("[/\\\\]", "");
         File projectLocation = new File(GatewayCmdUtils.getProjectDirectoryPath(projectName));
-
-        if (!projectLocation.exists()) {
-            throw new CLIRuntimeException("Project " + projectName + " does not exist.");
-        }
-        //extract the ballerina platform and runtime
-        ToolkitLibExtractionUtils.extractPlatformAndRuntime();
-
-        String importedAPIDefLocation = GatewayCmdUtils.getProjectGenAPIDefinitionPath(projectName);
-        String addedAPIDefLocation = GatewayCmdUtils.getProjectAPIFilesDirectoryPath(projectName);
-        boolean isImportedAPIsAvailable = checkFolderContentAvailablity(importedAPIDefLocation);
-        boolean isAddedAPIsAvailable = checkFolderContentAvailablity(addedAPIDefLocation);
-
-        if (!isImportedAPIsAvailable && !isAddedAPIsAvailable) {
-            throw new CLIRuntimeException("Nothing to build. API definitions does not exist.");
-        }
-
         try {
+            String projectCanonicalPath = projectLocation.getCanonicalPath();
+            String projectAbsolutePath = projectLocation.getAbsolutePath();
+
+            if (!projectLocation.exists()) {
+                throw new CLIRuntimeException("Project " + projectName + " does not exist.");
+            }
+            // Some times user might run the command from different directory other than the directory where the project
+            // exists. In those cases we need to ask the users to
+            if (!projectAbsolutePath.equalsIgnoreCase(projectCanonicalPath)) {
+                throw new CLIRuntimeException(
+                        "Current directory: '" + GatewayCmdUtils.getUserDir() + "' should have a project with name: '"
+                                + projectName
+                                + "'. Execute the build command from the directory where the project is initialized");
+            }
+
+            //extract the ballerina platform and runtime
+            ToolkitLibExtractionUtils.extractPlatformAndRuntime();
+
+            String importedAPIDefLocation = GatewayCmdUtils.getProjectGenAPIDefinitionPath(projectName);
+            String addedAPIDefLocation = GatewayCmdUtils.getProjectAPIFilesDirectoryPath(projectName);
+            boolean isImportedAPIsAvailable = checkFolderContentAvailablity(importedAPIDefLocation);
+            boolean isAddedAPIsAvailable = checkFolderContentAvailablity(addedAPIDefLocation);
+
+            if (!isImportedAPIsAvailable && !isAddedAPIsAvailable) {
+                throw new CLIRuntimeException("Nothing to build. API definitions does not exist.");
+            }
             String toolkitConfigPath = GatewayCmdUtils.getMainConfigLocation();
             init(projectName, toolkitConfigPath, deploymentConfigPath);
 

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/OpenAPICodegenUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/OpenAPICodegenUtils.java
@@ -421,7 +421,13 @@ public class OpenAPICodegenUtils {
      * @param openApiFilePath OpenAPI definition file
      */
     private static void validateBasepath(OpenAPI openAPI, String openApiFilePath) {
-        String basePath = (String) openAPI.getExtensions().get(OpenAPIConstants.BASEPATH);
+        Map<String, Object> openAPIExtensions = openAPI.getExtensions();
+        if (openAPIExtensions == null) {
+            throw new CLIRuntimeException(" At least '" + OpenAPIConstants.BASEPATH + "' property and '"
+                    + OpenAPIConstants.PRODUCTION_ENDPOINTS + "' property should present in the open API "
+                    + "definition: '" + openApiFilePath + "'.");
+        }
+        String basePath = (String) openAPIExtensions.get(OpenAPIConstants.BASEPATH);
         if (basePath == null || basePath.isEmpty()) {
             throw new CLIRuntimeException("'" + OpenAPIConstants.BASEPATH + "' property is not included in openAPI " +
                     "definition '" + openApiFilePath + "'.");


### PR DESCRIPTION
### Purpose
This fixes the NPE when standard openAPI is used. This will give the error message to the user to inform to add minimum extensions to the swagger.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #827

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
