### PR TITLE
Fix #837 - Subscription validation configurable

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
@@ -220,6 +220,7 @@
  public const string CERTIFICATE_ALIAS = "certificateAlias";
  public const string TRUST_STORE_PATH = "trustStorePath";
  public const string TRUST_STORE_PASSWORD = "trustStorePassword";
+ public const string VALIDATE_SUBSCRIPTION = "validateSubscription";
 
  public const string CACHING_ID = "caching";
  public const string TOKEN_CACHE_ENABLED = "enabled";

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/subscription_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/subscription_filter.bal
@@ -24,11 +24,13 @@ import ballerina/runtime;
 // OAuthnFilter will handle the subscription validation as well.
 public type SubscriptionFilter object {
 
+    public boolean subsciptionEnabled = getConfigBooleanValue(JWT_INSTANCE_ID, VALIDATE_SUBSCRIPTION, false);
+
     public function filterRequest(http:Caller caller, http:Request request, @tainted http:FilterContext filterContext)
                         returns boolean {
         int startingTime = getCurrentTime();
         checkOrSetMessageID(filterContext);
-        boolean result = doSubscriptionFilterRequest(caller, request, filterContext);
+        boolean result = doSubscriptionFilterRequest(caller, request, filterContext, self.subsciptionEnabled);
         setLatency(startingTime, filterContext, SECURITY_LATENCY_SUBS);
         return result;
     }
@@ -40,15 +42,15 @@ public type SubscriptionFilter object {
     }
 };
 
