### PR TITLE
Fix #929 - Enbale response caching open API extension

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/OpenAPIConstants.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/OpenAPIConstants.java
@@ -21,6 +21,7 @@ public class OpenAPIConstants {
     public static final String THROTTLING_TIER = "x-wso2-throttling-tier";
     public static final String DISABLE_SECURITY = "x-wso2-disable-security";
     public static final String AUTHORIZATION_HEADER = "x-wso2-auth-header";
+    public static final String RESPONSE_CACHE = "x-wso2-response-cache";
     public static final String INTERCEPTOR_FUNC_SEPARATOR = ":";
     public static final String INTERCEPTOR_PATH_SEPARATOR = "/";
     public static final String INTERCEPTOR_JAVA_PREFIX = "java:";
@@ -33,6 +34,10 @@ public class OpenAPIConstants {
     public static final String TRANSPORT_HTTP = "http";
     public static final String TRANSPORT_HTTPS = "https";
     public static final String MANDATORY = "mandatory";
+    public static final String ENABLED = "enabled";
+    public static final String DISABLED = "Disabled";
+    public static final String CACHE_TIMEOUT = "cacheTimeoutInSeconds";
+    public static final String CACHE_ENABLED = "Enabled";
 
     public static final ImmutableList<String> MODULE_IDENTIFIER_LIST = ImmutableList.of("vienna", "canberra",
             "berlin", "athens", "georgetown", "budapest", "jakarta", "rome", "dublin", "tokyo", "bucharest", "moscow",

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/APIDetailedDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/APIDetailedDTO.java
@@ -68,7 +68,7 @@ public class APIDetailedDTO extends APIInfoDTO {
     
     private String apiDefinition = null;
     private String wsdlUri = null;
-    private String responseCaching = null;
+    private String responseCaching = "Disabled";
     private Integer cacheTimeout = null;
     private String destinationStatsEnabled = null;
     private Boolean isDefaultVersion = null;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/template/service/BallerinaService.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/template/service/BallerinaService.java
@@ -152,7 +152,7 @@ public class BallerinaService implements BallerinaOpenAPIObject<BallerinaService
         //set default auth providers for api level
         OpenAPICodegenUtils.addDefaultAuthProviders(this.authProviders, api.getApplicationSecurity());
         resolveInterceptors(definition.getExtensions());
-
+        setResponseCache(definition.getExtensions());
         return buildContext(definition);
     }
 
@@ -440,6 +440,27 @@ public class BallerinaService implements BallerinaOpenAPIObject<BallerinaService
                 (endpointConfig.getSandboxEndpointList() != null &&
                         endpointConfig.getSandboxEndpointList().getSecurityConfig() != null)) {
             hasEpSecurity = true;
+        }
+    }
+
+    public void setResponseCache(Map<String, Object> exts) {
+        if (exts != null) {
+            Object responseCacheObject = exts.get(OpenAPIConstants.RESPONSE_CACHE);
+            if (responseCacheObject != null) {
+                // This logic is written to maintain backward compatibility with APIM 2.x.
+                // We can not use mapping object dto.
+                Map cacheObjectMap = (Map) responseCacheObject;
+                boolean enabled = (boolean) cacheObjectMap.get(OpenAPIConstants.ENABLED);
+                if (enabled) {
+                    api.setResponseCaching(OpenAPIConstants.CACHE_ENABLED);
+                    if (cacheObjectMap.containsKey(OpenAPIConstants.CACHE_TIMEOUT)) {
+                        int cacheTimeout = (int) cacheObjectMap.get(OpenAPIConstants.CACHE_TIMEOUT);
+                        api.setCacheTimeout(cacheTimeout * 1000); //set the value in milli seconds.
+                    }
+                } else {
+                    api.setResponseCaching(OpenAPIConstants.DISABLED);
+                }
+            }
         }
     }
 }

--- a/components/micro-gateway-cli/src/main/resources/templates/caching.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/caching.mustache
@@ -1,3 +1,6 @@
 {{#equals api.responseCaching "Disabled"}},
     cache: { enabled: false }{{else}},
-    cache: { isShared: true }{{/equals}}
+    cache: { enabled: true,
+    isShared: true {{#if api.cacheTimeout}},
+    expiryTimeInMillis: {{api.cacheTimeout}} {{/if}} }{{/equals}}
+


### PR DESCRIPTION
### Purpose
Introduces the open API extension for response caching enable and disable. Explained in the issue #929 

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #929 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
