### PR TITLE
Bug fixes

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
@@ -212,6 +212,9 @@ public class BuildCmd implements LauncherCmd {
 
     private boolean isProtosAvailable(String fileLocation) {
         File file = new File(fileLocation);
+        if (!file.exists()) {
+            return false;
+        }
         FilenameFilter protoFilter = (f, name) -> (name.endsWith(".proto"));
         String[] fileNames = file.list(protoFilter);
         if (fileNames != null && fileNames.length > 0) {

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/grpc_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/grpc_filter.bal
@@ -86,11 +86,7 @@ public function attachGrpcErrorHeaders(http:Response response, string errorMsg) 
     }
     response.setHeader(GRPC_STATUS_HEADER, grpcStatus, mime:TRAILING);
     response.setHeader(GRPC_MESSAGE_HEADER, grpcErrorMessage, mime:TRAILING);
-    //todo: temp workaround, fix this after ballerina patch release
-    //todo: check the implementation with different gRPC clients other than ballerina and java
-    //this fixes the problem as the first 5 bytes are reserved in gRPC. Therefore gRPC client doesnot identify that
-    //there is a payload attached.
-    response.setTextPayload("xxxx");
+    response.setTextPayload("");
     response.setContentType(GRPC_CONTENT_TYPE_HEADER);
     printDebug(KEY_GRPC_FILTER, "grpc status is " + grpcStatus + " and grpc Message is " + grpcErrorMessage);
 

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/analytics_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/analytics_util.bal
@@ -103,8 +103,10 @@ function populateFaultAnalyticsDTO(http:FilterContext context, string err) retur
     eventDto.apiCreatorTenantDomain = getTenantDomain(context);
     eventDto.hostName = retrieveHostname(DATACENTER_ID, <string>context.attributes[HOSTNAME_PROPERTY]);
     eventDto.protocol = <string>context.attributes[PROTOCOL_PROPERTY];
-    if (isSecured && context.attributes.hasKey(AUTHENTICATION_CONTEXT)) {
-        AuthenticationContext authContext = <AuthenticationContext>context.attributes[AUTHENTICATION_CONTEXT];
+
+    runtime:InvocationContext invocationContext = runtime:getInvocationContext();
+    if (isSecured && invocationContext.attributes.hasKey(AUTHENTICATION_CONTEXT)) {
+        AuthenticationContext authContext = <AuthenticationContext>invocationContext.attributes[AUTHENTICATION_CONTEXT];
         metaInfo["keyType"] = authContext.keyType;
         eventDto.consumerKey = authContext.consumerKey;
         eventDto.userName = authContext.username;


### PR DESCRIPTION
### Purpose

1. Set an empty string as payload, in the gRPC error scenario.
2. Analytics: fix the issue where the fault event does not contain application name and api_creator fields.
3. Allow the 3.0.x initialized project, to be continued in 3.1.0 by allowing the project to build without grpc_definitions directory.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1108 , #1096 , #1031 and #1055

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
MacOS Mojave

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
