### PR TITLE
Remove docker k8s libs from toolkit

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -66,16 +66,6 @@
             <groupId>org.wso2.am.microgw</groupId>
             <artifactId>org.wso2.micro.gateway.tools</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.ballerinax.docker</groupId>
-            <artifactId>docker-extension</artifactId>
-            <version>${ballerina.platform.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.ballerinax.kubernetes</groupId>
-            <artifactId>kubernetes-extension</artifactId>
-            <version>${ballerina.platform.version}</version>
-        </dependency>
         <!--required for the message broker-->
         <dependency>
             <groupId>org.wso2.securevault</groupId>

--- a/distribution/src/main/assembly/linux_bin.xml
+++ b/distribution/src/main/assembly/linux_bin.xml
@@ -137,8 +137,6 @@
                 <include>org.wso2.am.microgw:org.wso2.micro.gateway.cli:jar</include>
                 <include>com.moandjiezana.toml:toml4j:jar</include>
                 <include>com.beust:jcommander:jar</include>
-                <include>org.ballerinax.docker:docker-extension:jar</include>
-                <include>org.ballerinax.kubernetes:kubernetes-extension:jar</include>
             </includes>
         </dependencySet>
         <dependencySet>

--- a/distribution/src/main/assembly/macos_bin.xml
+++ b/distribution/src/main/assembly/macos_bin.xml
@@ -146,8 +146,6 @@
                 <include>org.wso2.am.microgw:org.wso2.micro.gateway.cli:jar</include>
                 <include>com.moandjiezana.toml:toml4j:jar</include>
                 <include>com.beust:jcommander:jar</include>
-                <include>org.ballerinax.docker:docker-extension:jar</include>
-                <include>org.ballerinax.kubernetes:kubernetes-extension:jar</include>
             </includes>
         </dependencySet>
         <dependencySet>

--- a/distribution/src/main/assembly/windows_bin.xml
+++ b/distribution/src/main/assembly/windows_bin.xml
@@ -137,8 +137,6 @@
                 <include>org.wso2.am.microgw:org.wso2.micro.gateway.cli:jar</include>
                 <include>com.moandjiezana.toml:toml4j:jar</include>
                 <include>com.beust:jcommander:jar</include>
-                <include>org.ballerinax.docker:docker-extension:jar</include>
-                <include>org.ballerinax.kubernetes:kubernetes-extension:jar</include>
             </includes>
         </dependencySet>
         <dependencySet>


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
We no longer need to pack docker, k8s ballerina libs manually into toolkit. New ballerina distribution downloaded from b7a product dist contains both these libs.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Task

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
