### PR TITLE
Fixes and tests for #884 and #891

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -404,7 +404,7 @@
     </build>
 
     <properties>
-        <ballerina.platform.version>0.990.6</ballerina.platform.version>
+        <ballerina.platform.version>0.990.7</ballerina.platform.version>
         <broker.version>0.970.5</broker.version>
         <assembly.plugin.version>2.5.2</assembly.plugin.version>
         <compiler.plugin.version>3.7.0</compiler.plugin.version>

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/resource/GH884PathParamWithSuffixTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/resource/GH884PathParamWithSuffixTestCase.java
@@ -1,0 +1,72 @@
+package org.wso2.micro.gateway.tests.resource;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.apache.http.HttpStatus;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.micro.gateway.tests.common.BaseTestCase;
+import org.wso2.micro.gateway.tests.common.ResponseConstants;
+import org.wso2.micro.gateway.tests.common.model.ApplicationDTO;
+import org.wso2.micro.gateway.tests.util.HttpClientRequest;
+import org.wso2.micro.gateway.tests.util.HttpResponse;
+import org.wso2.micro.gateway.tests.util.TestConstant;
+import org.wso2.micro.gateway.tests.util.TokenUtil;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * If an resource is templated in following format with an extension (suffix starting with '.'),
+ * Gateway should consider it as a valid resource and handle the requests properly.
+ * <p>
+ *     Ex:
+ *     {@code GET '/petstore/pet/{petId}.api'}
+ * </p>
+ */
+public class GH884PathParamWithSuffixTestCase extends BaseTestCase {
+    private String jwtTokenProd;
+
+    @BeforeClass
+    public void start() throws Exception {
+        String project = "param_suffix";
+        ApplicationDTO application = new ApplicationDTO();
+        application.setName("jwtApp");
+        application.setTier("Unlimited");
+        application.setId((int) (Math.random() * 1000));
+
+        jwtTokenProd = TokenUtil.getBasicJWT(application, new JSONObject(), TestConstant.KEY_TYPE_PRODUCTION, 3600);
+        super.init(project, new String[]{"resource/884_path_param_suffix.yaml"});
+    }
+
+
+    @Test(description = "Test Invoking an suffixed API resource.")
+    public void testInvokingSuffixedResource() throws Exception {
+        HttpResponse response = sendRequest("petstore/v2/pet/1.api");
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getData(), ResponseConstants.petByIdResponse);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+    }
+
+    @Test(description = "Test invoking a suffixed resource without the suffix.")
+    public void testInvokingSuffixedResourceWithoutSuffix() throws Exception {
+        HttpResponse response = sendRequest("petstore/v2/pet/1");
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_NOT_FOUND, "Response code mismatched");
+    }
+
+    private HttpResponse sendRequest(String path) throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
+
+        return HttpClientRequest.doGet(getServiceURLHttp(path), headers);
+    }
+
+    @AfterClass
+    public void stop() throws Exception {
+        //Stop all the mock servers
+        super.finalize();
+    }
+}

--- a/tests/src/test/resources/openAPIs/resource/884_path_param_suffix.yaml
+++ b/tests/src/test/resources/openAPIs/resource/884_path_param_suffix.yaml
@@ -1,0 +1,99 @@
+---
+openapi: 3.0.0
+servers:
+- url: https://petstore.swagger.io/v2
+- url: http://petstore.swagger.io/v2
+info:
+  description: 'This is a sample server Petstore server.'
+  version: 1.0.0
+  title: Swagger Petstore New
+  termsOfService: http://swagger.io/terms/
+x-wso2-basePath: /petstore/v2
+x-wso2-production-endpoints:
+  urls:
+    - https://localhost:2380/v2
+paths:
+  "/pet/{petId}.api":
+    get:
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Pet not found
+      security:
+        - api_key: []
+components:
+  schemas:
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Category
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      required:
+      - name
+      - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          "$ref": "#/components/schemas/Category"
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            "$ref": "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+          - available
+          - pending
+          - sold
+          -

--- a/tests/src/test/resources/testng.xml
+++ b/tests/src/test/resources/testng.xml
@@ -45,6 +45,7 @@
             <class name="org.wso2.micro.gateway.tests.endpoints.EndpointWithSecurityTestCase" />
             <class name="org.wso2.micro.gateway.tests.security.ScopesTestCase" />
             <class name="org.wso2.micro.gateway.tests.security.DisableSecurityAndCustomAuthHeaderTestCase" />
+            <class name="org.wso2.micro.gateway.tests.resource.GH884PathParamWithSuffixTestCase" />
         </classes>
     </test>
 


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
* Enable adding resources with suffixes starting with `.`. Ex: `/petstore/pet/{petId}.api`
* Fix issue when calling APIs from external network.
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #884 
Fixes #891 

### Automation tests
 - Unit tests added: No
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
MacOS

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
