### PR TITLE
Fix #896 - Expose token, revoke endpoints in 9095 port

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/templates/main.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/main.mustache
@@ -5,6 +5,7 @@ public function main() {
                                 {{/value}}{{/operations}}{{/value}}{{#unless @last}},{{/unless}}{{/paths}}];
     gateway:populateAnnotationMaps("{{cut qualifiedServiceName " "}}", {{cut qualifiedServiceName " "}}, {{cut qualifiedServiceName " "}}_service);
     {{/each}}
+    addTokenServicesFilterAnnotation();
 
     initThrottlePolicies();
 

--- a/components/micro-gateway-cli/src/main/resources/templates/tokenServices.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/tokenServices.mustache
@@ -12,7 +12,10 @@ import wso2/gateway;
         }
      {{/corsConfiguration.corsConfigurationEnabled}}
 }
-service authorizeService on tokenListenerEndpoint {
+@gateway:Filters {
+    skipAll: true
+}
+service authorizeService on tokenListenerEndpoint, apiSecureListener {
 
     @http:ResourceConfig {
         path: "/*"
@@ -49,7 +52,10 @@ service authorizeService on tokenListenerEndpoint {
         }
     {{/corsConfiguration.corsConfigurationEnabled}}
 }
-service tokenService on tokenListenerEndpoint {
+@gateway:Filters {
+    skipAll: true
+}
+service tokenService on tokenListenerEndpoint, apiSecureListener {
 
     @http:ResourceConfig {
         path: "/*"
@@ -86,7 +92,10 @@ service tokenService on tokenListenerEndpoint {
         }
     {{/corsConfiguration.corsConfigurationEnabled}}
 }
-service revokeService on tokenListenerEndpoint {
+@gateway:Filters {
+    skipAll: true
+}
+service revokeService on tokenListenerEndpoint, apiSecureListener {
 
     @http:ResourceConfig {
         path: "/*"
@@ -122,7 +131,10 @@ service revokeService on tokenListenerEndpoint {
         }
     {{/corsConfiguration.corsConfigurationEnabled}}
 }
-service userInfoService on tokenListenerEndpoint {
+@gateway:Filters {
+    skipAll: true
+}
+service userInfoService on tokenListenerEndpoint, apiSecureListener {
 
     @http:ResourceConfig {
         path: "/*"
@@ -145,4 +157,11 @@ service userInfoService on tokenListenerEndpoint {
             _ = caller->respond(errorResponse);
         }
     }
+}
+
+public function addTokenServicesFilterAnnotation() {
+    gateway:filterConfigAnnotationMap["authorizeService"] = gateway:getFilterDetailsFromServiceAnnotation(reflect:getServiceAnnotations(authorizeService));
+    gateway:filterConfigAnnotationMap["tokenService"] = gateway:getFilterDetailsFromServiceAnnotation(reflect:getServiceAnnotations(tokenService));
+    gateway:filterConfigAnnotationMap["revokeService"] = gateway:getFilterDetailsFromServiceAnnotation(reflect:getServiceAnnotations(revokeService));
+    gateway:filterConfigAnnotationMap["userInfoService"] = gateway:getFilterDetailsFromServiceAnnotation(reflect:getServiceAnnotations(userInfoService));
 }

--- a/components/micro-gateway-core/src/main/ballerina/gateway/annotation.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/annotation.bal
@@ -31,4 +31,10 @@ public type APIConfiguration record {
 
 public annotation <service> API APIConfiguration;
 
+public type FilterConfiguration record {
+    boolean skipAll = false ;
+};
+
+public annotation <service> Filters FilterConfiguration;
+
 

--- a/components/micro-gateway-core/src/main/ballerina/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/constants/constants.bal
@@ -26,6 +26,7 @@
  public const string RESOURCE_ANN_NAME = "ResourceConfig";
  public const string SERVICE_ANN_NAME = "ServiceConfig";
  public const string API_ANN_NAME = "API";
+ public const string FILTER_ANN_NAME = "Filters";
  public const string SKIP_FILTERS_ANN_NAME = "SkipFilters";
  public const string GATEWAY_ANN_PACKAGE = "wso2/gateway";
 
@@ -75,6 +76,7 @@
  public const string PASSED = "passed";
 
  public const string FILTER_FAILED = "filter_failed";
+ public const string SKIP_ALL_FILTERS = "skip_filters";
  public const string REMOTE_ADDRESS = "remote_address";
  public const string ERROR_CODE = "error_code";
  public const string ERROR_MESSAGE = "error_message";

--- a/components/micro-gateway-core/src/main/ballerina/gateway/filters/analytics_request_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/filters/analytics_request_filter.bal
@@ -21,6 +21,10 @@ import ballerina/time;
 public type AnalyticsRequestFilter object {
 
     public function filterRequest(http:Caller caller, http:Request request, http:FilterContext context) returns boolean {
+        if (context.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>context.attributes[SKIP_ALL_FILTERS]) {
+            printDebug(KEY_ANALYTICS_FILTER, "Skip all filter annotation set in the service. Skip the filter");
+            return true;
+        }
         //Filter only if analytics is enabled.
         if (isAnalyticsEnabled) {
             checkOrSetMessageID(context);
@@ -35,7 +39,10 @@ public type AnalyticsRequestFilter object {
     }
 
     public function filterResponse(http:Response response, http:FilterContext context) returns boolean {
-
+        if (context.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>context.attributes[SKIP_ALL_FILTERS]) {
+            printDebug(KEY_ANALYTICS_FILTER, "Skip all filter annotation set in the service. Skip the filter in response path");
+            return true;
+        }
         if (isAnalyticsEnabled) {
             boolean filterFailed = <boolean>context.attributes[FILTER_FAILED];
             if (context.attributes.hasKey(IS_THROTTLE_OUT)) {

--- a/components/micro-gateway-core/src/main/ballerina/gateway/filters/authn_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/filters/authn_filter.bal
@@ -39,7 +39,11 @@ public type AuthnFilter object {
 
     public function filterRequest(http:Caller caller, http:Request request, http:FilterContext context)
                         returns boolean {
-        //Setting UUID
+        setFilterSkipToFilterContext(context);
+        if (context.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>context.attributes[SKIP_ALL_FILTERS]) {
+            printDebug(KEY_AUTHN_FILTER, "Skip all filter annotation set in the service. Skip the filter");
+            return true;
+        }
         if(request.mutualSslHandshake["status"] != PASSED) {
             int startingTime = getCurrentTime();
             context.attributes[REQUEST_TIME] = startingTime;

--- a/components/micro-gateway-core/src/main/ballerina/gateway/filters/authz_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/filters/authz_filter.bal
@@ -37,7 +37,9 @@ public type OAuthzFilter object {
     public function filterRequest(http:Caller caller, http:Request request, http:FilterContext context) returns
                                                                                                             boolean
     {
-
+        if (context.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>context.attributes[SKIP_ALL_FILTERS]) {
+            printDebug(KEY_AUTHZ_FILTER, "Skip all filter annotation set in the service. Skip the filter");
+        }
         string checkAuthentication = getConfigValue(MTSL_CONF_INSTANCE_ID, MTSL_CONF_SSLVERIFYCLIENT, "");
 
         if (checkAuthentication != "require") {
@@ -62,6 +64,10 @@ public type OAuthzFilter object {
     }
 
     public function filterResponse(http:Response response, http:FilterContext context) returns boolean {
+        if (context.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>context.attributes[SKIP_ALL_FILTERS]) {
+            printDebug(KEY_AUTHZ_FILTER, "Skip all filter annotation set in the service. Skip the filter in response path");
+            return true;
+        }
         int startingTime = getCurrentTime();
         boolean result = doAuthzFilterResponse(response, context);
         setLatency(startingTime, context, SECURITY_LATENCY_AUTHZ_RESPONSE);

--- a/components/micro-gateway-core/src/main/ballerina/gateway/filters/mutualSSL_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/filters/mutualSSL_filter.bal
@@ -24,6 +24,11 @@ import ballerina/io;
 public type MutualSSLFilter object {
 
     public function filterRequest(http:Caller caller, http:Request request, http:FilterContext context) returns boolean {
+        setFilterSkipToFilterContext(context);
+        if (context.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>context.attributes[SKIP_ALL_FILTERS]) {
+            printDebug(KEY_MUTUAL_SSL_FILTER, "Skip all filter annotation set in the service. Skip the filter");
+            return true;
+        }
         int startingTime = getCurrentTime();
         checkOrSetMessageID(context);
         setHostHeaderToFilterContext(request, context);
@@ -44,7 +49,7 @@ function doMTSLFilterRequest(http:Caller caller, http:Request request, http:Filt
     boolean isAuthenticated = true;
     AuthenticationContext authenticationContext = {};
     boolean isSecured = true;
-    printDebug(KEY_AUTHN_FILTER, "Processing request via MutualSSL filter.");
+    printDebug(KEY_MUTUAL_SSL_FILTER, "Processing request via MutualSSL filter.");
 
     context.attributes[IS_SECURED] = isSecured;
     int startingTime = getCurrentTime();

--- a/components/micro-gateway-core/src/main/ballerina/gateway/filters/subscription_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/filters/subscription_filter.bal
@@ -27,6 +27,10 @@ public type SubscriptionFilter object {
 
     public function filterRequest(http:Caller caller, http:Request request, http:FilterContext filterContext)
                         returns boolean {
+        if (filterContext.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>filterContext.attributes[SKIP_ALL_FILTERS]) {
+            printDebug(KEY_SUBSCRIPTION_FILTER, "Skip all filter annotation set in the service. Skip the filter");
+            return true;
+        }
         int startingTime = getCurrentTime();
         checkOrSetMessageID(filterContext);
         boolean result = doSubscriptionFilterRequest(caller, request, filterContext);

--- a/components/micro-gateway-core/src/main/ballerina/gateway/filters/throttle_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/filters/throttle_filter.bal
@@ -28,6 +28,10 @@ public type ThrottleFilter object {
     }
 
     public function filterRequest(http:Caller caller, http:Request request, http:FilterContext context) returns boolean {
+        if (context.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>context.attributes[SKIP_ALL_FILTERS]) {
+            printDebug(KEY_THROTTLE_FILTER, "Skip all filter annotation set in the service. Skip the filter");
+            return true;
+        }
         int startingTime = getCurrentTime();
         checkOrSetMessageID(context);
         boolean result = doThrottleFilterRequest(caller, request, context, self.deployedPolicies);

--- a/components/micro-gateway-core/src/main/ballerina/gateway/filters/validation_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/gateway/filters/validation_filter.bal
@@ -48,6 +48,10 @@ public type ValidationFilter object {
 
     public function filterRequest(http:Caller caller, http:Request request, http:FilterContext filterContext)
                         returns boolean {
+        if (filterContext.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>filterContext.attributes[SKIP_ALL_FILTERS]) {
+            printDebug(KEY_VALIDATION_FILTER, "Skip all filter annotation set in the service. Skip the filter");
+            return true;
+        }
         int startingTime = getCurrentTime();
         checkOrSetMessageID(filterContext);
         boolean result =  doValidationFilterRequest(caller, request, filterContext, self.openAPIs);
@@ -56,6 +60,10 @@ public type ValidationFilter object {
     }
 
     public function filterResponse(http:Response response, http:FilterContext context) returns boolean {
+        if (context.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>context.attributes[SKIP_ALL_FILTERS]) {
+            printDebug(KEY_VALIDATION_FILTER, "Skip all filter annotation set in the service. Skip the filter in response path");
+            return true;
+        }
         int startingTime = getCurrentTime();
         boolean result = doValidationFilterResponse(response, context, self.openAPIs);
         setLatency(startingTime, context, SECURITY_LATENCY_VALIDATION);


### PR DESCRIPTION
### Purpose
/token, /revoke and etc endpoints are exposed via 9096 port in mgw. Which is different from 9095 port where the api requests are served. We need to expose token services also using 9095 port in scenarios like when the ssl termination happens at the gateway level, then routing to relevant port will be difficult from an load balancer

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #896

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
MacOS

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
