### PR TITLE
Fix #896 jballerina - Expose token, revoke endpoints in 9095 port

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/templates/main.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/main.mustache
@@ -7,6 +7,7 @@ public function main() {
     gateway:populateAnnotationMaps("{{cut qualifiedServiceName " "}}", {{cut qualifiedServiceName " "}}, {{cut qualifiedServiceName " "}}_service);
     {{/each}}
 
+    addTokenServicesFilterAnnotation();
     initThrottlePolicies();
     gateway:startObservabilityListener();
 

--- a/components/micro-gateway-cli/src/main/resources/templates/tokenServices.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/tokenServices.mustache
@@ -1,22 +1,31 @@
 import ballerina/http;
+import ballerina/reflect;
 import wso2/gateway;
 import ballerina/log;
 
 @http:ServiceConfig {
-    basePath:"/authorize"
-    {{#corsConfiguration.corsConfigurationEnabled}},
-        cors: {
-             allowOrigins: [{{#corsConfiguration.accessControlAllowOrigins}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowOrigins}}],
-             allowCredentials: {{corsConfiguration.accessControlAllowCredentials}},
-             allowHeaders: [{{#corsConfiguration.accessControlAllowHeaders}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowHeaders}}],
-             allowMethods: [{{#corsConfiguration.accessControlAllowMethods}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowMethods}}]
-        }
+    basePath:"/authorize",
+    auth: {
+        enabled: false
+    } {{#corsConfiguration.corsConfigurationEnabled}},
+    cors: {
+         allowOrigins: [{{#corsConfiguration.accessControlAllowOrigins}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowOrigins}}],
+         allowCredentials: {{corsConfiguration.accessControlAllowCredentials}},
+         allowHeaders: [{{#corsConfiguration.accessControlAllowHeaders}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowHeaders}}],
+         allowMethods: [{{#corsConfiguration.accessControlAllowMethods}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowMethods}}]
+    }
     {{/corsConfiguration.corsConfigurationEnabled}}
 }
-service authorizeService on tokenListenerEndpoint {
+@gateway:Filters {
+    skipAll: true
+}
+service authorizeService on tokenListenerEndpoint, apiSecureListener {
 
     @http:ResourceConfig {
-        path: "/*"
+        path: "/*",
+        auth: {
+            enabled: false
+        }
     }
     resource function authorizeResource(http:Caller caller, http:Request req) {
         gateway:checkExpectHeaderPresent(req);
@@ -27,6 +36,7 @@ service authorizeService on tokenListenerEndpoint {
         if(response is http:Response) {
             forwardedResponse = response;
         } else {
+            log:printError("Error occurred while invoking the authorize endpoint", err = response);
             http:Response errorResponse = new;
             json errMsg = { "error": "error occurred while invoking the authorize endpoint" };
             errorResponse.setJsonPayload(errMsg);
@@ -41,20 +51,28 @@ service authorizeService on tokenListenerEndpoint {
 }
 
 @http:ServiceConfig {
-    basePath:"/revoke"
-    {{#corsConfiguration.corsConfigurationEnabled}},
-        cors: {
-             allowOrigins: [{{#corsConfiguration.accessControlAllowOrigins}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowOrigins}}],
-             allowCredentials: {{corsConfiguration.accessControlAllowCredentials}},
-             allowHeaders: [{{#corsConfiguration.accessControlAllowHeaders}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowHeaders}}],
-             allowMethods: [{{#corsConfiguration.accessControlAllowMethods}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowMethods}}]
-        }
+    basePath:"/revoke",
+    auth: {
+        enabled: false
+    } {{#corsConfiguration.corsConfigurationEnabled}},
+    cors: {
+         allowOrigins: [{{#corsConfiguration.accessControlAllowOrigins}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowOrigins}}],
+         allowCredentials: {{corsConfiguration.accessControlAllowCredentials}},
+         allowHeaders: [{{#corsConfiguration.accessControlAllowHeaders}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowHeaders}}],
+         allowMethods: [{{#corsConfiguration.accessControlAllowMethods}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowMethods}}]
+    }
     {{/corsConfiguration.corsConfigurationEnabled}}
 }
-service revokeService on tokenListenerEndpoint {
+@gateway:Filters {
+    skipAll: true
+}
+service revokeService on tokenListenerEndpoint, apiSecureListener {
 
     @http:ResourceConfig {
-        path: "/*"
+        path: "/*",
+        auth: {
+            enabled: false
+        }
     }
     resource function revokeResource(http:Caller caller, http:Request req) {
         gateway:checkExpectHeaderPresent(req);
@@ -65,6 +83,7 @@ service revokeService on tokenListenerEndpoint {
         if(response is http:Response) {
             forwardedResponse = response;
         } else {
+            log:printError("Error occurred while invoking the revoke endpoint", err = response);
             http:Response errorResponse = new;
             json errMsg = { "error": "error occurred while invoking the revoke endpoint" };
             errorResponse.setJsonPayload(errMsg);
@@ -79,20 +98,28 @@ service revokeService on tokenListenerEndpoint {
 }
 
 @http:ServiceConfig {
-    basePath:"/token"
-    {{#corsConfiguration.corsConfigurationEnabled}},
-        cors: {
-             allowOrigins: [{{#corsConfiguration.accessControlAllowOrigins}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowOrigins}}],
-             allowCredentials: {{corsConfiguration.accessControlAllowCredentials}},
-             allowHeaders: [{{#corsConfiguration.accessControlAllowHeaders}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowHeaders}}],
-             allowMethods: [{{#corsConfiguration.accessControlAllowMethods}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowMethods}}]
-        }
+    basePath:"/token",
+    auth: {
+        enabled: false
+    } {{#corsConfiguration.corsConfigurationEnabled}},
+    cors: {
+         allowOrigins: [{{#corsConfiguration.accessControlAllowOrigins}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowOrigins}}],
+         allowCredentials: {{corsConfiguration.accessControlAllowCredentials}},
+         allowHeaders: [{{#corsConfiguration.accessControlAllowHeaders}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowHeaders}}],
+         allowMethods: [{{#corsConfiguration.accessControlAllowMethods}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowMethods}}]
+    }
     {{/corsConfiguration.corsConfigurationEnabled}}
 }
-service tokenService on tokenListenerEndpoint {
+@gateway:Filters {
+    skipAll: true
+}
+service tokenService on tokenListenerEndpoint, apiSecureListener {
 
     @http:ResourceConfig {
-        path: "/*"
+        path: "/*",
+        auth: {
+            enabled: false
+        }
     }
     resource function tokenResource(http:Caller caller, http:Request req) {
         gateway:checkExpectHeaderPresent(req);
@@ -103,6 +130,7 @@ service tokenService on tokenListenerEndpoint {
         if(response is http:Response) {
             forwardedResponse = response;
         } else {
+            log:printError("Error occurred while invoking the token endpoint", err = response);
             http:Response errorResponse = new;
             json errMsg = { "error": "error occurred while invoking the token endpoint" };
             errorResponse.setJsonPayload(errMsg);
@@ -116,20 +144,28 @@ service tokenService on tokenListenerEndpoint {
 }
 
 @http:ServiceConfig {
-    basePath:"/userinfo"
-    {{#corsConfiguration.corsConfigurationEnabled}},
-        cors: {
-             allowOrigins: [{{#corsConfiguration.accessControlAllowOrigins}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowOrigins}}],
-             allowCredentials: {{corsConfiguration.accessControlAllowCredentials}},
-             allowHeaders: [{{#corsConfiguration.accessControlAllowHeaders}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowHeaders}}],
-             allowMethods: [{{#corsConfiguration.accessControlAllowMethods}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowMethods}}]
-        }
+    basePath:"/userinfo",
+    auth: {
+        enabled: false
+    } {{#corsConfiguration.corsConfigurationEnabled}},
+    cors: {
+         allowOrigins: [{{#corsConfiguration.accessControlAllowOrigins}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowOrigins}}],
+         allowCredentials: {{corsConfiguration.accessControlAllowCredentials}},
+         allowHeaders: [{{#corsConfiguration.accessControlAllowHeaders}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowHeaders}}],
+         allowMethods: [{{#corsConfiguration.accessControlAllowMethods}}"{{.}}"{{#unless @last}},{{/unless}}{{/corsConfiguration.accessControlAllowMethods}}]
+    }
     {{/corsConfiguration.corsConfigurationEnabled}}
 }
-service userInfoService on tokenListenerEndpoint {
+@gateway:Filters {
+    skipAll: true
+}
+service userInfoService on tokenListenerEndpoint, apiSecureListener {
 
     @http:ResourceConfig {
-        path: "/*"
+        path: "/*",
+        auth: {
+            enabled: false
+        }
     }
     resource function userInfoResource(http:Caller caller, http:Request req) {
         gateway:checkExpectHeaderPresent(req);
@@ -140,6 +176,7 @@ service userInfoService on tokenListenerEndpoint {
         if(response is http:Response) {
             forwardedResponse = response;
         } else {
+            log:printError("Error occurred while invoking the userinfo endpoint", err = response);
             http:Response errorResponse = new;
             json errMsg = { "error": "error occurred while invoking the user info endpoint" };
             errorResponse.setJsonPayload(errMsg);
@@ -150,4 +187,12 @@ service userInfoService on tokenListenerEndpoint {
            log:printError("Error when responding during the user info endpoint request", err = result);
         }
     }
+}
+
+public function addTokenServicesFilterAnnotation() {
+    map<gateway:FilterConfiguration?> filterConfigAnnotationMap = gateway:getFilterConfigAnnotationMap();
+    filterConfigAnnotationMap["authorizeService"] = <gateway:FilterConfiguration?>reflect:getServiceAnnotations(authorizeService, gateway:FILTER_ANN_NAME, gateway:GATEWAY_ANN_PACKAGE);
+    filterConfigAnnotationMap["tokenService"] = <gateway:FilterConfiguration?>reflect:getServiceAnnotations(tokenService, gateway:FILTER_ANN_NAME, gateway:GATEWAY_ANN_PACKAGE);
+    filterConfigAnnotationMap["revokeService"] = <gateway:FilterConfiguration?>reflect:getServiceAnnotations(revokeService, gateway:FILTER_ANN_NAME, gateway:GATEWAY_ANN_PACKAGE);
+    filterConfigAnnotationMap["userInfoService"] = <gateway:FilterConfiguration?>reflect:getServiceAnnotations(userInfoService, gateway:FILTER_ANN_NAME, gateway:GATEWAY_ANN_PACKAGE);
 }

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/annotation.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/annotation.bal
@@ -36,3 +36,10 @@ public type ResourceConfiguration record {
 };
 
 public annotation ResourceConfiguration Resource on resource function;
+
+public type FilterConfiguration record {
+    boolean skipAll = false;
+};
+
+public annotation FilterConfiguration Filters on service;
+

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
@@ -26,6 +26,7 @@ public const string ANN_PACKAGE = "ballerina/http";
 public const string RESOURCE_ANN_NAME = "ResourceConfig";
 public const string SERVICE_ANN_NAME = "ServiceConfig";
 public const string API_ANN_NAME = "API";
+public const string FILTER_ANN_NAME = "Filters";
 public const string SKIP_FILTERS_ANN_NAME = "SkipFilters";
 public const string GATEWAY_ANN_PACKAGE = "wso2/gateway:3.1.0";
 
@@ -76,6 +77,7 @@ public const string STATUS = "status";
 public const string PASSED = "passed";
 
 public const string FILTER_FAILED = "filter_failed";
+public const string SKIP_ALL_FILTERS = "skip_filters";
 public const string REMOTE_ADDRESS = "remote_address";
 public const string ERROR_CODE = "error_code";
 public const string ERROR_MESSAGE = "error_message";

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/analytics_request_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/analytics_request_filter.bal
@@ -20,6 +20,10 @@ import ballerina/runtime;
 public type AnalyticsRequestFilter object {
 
     public function filterRequest(http:Caller caller, http:Request request, http:FilterContext context) returns boolean {
+        if (context.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>context.attributes[SKIP_ALL_FILTERS]) {
+            printDebug(KEY_ANALYTICS_FILTER, "Skip all filter annotation set in the service. Skip the filter");
+            return true;
+        }
         //Filter only if analytics is enabled.
         if (isAnalyticsEnabled) {
             checkOrSetMessageID(context);

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/authz_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/authz_filter.bal
@@ -30,6 +30,10 @@ public type OAuthzFilter object {
     }
 
     public function filterRequest(http:Caller caller, http:Request request, http:FilterContext context) returns boolean {
+        if (context.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>context.attributes[SKIP_ALL_FILTERS]) {
+            printDebug(KEY_AUTHZ_FILTER, "Skip all filter annotation set in the service. Skip the filter");
+            return true;
+        }
         string checkAuthentication = getConfigValue(MTSL_CONF_INSTANCE_ID, MTSL_CONF_SSLVERIFYCLIENT, "");
         if (checkAuthentication != "require") {
             //Setting UUID
@@ -60,6 +64,10 @@ public type OAuthzFilter object {
     }
 
     public function filterResponse(http:Response response, http:FilterContext context) returns boolean {
+        if (context.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>context.attributes[SKIP_ALL_FILTERS]) {
+            printDebug(KEY_AUTHZ_FILTER, "Skip all filter annotation set in the service. Skip the filter");
+            return true;
+        }
         int startingTime = getCurrentTime();
         boolean result = doAuthzFilterResponse(response, context);
         setLatency(startingTime, context, SECURITY_LATENCY_AUTHZ_RESPONSE);

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/pre_authn_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/pre_authn_filter.bal
@@ -103,12 +103,12 @@ returns boolean {
     }
 
     if (isSecuredResource) {
-        if(!request.hasHeader(authHeaderName) || request.getHeader(authHeaderName).length() == 0) {
-        printDebug(KEY_PRE_AUTHN_FILTER, "Authentication header is missing for secured resource");
-        setErrorMessageToInvocationContext(API_AUTH_MISSING_CREDENTIALS);
-        setErrorMessageToFilterContext(context, API_AUTH_MISSING_CREDENTIALS);
-        sendErrorResponse(caller, request, context);
-        return false;
+        if (!request.hasHeader(authHeaderName) || request.getHeader(authHeaderName).length() == 0) {
+            printDebug(KEY_PRE_AUTHN_FILTER, "Authentication header is missing for secured resource");
+            setErrorMessageToInvocationContext(API_AUTH_MISSING_CREDENTIALS);
+            setErrorMessageToFilterContext(context, API_AUTH_MISSING_CREDENTIALS);
+            sendErrorResponse(caller, request, context);
+            return false;
         }
     }
 

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/subscription_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/subscription_filter.bal
@@ -28,6 +28,10 @@ public type SubscriptionFilter object {
 
     public function filterRequest(http:Caller caller, http:Request request,@tainted http:FilterContext filterContext)
     returns boolean {
+        if (filterContext.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>filterContext.attributes[SKIP_ALL_FILTERS]) {
+            printDebug(KEY_SUBSCRIPTION_FILTER, "Skip all filter annotation set in the service. Skip the filter");
+            return true;
+        }
         int startingTime = getCurrentTime();
         checkOrSetMessageID(filterContext);
         boolean result = doSubscriptionFilterRequest(caller, request, filterContext, self.subsciptionEnabled);

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/throttle_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/throttle_filter.bal
@@ -25,6 +25,10 @@ public type ThrottleFilter object {
     }
 
     public function filterRequest(http:Caller caller, http:Request request, http:FilterContext context) returns boolean {
+        if (context.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>context.attributes[SKIP_ALL_FILTERS]) {
+            printDebug(KEY_THROTTLE_FILTER, "Skip all filter annotation set in the service. Skip the filter");
+            return true;
+        }
         int startingTime = getCurrentTime();
         checkOrSetMessageID(context);
         boolean result = doThrottleFilterRequest(caller, request, context, self.deployedPolicies);


### PR DESCRIPTION
### Purpose
/token, /revoke and etc endpoints are exposed via 9096 port in mgw. Which is different from 9095 port where the api requests are served. We need to expose token services also using 9095 port in scenarios like when the ssl termination happens at the gateway level, then routing to relevant port will be difficult from an load balancer

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #896 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
