### PR TITLE
Fix #1059 - Issues running in k8s

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/config/KubernetesDeployment.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/config/KubernetesDeployment.java
@@ -40,7 +40,7 @@ public class KubernetesDeployment {
     private String image;
     private String env;
     private String buildImage;
-    private String cmd = "CMD gateway ${APP} --b7a.config.file=conf/micro-gw.conf";
+    private String cmd = "CMD gateway ${APP}";
     private CopyFileConfig copyFiles;
     private String dockerHost;
     private String dockerCertPath;

--- a/components/micro-gateway-cli/src/main/resources/templates/listeners.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/listeners.mustache
@@ -5,7 +5,10 @@ import ballerina/io;
 import ballerina/log;
 
 {{#if containerConfig.hasDocker}}import ballerina/docker;{{/if}}
-{{#if containerConfig.kubernetes.kubernetesService.enable}}import ballerina/kubernetes;{{/if}}
+{{#if containerConfig.kubernetes.kubernetesService.enable}}import ballerina/kubernetes;
+{{else if containerConfig.kubernetes.kubernetesServiceHttps.enable}}import ballerina/kubernetes;
+{{else if containerConfig.kubernetes.kubernetesServiceHttp.enable}}import ballerina/kubernetes;{{/if}}
+
 
 //Throttle tier data initiation
 

--- a/distribution/resources/bin/gateway
+++ b/distribution/resources/bin/gateway
@@ -192,7 +192,7 @@ java_cmd_gateway () {
     $JAVA_OPTS \
     -Dmgw-runtime.home=${GW_HOME} \
     -Dballerina.home=${GW_HOME}/runtime \
-    -jar $args --api.usage.data.path=$GW_HOME/api-usage-data --b7a.config.file=$MGW_CONF_DIR/micro-gw.conf 2>&1 | tee -a $GW_HOME/logs/microgateway.log
+    -jar $args --api.usage.data.path=$GW_HOME/api-usage-data --b7a.config.file=$CONFIG_FILE 2>&1 | tee -a $GW_HOME/logs/microgateway.log
 }
 
 java_cmd_gateway_background () {
@@ -205,7 +205,7 @@ java_cmd_gateway_background () {
     $JAVA_OPTS \
     -Dmgw-runtime.home=${GW_HOME} \
     -Dballerina.home=${GW_HOME}/runtime \
-    -jar $args --api.usage.data.path=$GW_HOME/api-usage-data --b7a.config.file=$MGW_CONF_DIR/micro-gw.conf 2>&1 | tee -a $GW_HOME/logs/microgateway.log
+    -jar $args --api.usage.data.path=$GW_HOME/api-usage-data --b7a.config.file=$CONFIG_FILE 2>&1 | tee -a $GW_HOME/logs/microgateway.log
 EOF
 }
 
@@ -251,6 +251,12 @@ fi
 
 OBSERVABILITY_FLAG="false"
 CONFIG_FILE="$MGW_CONF_DIR/micro-gw.conf"
+K8S_MOUNT_PATH="/home/ballerina/conf/ballerina.conf"
+# if externally config map mounted conf found then use that as the config file location. This happens when used with k8s
+if [ -f "$K8S_MOUNT_PATH" ]
+then
+	CONFIG_FILE="$K8S_MOUNT_PATH"
+fi
 CONFIG_OUT_FILE="$GW_HOME/.config"
 
 if [[ $b7a_observability_metrics_enabled == "true" ]]; then


### PR DESCRIPTION
### Purpose
When user specify the micro-gw.conf as a config map in the deployment.toml file when generating the k8s artifacts, gateway pods are not starting due to , conf is mounted as the /home/ballerina/conf/ballerina.conf. But gateway shell script try to find the conf file in /home/ballerina/conf/micro-gw.conf.

In this fix we are taking the /home/ballerina/conf/ballerina.conf as the conf file if it is present. Only wat this is going to present is , specify this as a config map[1] in the deployment.toml

```toml
[kubernetes.kubernetesConfigMap]
    enable = true
    ballerinaConf = 'Documents/MGW/jballerina/wso2am-micro-gw-toolkit-macos-3.1.0-beta-SNAPSHOT/resources/conf/micro-gw.conf'
```

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1059 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