-function doSubscriptionFilterRequest(http:Caller caller, http:Request request, @tainted http:FilterContext filterContext)
-             returns boolean {
+function doSubscriptionFilterRequest(http:Caller caller, http:Request request,
+        @tainted http:FilterContext filterContext, boolean subsciptionEnabled) returns boolean {
     runtime:InvocationContext invocationContext = runtime:getInvocationContext();
     runtime:AuthenticationContext? authContext= runtime:getInvocationContext()?.authenticationContext;
     if (authContext is runtime:AuthenticationContext) {
         string? authScheme = authContext?.scheme;
-        if(authScheme is string) {
+        if (authScheme is string) {
             printDebug(KEY_SUBSCRIPTION_FILTER, "Auth scheme: " + authScheme);
-            if (authScheme != AUTH_SCHEME_JWT){
+            if (authScheme != AUTH_SCHEME_JWT) {
                 printDebug(KEY_SUBSCRIPTION_FILTER, "Skipping since auth scheme != jwt.");
                 return true;
             }
@@ -60,31 +62,32 @@ function doSubscriptionFilterRequest(http:Caller caller, http:Request request, @
 
         string? jwtToken = authContext?.authToken;
         string currentAPIContext = getContext(filterContext);
+        boolean subscriptionValidated = false;
         AuthenticationContext authenticationContext = {};
         json|error decodedPayload = {};
-        if(jwtToken is string) {
+        if (jwtToken is string) {
             var cachedJwt = trap <jwt:CachedJwt>jwtCache.get(jwtToken);
             if (cachedJwt is jwt:CachedJwt) {
                 printDebug(KEY_SUBSCRIPTION_FILTER, "jwt found from the jwt cache");
                 jwt:JwtPayload jwtPayload = cachedJwt.jwtPayload;
                 json payload = {};
-                if(payload is map<json>){
+                if (payload is map<json>) {
                     map<json>? customClaims = jwtPayload?.customClaims;
-                    if(customClaims is map<json>) {
-                        if(customClaims.hasKey(APPLICATION)) {
+                    if (customClaims is map<json>) {
+                        if (customClaims.hasKey(APPLICATION)) {
                             payload["application"] = customClaims[APPLICATION];
                         }
-                        if(customClaims.hasKey(SUBSCRIBED_APIS)) {
+                        if (customClaims.hasKey(SUBSCRIBED_APIS)) {
                             payload["subscribedAPIs"] = customClaims[SUBSCRIBED_APIS];
                         }
-                        if(customClaims.hasKey(CONSUMER_KEY)) {
+                        if (customClaims.hasKey(CONSUMER_KEY)) {
                             payload["consumerKey"] = customClaims[CONSUMER_KEY];
                         }
-                        if(customClaims.hasKey(KEY_TYPE)) {
+                        if (customClaims.hasKey(KEY_TYPE)) {
                             payload["keytype"] = customClaims[KEY_TYPE];
                         }
                     }
-                    if(jwtPayload?.sub is string) {
+                    if (jwtPayload?.sub is string) {
                         payload["sub"] = jwtPayload?.sub;
                     }
                     decodedPayload = payload;
@@ -107,105 +110,86 @@ function doSubscriptionFilterRequest(http:Caller caller, http:Request request, @
             if (decodedPayload is json) {
                 printTrace(KEY_SUBSCRIPTION_FILTER, "Decoded JWT payload: " + decodedPayload.toString());
                 json[] subscribedAPIList = [];
+                authenticationContext.apiKey = jwtToken;
+                authenticationContext.username = decodedPayload.sub.toString();
+                authenticationContext.callerToken = jwtToken;
+                json|error application = decodedPayload.application;
+                if (application is map<json>) {
+                    if (decodedPayload.application.id != null) {
+                        authenticationContext.applicationId = decodedPayload.application.id.toString();
+                    }
+                    if (decodedPayload.application.name != null) {
+                        authenticationContext.applicationName = decodedPayload.application.name.toString
+                        ();
+                    }
+                    if (decodedPayload.application.tier != null) {
+                        authenticationContext.applicationTier = decodedPayload.application.tier.toString
+                        ();
+                    }
+                    if (decodedPayload.application.owner != null) {
+                        authenticationContext.subscriber = decodedPayload.application.owner.toString();
+                    }
+                }
+                if (decodedPayload.consumerKey != null) {
+                    authenticationContext.consumerKey = decodedPayload.consumerKey.toString();
+                }
+                if (decodedPayload.keytype != null) {
+                    authenticationContext.keyType = decodedPayload.keytype.toString();
+                    invocationContext.attributes[KEY_TYPE_ATTR] = authenticationContext.keyType;
+                    printDebug(KEY_SUBSCRIPTION_FILTER, "Setting key type as " +
+                                                        authenticationContext.keyType);
+                }
                 json|error jsonSubscribedApis = decodedPayload.subscribedAPIs;
                 if (jsonSubscribedApis is json) {
                     printDebug(KEY_SUBSCRIPTION_FILTER, "subscribedAPIs claim found in the jwt");
-                    if(jsonSubscribedApis is json[]) {
+                    if (jsonSubscribedApis is json[]) {
                     subscribedAPIList = jsonSubscribedApis;
                     }
                     printDebug(KEY_SUBSCRIPTION_FILTER, "Subscribed APIs list : " + subscribedAPIList.toString());
                     APIConfiguration? apiConfig = apiConfigAnnotationMap[filterContext.getServiceName()];
                     int l = subscribedAPIList.length();
-                    if (l == 0){
-                        authenticationContext.authenticated = true;
-                        authenticationContext.apiKey = jwtToken;
-                        authenticationContext.username = decodedPayload.sub.toString();
-                        if (decodedPayload.application.id != null) {
-                            authenticationContext.applicationId = decodedPayload.application.id.toString();
-                        }
-                        if (decodedPayload.application.name != null) {
-                            authenticationContext.applicationName = decodedPayload.application.name.toString
-                            ();
-                        }
-                        if (decodedPayload.application.tier != null) {
-                            authenticationContext.applicationTier = decodedPayload.application.tier.toString
-                            ();
-                        }
-                        authenticationContext.subscriber = decodedPayload.application.owner.toString();
-                        authenticationContext.consumerKey = decodedPayload.consumerKey.toString();
-                        authenticationContext.keyType = decodedPayload.keytype.toString();
-                        invocationContext.attributes[KEY_TYPE_ATTR] = authenticationContext.
-                        keyType;
-                        invocationContext.attributes[AUTHENTICATION_CONTEXT] = authenticationContext;
-                        return true;
-                    }
                     int index = 0;
                     while (index < l) {
                         var subscription = subscribedAPIList[index];
                         string apiName="";
                         string apiVersion="";
-                        if(apiConfig is APIConfiguration){
+                        if (apiConfig is APIConfiguration) {
                             apiName= apiConfig.name;
                             apiVersion = apiConfig?.apiVersion;
                         }
-
                         if (subscription.name.toString() == apiName &&
                                             subscription.'version.toString() == apiVersion) {
                             printDebug(KEY_SUBSCRIPTION_FILTER, "Found a matching subscription with name:" +
                                     subscription.name.toString() + " version:" + subscription.'version.
                                     toString());
+                            subscriptionValidated = true;
                             authenticationContext.authenticated = true;
                             authenticationContext.tier = subscription.subscriptionTier.toString();
-                            authenticationContext.apiKey = jwtToken;
-                            authenticationContext.username = decodedPayload.sub.toString();
-                            authenticationContext.callerToken = jwtToken;
-                            authenticationContext.applicationId = decodedPayload.application.id.toString();
-                            authenticationContext.applicationName = decodedPayload.application.name.toString
-                            ();
-                            authenticationContext.applicationTier = decodedPayload.application.tier.toString
-                            ();
-                            authenticationContext.subscriber = decodedPayload.application.owner.toString();
-                            authenticationContext.consumerKey = decodedPayload.consumerKey.toString();
                             authenticationContext.apiTier = subscription.subscriptionTier.toString();
                             authenticationContext.apiPublisher = subscription.publisher.toString();
                             authenticationContext.subscriberTenantDomain = subscription
                             .subscriberTenantDomain.toString();
-                            authenticationContext.keyType = decodedPayload.keytype.toString();
-                            // setting keytype to invocationContext
-                            printDebug(KEY_SUBSCRIPTION_FILTER, "Setting key type as " +
-                                    authenticationContext.keyType);
-                            invocationContext.attributes[KEY_TYPE_ATTR] = authenticationContext
-                            .keyType;
                             invocationContext.attributes[AUTHENTICATION_CONTEXT] = authenticationContext;
                             printDebug(KEY_SUBSCRIPTION_FILTER, "Subscription validation success.");
                             return true;
                         }
                         index+=1;
-
                     }
-                    setErrorMessageToFilterContext(filterContext, API_AUTH_FORBIDDEN);
-                    sendErrorResponse(caller, request, <@untainted>filterContext);
-                    return false;
-                } else {
-                    authenticationContext.authenticated = true;
-                    authenticationContext.apiKey = jwtToken;
-                    authenticationContext.username = decodedPayload.sub.toString();
-                    if(decodedPayload.application != null) {
-                        if (decodedPayload.application.id != null) {
-                            authenticationContext.applicationId = decodedPayload.application.id.toString();
-                        }
-                        if (decodedPayload.application.name != null) {
-                            authenticationContext.applicationName = decodedPayload.application.name.toString
-                            ();
-                        }
-                        if (decodedPayload.application.tier != null) {
-                            authenticationContext.applicationTier = decodedPayload.application.tier.toString
-                            ();
-                        }
-                    }
-                    invocationContext.attributes[KEY_TYPE_ATTR] = authenticationContext.keyType;
                     invocationContext.attributes[AUTHENTICATION_CONTEXT] = authenticationContext;
-
+                    if (subsciptionEnabled && !subscriptionValidated) {
+                        setErrorMessageToFilterContext(filterContext, API_AUTH_FORBIDDEN);
+                        sendErrorResponse(caller, request, <@untainted>filterContext);
+                        return false;
+                    }
+                } else {
+                    printDebug(KEY_SUBSCRIPTION_FILTER, "subscribedAPIs claim not found in the jwt");
+                    if (subsciptionEnabled) {
+                        setErrorMessageToFilterContext(filterContext, API_AUTH_FORBIDDEN);
+                        sendErrorResponse(caller, request, <@untainted>filterContext);
+                        return false;
+                    }
+                    authenticationContext.authenticated = true;
+                    invocationContext.attributes[AUTHENTICATION_CONTEXT] = authenticationContext;
                     return true;
                 }
 

--- a/distribution/resources/conf/micro-gw.conf
+++ b/distribution/resources/conf/micro-gw.conf
@@ -24,6 +24,7 @@ timestampSkew=5000
 issuer="https://localhost:9443/oauth2/token"
 audience="http://org.wso2.apimgt/gateway"
 certificateAlias="wso2apim"
+validateSubscription=false
 
 
 [jwtConfig]


### PR DESCRIPTION
### Purpose
With this PR subscription validation can be made configurable for the jwt authentication.
We can use the following config of the micro-gw.conf

[jwtTokenConfig]
issuer="https://localhost:9443/oauth2/token"
audience="http://org.wso2.apimgt/gateway"
certificateAlias="wso2apim"
**validateSubscription=false**

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #837 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
