### PR TITLE
Fix #847 - Support open API without extensions

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/CliConstants.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/CliConstants.java
@@ -92,4 +92,9 @@ public class CliConstants {
     public static final String API_SWAGGER = "swagger.json";
     public static final String API_OPENAPI_YAML = "openAPI.yaml";
     public static final String REST_API_V1_PREFIX = "v1.";
+
+    public static final String JSON_EXTENSION = ".json";
+    public static final String YAML_EXTENSION = ".yaml";
+
+    public static final String WARN_LOG_PATTERN = "WARN: ";
 }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/template/service/BallerinaOperation.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/template/service/BallerinaOperation.java
@@ -90,6 +90,8 @@ public class BallerinaOperation implements BallerinaOpenAPIObject<BallerinaOpera
         this.basicAuth = OpenAPICodegenUtils.getMgwResourceBasicAuth(operation);
         //to set resource level scopes in dev-first approach
         this.scope = OpenAPICodegenUtils.getMgwResourceScope(operation);
+        //set resource level endpoint configuration
+        setEpConfigDTO(operation);
         Map<String, Object> extensions = operation.getExtensions();
         if (extensions != null) {
             Optional<Object> resourceTier = Optional.ofNullable(extensions.get(X_THROTTLING_TIER));
@@ -102,8 +104,6 @@ public class BallerinaOperation implements BallerinaOpenAPIObject<BallerinaOpera
                     this.isSecured = false;
                 }
             });
-            //set resource level endpoint configuration
-            setEpConfigDTO(operation);
             //set resource level request interceptors
             Optional<Object> requestInterceptor = Optional.ofNullable(extensions
                     .get(OpenAPIConstants.REQUEST_INTERCEPTOR));

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/template/service/BallerinaPath.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/template/service/BallerinaPath.java
@@ -16,12 +16,15 @@
 
 package org.wso2.apimgt.gateway.cli.model.template.service;
 
+import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.servers.Server;
 import org.wso2.apimgt.gateway.cli.exception.BallerinaServiceGenException;
 import org.wso2.apimgt.gateway.cli.model.rest.ext.ExtendedAPI;
 
 import java.util.AbstractMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -45,36 +48,43 @@ public class BallerinaPath implements BallerinaOpenAPIObject<BallerinaPath, Path
         // Swagger PathItem object doesn't provide a iterable structure for operations
         // Therefore we have to manually check if each http verb exists
         if (item.getGet() != null) {
+            setServersToOperationLevel(item.getGet(), item.getServers());
             operation = new BallerinaOperation().buildContext(item.getGet(), api);
             entry = new AbstractMap.SimpleEntry<>("get", operation);
             operations.add(entry);
         }
         if (item.getPut() != null) {
+            setServersToOperationLevel(item.getPut(), item.getServers());
             operation = new BallerinaOperation().buildContext(item.getPut(), api);
             entry = new AbstractMap.SimpleEntry<>("put", operation);
             operations.add(entry);
         }
         if (item.getPost() != null) {
+            setServersToOperationLevel(item.getPost(), item.getServers());
             operation = new BallerinaOperation().buildContext(item.getPost(), api);
             entry = new AbstractMap.SimpleEntry<>("post", operation);
             operations.add(entry);
         }
         if (item.getDelete() != null) {
+            setServersToOperationLevel(item.getDelete(), item.getServers());
             operation = new BallerinaOperation().buildContext(item.getDelete(), api);
             entry = new AbstractMap.SimpleEntry<>("delete", operation);
             operations.add(entry);
         }
         if (item.getOptions() != null) {
+            setServersToOperationLevel(item.getOptions(), item.getServers());
             operation = new BallerinaOperation().buildContext(item.getOptions(), api);
             entry = new AbstractMap.SimpleEntry<>("options", operation);
             operations.add(entry);
         }
         if (item.getHead() != null) {
+            setServersToOperationLevel(item.getHead(), item.getServers());
             operation = new BallerinaOperation().buildContext(item.getHead(), api);
             entry = new AbstractMap.SimpleEntry<>("head", operation);
             operations.add(entry);
         }
         if (item.getPatch() != null) {
+            setServersToOperationLevel(item.getPatch(), item.getServers());
             operation = new BallerinaOperation().buildContext(item.getPatch(), api);
             entry = new AbstractMap.SimpleEntry<>("patch", operation);
             operations.add(entry);
@@ -95,5 +105,19 @@ public class BallerinaPath implements BallerinaOpenAPIObject<BallerinaPath, Path
 
     public Set<Map.Entry<String, BallerinaOperation>> getOperations() {
         return operations;
+    }
+
+
+    /**
+     * Method to set the Path level server opeartions to operation level servers,
+     * if operation level servers are not present
+     *
+     * @param operation {@link Operation} The current considered operation object
+     * @param pathLevelServers list if server objects defined in the open API PAth level
+     */
+    private void setServersToOperationLevel(Operation operation, List<Server> pathLevelServers) {
+        if (operation.getServers() == null && pathLevelServers != null) {
+            operation.setServers(pathLevelServers);
+        }
     }
 }


### PR DESCRIPTION
### Purpose
Standard open API without wso2 specific vendor extensions should be allow to create micro gateway projects.
From the PR we supports 
Open API v3 - servers object to get the production endpoints and base path
Open API v2 - scheme, host, base path objects to get the base path and production endpoints

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #847

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
