### PR TITLE
Fix issue in proxying with ssl bump and path parameters containing special characters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -404,7 +404,7 @@
     </build>
 
     <properties>
-        <ballerina.platform.version>0.990.5</ballerina.platform.version>
+        <ballerina.platform.version>0.990.6</ballerina.platform.version>
         <broker.version>0.970.5</broker.version>
         <assembly.plugin.version>2.5.2</assembly.plugin.version>
         <compiler.plugin.version>3.7.0</compiler.plugin.version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -33,18 +33,42 @@
         <dependency>
             <groupId>org.ballerinalang</groupId>
             <artifactId>ballerina-config</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-common</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.ballerinalang</groupId>
             <artifactId>ballerina-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-common</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.ballerinalang</groupId>
             <artifactId>ballerina-lang</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-common</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.ballerinalang</groupId>
             <artifactId>ballerina-builtin</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-common</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.ballerinalang</groupId>
@@ -101,11 +125,6 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
             <scope>test</scope>
         </dependency>
@@ -145,10 +164,26 @@
         <dependency>
             <groupId>io.ballerina.messaging</groupId>
             <artifactId>broker-launcher</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-buffer</artifactId>
+                </exclusion>
+            </exclusions>
             <version>0.970.5</version>
         </dependency>
-
-
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>${netty.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <version>${netty.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
### Purpose
This PR contains a ballerina patch version upgrade. Basically the upgrade contains two fixes.

1. When rest resource is defined line /pet/{petId} and if the request petId=1/1 then micro gateway sends a 404. Even encoding the path parameter does not works.
2. When squid proxy is used to connect with back end , and ssl bump is enabled in the squid proxy, then micro gateway requests the certificate of the proxy during the ssl handshake. This is due to an issue in the netty transport which was fixed in lates netty version. So the ballerina upgrade contains the netty version update as well. 

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #874 , #875

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
