### PR TITLE
Build command fails on windows

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
@@ -274,7 +274,10 @@ public class BuildCmd implements LauncherCmd {
         String templateFile = CmdUtils.getMicroGWConfResourceLocation() + File.separator
                 + CliConstants.BALLERINA_TOML_FILE;
         String fileContent = CmdUtils.readFileAsString(templateFile, false);
-        fileContent = fileContent.replace(CliConstants.MICROGW_HOME_PLACEHOLDER, CmdUtils.getCLIHome());
+
+        // Windows paths contains '\' separator which causes issues when included in ballerina.toml
+        String unixHomePath = CmdUtils.getCLIHome().replace('\\', '/');
+        fileContent = fileContent.replace(CliConstants.MICROGW_HOME_PLACEHOLDER, unixHomePath);
         Files.write(Paths.get(ballerinaTomlFile), fileContent.getBytes(StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
Ballerina doesn't like it when ballerina.toml contains Windows path separator '\' in library paths. Therefore we need to convert widows path separator `\` to `/` to make ballerina work on windows
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #930

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
MacOS
Windows Server 2016

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
