### PR TITLE
Fix #871 - Error when empty authorization header is provided

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/gateway/filters/authn_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/filters/authn_filter.bal
@@ -246,15 +246,14 @@ function doAuthnFilterRequest(http:Caller caller, http:Request request, http:Fil
                     return false;
                 }
 
-            }
-            else {
+            } else {
                 if (isCookie) {
-                    log:printError(<string>extractedToken.detail().message, err = extractedToken);
+                    log:printError(<string>extractedToken.reason(), err = extractedToken);
                     setErrorMessageToFilterContext(context, API_AUTH_INVALID_COOKIE);
                     sendErrorResponse(caller, request, untaint context);
                     return false;
                 } else {
-                    log:printError(<string>extractedToken.detail().message, err = extractedToken);
+                    log:printError(<string>extractedToken.reason(), err = extractedToken);
                     setErrorMessageToFilterContext(context, API_AUTH_MISSING_CREDENTIALS);
                     sendErrorResponse(caller, request, untaint context);
                     return false;


### PR DESCRIPTION
### Purpose
When sending requests with "Authorization" header with empty value it gives an error without sending the proper error response. This fixes that issue

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #871 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
