### PR TITLE
Fix #879 #880 - Disbale cors by default and improve reset command

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/ImportCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/ImportCmd.java
@@ -284,9 +284,7 @@ public class ImportCmd implements GatewayLauncherCmd {
         //if all the operations are success, write new config to file
         if (isOverwriteRequired) {
             Config newConfig = new Config();
-            Client client = new Client();
-            client.setHttpRequestTimeout(1000000);
-            newConfig.setClient(client);
+            newConfig.setClient(config.getClient());
 
             String encryptedCS = GatewayCmdUtils.encrypt(clientSecret, password);
             String encryptedTrustStorePass = GatewayCmdUtils.encrypt(trustStorePassword, password);
@@ -298,7 +296,7 @@ public class ImportCmd implements GatewayLauncherCmd {
                     .setTrustStorePassword(encryptedTrustStorePass)
                     .build();
             newConfig.setToken(token);
-            newConfig.setCorsConfiguration(GatewayCmdUtils.getDefaultCorsConfig());
+            newConfig.setCorsConfiguration(config.getCorsConfiguration());
             GatewayCmdUtils.saveConfig(newConfig, toolkitConfigPath);
         }
 

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/ResetCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/ResetCmd.java
@@ -21,6 +21,9 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.apache.commons.lang3.StringUtils;
+import org.wso2.apimgt.gateway.cli.config.TOMLConfigParser;
+import org.wso2.apimgt.gateway.cli.exception.CLIInternalException;
+import org.wso2.apimgt.gateway.cli.exception.ConfigParserException;
 import org.wso2.apimgt.gateway.cli.model.config.Client;
 import org.wso2.apimgt.gateway.cli.model.config.Config;
 import org.wso2.apimgt.gateway.cli.model.config.Token;
@@ -58,19 +61,17 @@ public class ResetCmd implements GatewayLauncherCmd {
             Runtime.getRuntime().exit(1);
         }
 
-        //Write empty config to config
-        Config newConfig = new Config();
-        Client client = new Client();
-        client.setHttpRequestTimeout(1000000);
-        newConfig.setClient(client);
-        Token token = new TokenBuilder().setBaseURL(StringUtils.EMPTY).setRestVersion(StringUtils.EMPTY)
-                .setPublisherEndpoint(StringUtils.EMPTY).setAdminEndpoint(StringUtils.EMPTY)
-                .setRegistrationEndpoint(StringUtils.EMPTY).setTokenEndpoint(StringUtils.EMPTY)
-                .setUsername(StringUtils.EMPTY).setClientId(StringUtils.EMPTY).setClientSecret(StringUtils.EMPTY)
-                .setTrustStoreLocation(StringUtils.EMPTY).setTrustStorePassword(StringUtils.EMPTY).build();
-        newConfig.setToken(token);
-        newConfig.setCorsConfiguration(GatewayCmdUtils.getDefaultCorsConfig());
-        GatewayCmdUtils.saveConfig(newConfig, configPath);
+        //Reset only the token related configurations and keep the rest of the configuration.
+        try {
+            Config newConfig = TOMLConfigParser.parse(configPath, Config.class);
+            Token token = newConfig.getToken();
+            token.setClientId(StringUtils.EMPTY);
+            token.setClientSecret(StringUtils.EMPTY);
+            token.setUsername(StringUtils.EMPTY);
+            GatewayCmdUtils.saveConfig(newConfig, configPath);
+        } catch (ConfigParserException e) {
+            throw new CLIInternalException("Error occurred while parsing the configuration : " + configPath, e);
+        }
     }
 
     @Override

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/GatewayCmdUtils.java
@@ -823,7 +823,7 @@ public class GatewayCmdUtils {
 
     public static APICorsConfigurationDTO getDefaultCorsConfig() {
         APICorsConfigurationDTO corsConfigurationDTO = new APICorsConfigurationDTO();
-        corsConfigurationDTO.setCorsConfigurationEnabled(true);
+        corsConfigurationDTO.setCorsConfigurationEnabled(false);
         corsConfigurationDTO.setAccessControlAllowOrigins(GatewayCliConstants.accessControlAllowOrigins);
         corsConfigurationDTO.setAccessControlAllowMethods(GatewayCliConstants.accessControlAllowMethods);
         corsConfigurationDTO.setAccessControlAllowHeaders(GatewayCliConstants.accessControlAllowHeaders);

--- a/components/micro-gateway-cli/src/main/resources/cli-help/cli-help.help
+++ b/components/micro-gateway-cli/src/main/resources/cli-help/cli-help.help
@@ -20,7 +20,7 @@ COMMAND is one of the available commands listed below:
     1. micro-gw init : Initialize a project.
     2. micro-gw build : Build the project.
     3. micro-gw import : Import a single API or multiple APIs to the project
-    4. micro-gw reset : Reset microgateway configurations to default.
+    4. micro-gw reset : Reset microgateway configurations to prompt different user credentials.
 
 OPTIONS
     "micro-gw help" has no command line options

--- a/components/micro-gateway-cli/src/main/resources/cli-help/cli-reset.help
+++ b/components/micro-gateway-cli/src/main/resources/cli-help/cli-reset.help
@@ -1,22 +1,23 @@
 NAME
-     micro-gw help reset - resets all the previously specified configurations.
+     micro-gw help reset - resets the user related configurations.
 
 SYNOPSIS
      micro-gw reset [-c|--config]
 
 DESCRIPTION
     
-     The reset command is used to clear all the previously specified configurations, such as "--server-url", "--username",
-      etc.
+     The reset command is used to clear all the previously user related configurations, such as "--username",
+     "--clientId", etc. This will enable different user credentials to be provided when importing APIs from
+     WSO2 API Manager
      
-     When running the setup command for the first time, those configurations are stored internally within the microgateway
-     CLI tool and will be reused for subsequent setup commands. To rerun the setup command with a new set of configurations,
-     the reset command needs to be run beforehand.
+     When running the setup command for the first time, those configurations are stored internally within the
+     microgateway CLI tool and will be reused for subsequent setup commands. To rerun the setup command with a
+     different user credentials, the reset command needs to be run beforehand.
      
      Using "micro-gw reset -c <config-file>", we can reset an externally provided config file. 
 
 EXAMPLES
-    Reset all the configuration to default.
+    Reset user related configuration to default.
     $ micro-gw reset
     
     Reset an external config file

--- a/components/micro-gateway-cli/src/main/resources/cli-help/cli-reset.help
+++ b/components/micro-gateway-cli/src/main/resources/cli-help/cli-reset.help
@@ -6,12 +6,12 @@ SYNOPSIS
 
 DESCRIPTION
     
-     The reset command is used to clear all the previously user related configurations, such as "--username",
+     The reset command is used to clear all the previous user configurations, such as "--username",
      "--clientId", etc. This will enable different user credentials to be provided when importing APIs from
      WSO2 API Manager
      
      When running the setup command for the first time, those configurations are stored internally within the
-     microgateway CLI tool and will be reused for subsequent setup commands. To rerun the setup command with a
+     microgateway CLI tool and will be reused for subsequent import commands. To rerun the import command with a
      different user credentials, the reset command needs to be run beforehand.
      
      Using "micro-gw reset -c <config-file>", we can reset an externally provided config file. 

--- a/distribution/resources/cli-conf/toolkit-config.toml
+++ b/distribution/resources/cli-conf/toolkit-config.toml
@@ -15,7 +15,7 @@ trustStoreLocation = ""
 trustStorePassword = ""
 
 [corsConfiguration]
-corsConfigurationEnabled = true
+corsConfigurationEnabled = false
 accessControlAllowCredentials = false
 accessControlAllowOrigins = ["*"]
 accessControlAllowHeaders = ["authorization", "Access-Control-Allow-Origin", "Content-Type", "SOAPAction"]


### PR DESCRIPTION
### Purpose
Disable cors configuration enabled in toolkit-config.toml . By default the cors config will be disabled

Reset command completely resets the toolkit-config.toml. But it should only resets the user credentials only

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #879 #880 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
