### PR TITLE
Fix #1048 - Scope issue with opaque tokens

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/authz_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/authz_filter.bal
@@ -44,6 +44,7 @@ public type OAuthzFilter object {
             // scope validation is done in authn filter for oauth2, hence we only need to
             //validate scopes if auth scheme is jwt.
             if (authScheme is string && authScheme == AUTH_SCHEME_JWT) {
+                printDebug(KEY_AUTHZ_FILTER, "Auth scheme was resolved as : " + authScheme);
                 //Start a new child span for the span.
                 int | error | () balSpan = startSpan(BALLERINA_AUTHZ_FILTER);
                 result = self.authzFilter.filterRequest(caller, request, context);

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/handler_providers/oauth2_key_validation_provider.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/handler_providers/oauth2_key_validation_provider.bal
@@ -93,6 +93,8 @@ public type OAuth2KeyValidationProvider object {
                 invocationContext.attributes[KEY_TYPE_ATTR] = authenticationContext
                 .keyType;
                 runtime:AuthenticationContext authContext = {scheme: AUTH_SCHEME_OAUTH2, authToken: credential};
+
+                printDebug(KEY_AUTHN_FILTER, "Set the auth context schema as : " + AUTH_SCHEME_OAUTH2);
                 invocationContext.authenticationContext = authContext;
                 return isAuthorized;
             } else {

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/utils.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/utils.bal
@@ -67,8 +67,9 @@ public function populateAnnotationMaps(string serviceName, service s, string[] r
 # + return - api key validation request dto.
 public function getKeyValidationRequestObject(runtime:InvocationContext context, string accessToken) returns APIRequestMetaDataDto {
     APIRequestMetaDataDto apiKeyValidationRequest = {};
-    string serviceName = runtime:getInvocationContext().attributes[http:SERVICE_NAME].toString();
-    string resourceName = runtime:getInvocationContext().attributes[http:RESOURCE_NAME].toString();
+    runtime:InvocationContext invocationContext = runtime:getInvocationContext();
+    string serviceName = invocationContext.attributes[http:SERVICE_NAME].toString();
+    string resourceName = invocationContext.attributes[http:RESOURCE_NAME].toString();
     printDebug(KEY_UTILS, "Service Name : " + serviceName);
     printDebug(KEY_UTILS, "Resource Name : " + resourceName);
     http:HttpServiceConfig httpServiceConfig = <http:HttpServiceConfig>serviceAnnotationMap[serviceName];
@@ -76,6 +77,18 @@ public function getKeyValidationRequestObject(runtime:InvocationContext context,
     if (httpResourceConfig is http:HttpResourceConfig) {
         apiKeyValidationRequest.matchingResource = <string>httpResourceConfig.path;
         apiKeyValidationRequest.httpVerb = <string>httpResourceConfig.methods[0];
+        http:ResourceAuth? resourceLevelAuthAnn = httpResourceConfig?.auth;
+        // we are explicitly setting the scopes to principal, because scope validation happens at key validation
+        //service. Doing scope validation again in ballerina authz filter causes authorization failure.
+        //So we trust the scope validation done by key validation service and forcefully make the ballerina
+        //authz scope validation successful.
+        if (resourceLevelAuthAnn is http:ResourceAuth) {
+            var resourceScopes = resourceLevelAuthAnn?.scopes;
+            if (resourceScopes is string[]) {
+                runtime:Principal principal = {username: accessToken, scopes: resourceScopes};
+                invocationContext.principal = principal;
+            }
+        }
     }
     string apiContext = <string>httpServiceConfig.basePath;
     APIConfiguration? apiConfig = apiConfigAnnotationMap[serviceName];

--- a/distribution/resources/cli-conf/toolkit-config.toml
+++ b/distribution/resources/cli-conf/toolkit-config.toml
@@ -3,8 +3,8 @@ httpRequestTimeout = 1000000
 
 [token]
 baseURL = ""
-restVersion = "v1.0"
-dcrVersion = "v0.15"
+restVersion = "v1.1"
+dcrVersion = "v0.16"
 publisherEndpoint = "{baseURL}/api/am/publisher/{restVersion}"
 adminEndpoint = "{baseURL}/api/am/admin/{restVersion}"
 registrationEndpoint = "{baseURL}/client-registration/{dcrVersion}/register"

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/common/MockHttpServer.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/common/MockHttpServer.java
@@ -19,16 +19,6 @@ import org.wso2.micro.gateway.tests.common.model.ApplicationPolicy;
 import org.wso2.micro.gateway.tests.common.model.SubscriptionPolicy;
 import org.xml.sax.SAXException;
 
-import javax.jms.JMSException;
-import javax.naming.NamingException;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLParameters;
-import javax.net.ssl.TrustManagerFactory;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -41,6 +31,16 @@ import java.security.KeyStore;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import javax.jms.JMSException;
+import javax.naming.NamingException;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.TrustManagerFactory;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 /**
  * Mock http server for key-manager and APIM rest api endpoints
@@ -51,9 +51,9 @@ public class MockHttpServer extends Thread {
     private HttpsServer httpServer;
     private String KMServerUrl;
     private int KMServerPort = -1;
-    private String DCRRestAPIBasePath = "/client-registration/v0.15";
-    private String PubRestAPIBasePath = "/api/am/publisher/v1.0";
-    private String AdminRestAPIBasePath = "/api/am/admin/v1.0";
+    private String DCRRestAPIBasePath = "/client-registration/v0.16";
+    private String PubRestAPIBasePath = "/api/am/publisher/v1.1";
+    private String AdminRestAPIBasePath = "/api/am/admin/v1.1";
     private String TMRestAPIBasePath = "/endpoints";
     public final static String PROD_ENDPOINT_RESPONSE = "{\"type\": \"production\"}";
     public final static String SAND_ENDPOINT_RESPONSE = "{\"type\": \"sandbox\"}";

--- a/tests/src/test/resources/confs/default-cli-test-config.toml
+++ b/tests/src/test/resources/confs/default-cli-test-config.toml
@@ -2,9 +2,9 @@
 httpRequestTimeout = 1000000
 
 [token]
-publisherEndpoint = "https://localhost:9443/api/am/publisher/v1.0"
-adminEndpoint = "https://localhost:9443/api/am/admin/v1.0"
-registrationEndpoint = "https://localhost:9443/client-registration/v0.15/register"
+publisherEndpoint = "https://localhost:9443/api/am/publisher/v1.1"
+adminEndpoint = "https://localhost:9443/api/am/admin/v1.1"
+registrationEndpoint = "https://localhost:9443/client-registration/v0.16/register"
 tokenEndpoint = "https://localhost:9443/oauth2/token"
 username = "admin"
 clientId = ""


### PR DESCRIPTION
### Purpose
This issue happens, due to ballerina authz filter getting called from ballerina authn filter. But when used opaque tokens the key validation service call to external KM does validates the scopes. So ballerina authz filter again trying to validate the scopes causing the issue. Here we are trusting the validation done by external key validation service and forcefully make the ballerina authz filter scope validation successful.
Once the issue https://github.com/ballerina-platform/ballerina-lang/issues/21376 is fixed, we can remove this logic.
> And also this PR update the default rest versions of the toolkit config to work with APIM 3.1.0

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1048 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
