### PR TITLE
Fix the issue when the backend security is applied only for resources

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/templates/service.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/service.mustache
@@ -5,10 +5,8 @@ import ballerina/runtime;{{#importModules}}
 import {{.}};{{/importModules}}
 {{#if containerConfig.hasKubernetes}}import ballerina/kubernetes;{{/if}}
 import wso2/gateway;
-{{#if endpointConfig.prodEndpoints.securityConfig}}
-    {{#equals endpointConfig.prodEndpoints.securityConfig.type "basic"}} import ballerina/auth;{{/equals}}
-{{else if endpointConfig.sandEndpoints.securityConfig}}
-    {{#equals endpointConfig.sandEndpoints.securityConfig.type "basic"}} import ballerina/auth;{{/equals}}
+{{#if hasEpSecurity}}
+    import ballerina/auth;
 {{/if}}
 {{#equals endpointConfig.prodEndpoints.type "http"}}
     {{#endpointConfig.prodEndpoints}}{{>basicAuthHandler}}{{>httpEndpoint}}{{/endpointConfig.prodEndpoints}}


### PR DESCRIPTION
### Purpose
Fix the compilation error, when the backend security is applied only in the resource level. This was due to a bug in ballerina code generation using mustache files.

### Issues
Fixes #1040 

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
MacOS Mojave

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
