### PR TITLE
Fix #1116 - Reduce integration test running time

### DIFF
--- a/tests/src/test/java/org/wso2/micro/gateway/tests/endpoints/EndpointOverrideTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/endpoints/EndpointOverrideTestCase.java
@@ -17,32 +17,68 @@
  */
 package org.wso2.micro.gateway.tests.endpoints;
 
-import org.json.JSONObject;
-import org.testng.annotations.BeforeClass;
-import org.wso2.micro.gateway.tests.common.model.ApplicationDTO;
-import org.wso2.micro.gateway.tests.util.TestConstant;
-import org.wso2.micro.gateway.tests.util.TokenUtil;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.micro.gateway.tests.common.ResponseConstants;
+import org.wso2.micro.gateway.tests.util.HttpClientRequest;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class EndpointOverrideTestCase extends EndpointsByReferenceTestCase {
-    @Override
-    @BeforeClass
-    public void start() throws Exception {
 
-        String project = "EndpointOverrideProject";
-        //Define application info
-        ApplicationDTO application = new ApplicationDTO();
-        application.setName("jwtApp");
-        application.setTier("Unlimited");
-        application.setId((int) (Math.random() * 1000));
 
-        jwtTokenProd = TokenUtil.getBasicJWT(application, new JSONObject(), TestConstant.KEY_TYPE_PRODUCTION, 3600);
-        //generate apis with CLI and start the micro gateway server
-        String[] args = {"--myEndpoint1_prod_endpoint_0=https://localhost:2380/v1",
-                "--myEndpoint2_prod_endpoint_0=https://localhost:2380/v2",
-                "--myEndpoint3_prod_endpoint_0=https://localhost:2380/v1",
-                "--myEndpoint3_prod_endpoint_1=https://localhost:2380/v2",
-                "--myEndpoint4_prod_endpoint_1=https://localhost:2380/v2",
-        };
-        super.init(project, new String[]{"endpoints/endpoint_override.yaml"}, args);
+    @Test(description = "Test Invoking the resource which  endpoint defined at resource level")
+    public void testPerResourceEndpointOverride() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        //test endpoint with token
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
+        org.wso2.micro.gateway.tests.util.HttpResponse response = HttpClientRequest
+                .doGet(getServiceURLHttp("petstore/v2/pet/findByStatus"), headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getData(), ResponseConstants.responseBodyV1);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
     }
+
+    @Test(description = "Test Invoking the resource which endpoint defined at API level using references")
+    public void testPerAPIEndpointOverride() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        //test endpoint with token
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
+        org.wso2.micro.gateway.tests.util.HttpResponse response = HttpClientRequest
+                .doGet(getServiceURLHttp("petstore/v2/pet/1"), headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getData(), ResponseConstants.petByIdResponse);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+    }
+
+    @Test(description = "Test Invoking the load balanced endpoints in resource level using references")
+    public void testLoadBalancedEndpointResourceLevelOverride() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        //test endpoint with token
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
+        org.wso2.micro.gateway.tests.util.HttpResponse response = HttpClientRequest
+                .doGet(getServiceURLHttp("petstore/v2/pet/findByTags"), headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getData(), ResponseConstants.petByIdResponseV1);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        response = HttpClientRequest.doGet(getServiceURLHttp("petstore/v2/pet/findByTags"), headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getData(), ResponseConstants.petByIdResponse);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+    }
+
+    @Test(description = "Test Invoking the fail over endpoints using references")
+    public void testFailOverEndpointResourceLevelOverride() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        //test endpoint with token
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
+        org.wso2.micro.gateway.tests.util.HttpResponse response = HttpClientRequest
+                .doGet(getServiceURLHttp("petstore/v2/store/inventory"), headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getData(), ResponseConstants.storeInventoryResponse);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+    }
+
 }

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/endpoints/EndpointWithSecurityTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/endpoints/EndpointWithSecurityTestCase.java
@@ -17,28 +17,66 @@
  */
 package org.wso2.micro.gateway.tests.endpoints;
 
-import org.json.JSONObject;
-import org.testng.annotations.BeforeClass;
-import org.wso2.micro.gateway.tests.common.model.ApplicationDTO;
-import org.wso2.micro.gateway.tests.util.TestConstant;
-import org.wso2.micro.gateway.tests.util.TokenUtil;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.micro.gateway.tests.common.ResponseConstants;
+import org.wso2.micro.gateway.tests.util.HttpClientRequest;
 
-public class EndpointWithSecurityTestCase extends EndpointsByReferenceTestCase {
-    @Override
-    @BeforeClass
-    public void start() throws Exception {
+import java.util.HashMap;
+import java.util.Map;
 
-        String project = "EndpointWithSecurityProject";
-        //Define application info
-        ApplicationDTO application = new ApplicationDTO();
-        application.setName("jwtApp");
-        application.setTier("Unlimited");
-        application.setId((int) (Math.random() * 1000));
+public class EndpointWithSecurityTestCase extends MultipleEndpointsTestCase {
 
-        jwtTokenProd = TokenUtil.getBasicJWT(application, new JSONObject(), TestConstant.KEY_TYPE_PRODUCTION, 3600);
-        //generate apis with CLI and start the micro gateway server
-        String[] args = {"--myEndpoint1_prod_basic_password=admin", "--myEndpoint2_prod_basic_password=admin",
-                 "--myEndpoint3_prod_basic_password=admin", "--myEndpoint4_prod_basic_password=admin"};
-        super.init(project, new String[]{"endpoints/endpoint_security.yaml"}, args);
+    @Test(description = "Test Invoking the resource which  endpoint defined at resource level")
+    public void testPerResourceSecureEndpoint() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        //test endpoint with token
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
+        org.wso2.micro.gateway.tests.util.HttpResponse response = HttpClientRequest
+                .doGet(getServiceURLHttp("petstore/v5/pet/findByStatus"), headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getData(), ResponseConstants.responseBodyV1);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+    }
+
+    @Test(description = "Test Invoking the resource which endpoint defined at API level using references")
+    public void testPerAPISecureEndpoint() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        //test endpoint with token
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
+        org.wso2.micro.gateway.tests.util.HttpResponse response = HttpClientRequest
+                .doGet(getServiceURLHttp("petstore/v5/pet/1"), headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getData(), ResponseConstants.petByIdResponse);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+    }
+
+    @Test(description = "Test Invoking the load balanced endpoints in resource level using references")
+    public void testLoadBalancedSecureEndpointResourceLevel() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        //test endpoint with token
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
+        org.wso2.micro.gateway.tests.util.HttpResponse response = HttpClientRequest
+                .doGet(getServiceURLHttp("petstore/v5/pet/findByTags"), headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getData(), ResponseConstants.petByIdResponseV1);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        response = HttpClientRequest.doGet(getServiceURLHttp("petstore/v5/pet/findByTags"), headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getData(), ResponseConstants.petByIdResponse);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+    }
+
+    @Test(description = "Test Invoking the fail over endpoints using references")
+    public void testFailOverSecureEndpointResourceLevel() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        //test endpoint with token
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
+        org.wso2.micro.gateway.tests.util.HttpResponse response = HttpClientRequest
+                .doGet(getServiceURLHttp("petstore/v5/store/inventory"), headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getData(), ResponseConstants.storeInventoryResponse);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
     }
 }

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/endpoints/EndpointsByReferenceTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/endpoints/EndpointsByReferenceTestCase.java
@@ -20,7 +20,6 @@ package org.wso2.micro.gateway.tests.endpoints;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import org.json.JSONObject;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.micro.gateway.tests.common.BaseTestCase;
@@ -38,20 +37,32 @@ import java.util.Map;
  */
 public class EndpointsByReferenceTestCase extends BaseTestCase {
     protected String jwtTokenProd;
+    protected String context = "v1";
 
-    @BeforeClass
+    @BeforeClass()
     public void start() throws Exception {
 
         String project = "EndpointReferenceProject";
         //Define application info
+
         ApplicationDTO application = new ApplicationDTO();
         application.setName("jwtApp");
         application.setTier("Unlimited");
         application.setId((int) (Math.random() * 1000));
-
         jwtTokenProd = TokenUtil.getBasicJWT(application, new JSONObject(), TestConstant.KEY_TYPE_PRODUCTION, 3600);
+        String[] args = {"--myEndpoint1_prod_endpoint_0=https://localhost:2380/v1",
+                "--myEndpoint2_prod_endpoint_0=https://localhost:2380/v2",
+                "--myEndpoint3_prod_endpoint_0=https://localhost:2380/v1",
+                "--myEndpoint3_prod_endpoint_1=https://localhost:2380/v2",
+                "--myEndpoint4_prod_endpoint_1=https://localhost:2380/v2",
+                "--myEndpoint1_prod_basic_password=admin",
+                "--myEndpoint2_prod_basic_password=admin",
+                "--myEndpoint3_prod_basic_password=admin",
+                "--myEndpoint4_prod_basic_password=admin"
+        };
         //generate apis with CLI and start the micro gateway server
-        super.init(project, new String[]{"endpoints/endpoints_by_reference.yaml"});
+        super.init(project, new String[] { "endpoints/endpoints_by_reference.yaml", "endpoints/endpoint_override.yaml",
+                "endpoints/load_balance.yaml", "endpoints/fail_over.yaml", "endpoints/endpoint_security.yaml" }, args);
     }
 
     @Test(description = "Test Invoking the resource which  endpoint defined at resource level")
@@ -104,11 +115,5 @@ public class EndpointsByReferenceTestCase extends BaseTestCase {
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getData(), ResponseConstants.storeInventoryResponse);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-    }
-
-    @AfterClass
-    public void stop() throws Exception {
-        //Stop all the mock servers
-        super.finalize();
     }
 }

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/endpoints/MultipleEndpointsTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/endpoints/MultipleEndpointsTestCase.java
@@ -19,46 +19,23 @@
 package org.wso2.micro.gateway.tests.endpoints;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
-import org.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.micro.gateway.tests.common.BaseTestCase;
 import org.wso2.micro.gateway.tests.common.ResponseConstants;
-import org.wso2.micro.gateway.tests.common.model.ApplicationDTO;
 import org.wso2.micro.gateway.tests.util.HttpClientRequest;
-import org.wso2.micro.gateway.tests.util.TestConstant;
-import org.wso2.micro.gateway.tests.util.TokenUtil;
 
-import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
  * This test class is used to test load balance and failover endpoints
  */
-public class MultipleEndpointsTestCase extends BaseTestCase {
-    private String jwtTokenProd;
+public class MultipleEndpointsTestCase extends EndpointOverrideTestCase {
 
-    @BeforeClass
-    public void start() throws Exception {
-
-        String project = "multipleEndpointProject";
-        //Define application info
-        ApplicationDTO application = new ApplicationDTO();
-        application.setName("jwtApp");
-        application.setTier("Unlimited");
-        application.setId((int) (Math.random() * 1000));
-
-        jwtTokenProd = TokenUtil.getBasicJWT(application, new JSONObject(), TestConstant.KEY_TYPE_PRODUCTION, 3600);
-        //generate apis with CLI and start the micro gateway server
-        super.init(project, new String[]{"common_api.yaml", "endpoints/load_balance.yaml",
-                "endpoints/fail_over.yaml"});
-    }
 
     @Test(description = "Test Invoking the load balanced endpoints in resource level")
-    public void testLoadBalancedEndpointResourceLevel() throws Exception {
+    public void testLoadBalancedMultiEndpointResourceLevel() throws Exception {
         Map<String, String> headers = new HashMap<>();
         //test endpoint with token
         headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
@@ -74,23 +51,23 @@ public class MultipleEndpointsTestCase extends BaseTestCase {
     }
 
     @Test(description = "Test Invoking the load balanced endpoints in API level")
-    public void testLoadBalancedEndpointAPILevel() throws Exception {
+    public void testLoadBalancedMultiEndpointAPILevel() throws Exception {
         Map<String, String> headers = new HashMap<>();
         //test endpoint with token
         headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
         org.wso2.micro.gateway.tests.util.HttpResponse response = HttpClientRequest
-                .doGet(getServiceURLHttp("petstore/v2/pet/findByStatus"), headers);
+                .doGet(getServiceURLHttp("petstore/v4/pet/findByStatus"), headers);
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getData(), ResponseConstants.responseBodyV1);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-        response = HttpClientRequest.doGet(getServiceURLHttp("petstore/v2/pet/findByStatus"), headers);
+        response = HttpClientRequest.doGet(getServiceURLHttp("petstore/v4/pet/findByStatus"), headers);
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getData(), ResponseConstants.responseBody);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
     }
 
     @Test(description = "Test Invoking the fail over endpoints")
-    public void testFailOverEndpointResourceLevel() throws Exception {
+    public void testFailOverMultiEndpointResourceLevel() throws Exception {
         Map<String, String> headers = new HashMap<>();
         //test endpoint with token
         headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
@@ -103,7 +80,7 @@ public class MultipleEndpointsTestCase extends BaseTestCase {
     }
 
     @Test(description = "Test Invoking the load balanced endpoints in API level")
-    public void testFailOverEndpointAPILevel() throws Exception {
+    public void testFailOverMultiEndpointAPILevel() throws Exception {
         Map<String, String> headers = new HashMap<>();
         //test endpoint with token
         headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/extensions/OASAPIInvokeTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/extensions/OASAPIInvokeTestCase.java
@@ -19,7 +19,6 @@ package org.wso2.micro.gateway.tests.extensions;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.micro.gateway.tests.common.BaseTestCase;
@@ -33,12 +32,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class OASAPIInvokeTestCase extends BaseTestCase {
-    private String jwtTokenProd;
+    protected String jwtTokenProd;
 
     @BeforeClass
     public void start() throws Exception {
 
-        String project = "apimTestProject";
+        String project = "OpenApiThrottlingProject";
         API api = new API();
         api.setName("PetStoreAPI");
         api.setContext("petstore/v1");
@@ -68,12 +67,4 @@ public class OASAPIInvokeTestCase extends BaseTestCase {
         Assert.assertEquals(response.getData(), ResponseConstants.petByIdResponse);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
     }
-
-    @AfterClass
-    public void stop() throws Exception {
-        //Stop all the mock servers
-        mockHttpServer.stopIt();
-        super.finalize();
-    }
-
 }

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/http2/HTTP2RequestsWithHTTP1BackEndTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/http2/HTTP2RequestsWithHTTP1BackEndTestCase.java
@@ -30,42 +30,6 @@ public class HTTP2RequestsWithHTTP1BackEndTestCase extends HTTP2RequestsWithHTTP
 
     private static final Log log = LogFactory.getLog(HTTP2RequestsWithHTTP2BackEndTestCase.class);
     protected Http2ClientRequest http2ClientRequest;
-    //private String jwtTokenProd;
-
-//    @BeforeClass
-//    private void setup() throws Exception {
-//        String label = "apimTestLabel";
-//        String project = "apimTestProject";
-//        //get mock APIM Instance
-//        MockAPIPublisher pub = MockAPIPublisher.getInstance();
-//        API api = new API();
-//        api.setName("PizzaShackAPI");
-//        api.setContext("/pizzashack");
-//        api.setEndpoint(getMockServiceURLHttp("/echo"));
-//        api.setVersion("1.0.0");
-//        api.setProvider("admin");
-//        //Register API with label
-//        pub.addApi(label, api);
-//
-//        //Define application info
-//        ApplicationDTO application = new ApplicationDTO();
-//        application.setName("jwtApp");
-//        application.setTier("Unlimited");
-//        application.setId((int) (Math.random() * 1000));
-//
-//        //Register a production token with key validation info
-//        KeyValidationInfo info = new KeyValidationInfo();
-//        info.setApi(api);
-//        info.setApplication(application);
-//        info.setAuthorized(true);
-//        info.setKeyType(TestConstant.KEY_TYPE_PRODUCTION);
-//        info.setSubscriptionTier("Unlimited");
-//
-//        String configPath = "confs/http2-test.conf";
-//        super.init(label, project, configPath);
-//
-//        jwtTokenProd = getJWT(api, application, "Unlimited", TestConstant.KEY_TYPE_PRODUCTION, 3600);
-//    }
 
     @Test(description = "Test API invocation with an HTTP/2.0 request via insecure connection sending to HTTP/1.1 BE")
     public void testHTTP2RequestsViaInsecureConnectionWithHTTP1BE() throws Exception {

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/http2/HTTP2RequestsWithHTTP1BackEndTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/http2/HTTP2RequestsWithHTTP1BackEndTestCase.java
@@ -21,61 +21,51 @@ package org.wso2.micro.gateway.tests.http2;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.micro.gateway.tests.common.BaseTestCase;
-import org.wso2.micro.gateway.tests.common.KeyValidationInfo;
-import org.wso2.micro.gateway.tests.common.MockAPIPublisher;
-import org.wso2.micro.gateway.tests.common.model.API;
-import org.wso2.micro.gateway.tests.common.model.ApplicationDTO;
 import org.wso2.micro.gateway.tests.util.HTTP2Client.Http2ClientRequest;
-import org.wso2.micro.gateway.tests.util.TestConstant;
-
-import java.io.File;
-
 import static org.wso2.micro.gateway.tests.util.TestConstant.GATEWAY_LISTENER_HTTPS_PORT;
 import static org.wso2.micro.gateway.tests.util.TestConstant.GATEWAY_LISTENER_HTTP_PORT;
 
-public class HTTP2RequestsWithHTTP1BackEndTestCase extends BaseTestCase {
+public class HTTP2RequestsWithHTTP1BackEndTestCase extends HTTP2RequestsWithHTTP2BackEndTestCase {
 
     private static final Log log = LogFactory.getLog(HTTP2RequestsWithHTTP2BackEndTestCase.class);
     protected Http2ClientRequest http2ClientRequest;
-    private String jwtTokenProd;
+    //private String jwtTokenProd;
 
-    @BeforeClass
-    private void setup() throws Exception {
-        String label = "apimTestLabel";
-        String project = "apimTestProject";
-        //get mock APIM Instance
-        MockAPIPublisher pub = MockAPIPublisher.getInstance();
-        API api = new API();
-        api.setName("PizzaShackAPI");
-        api.setContext("/pizzashack");
-        api.setEndpoint(getMockServiceURLHttp("/echo"));
-        api.setVersion("1.0.0");
-        api.setProvider("admin");
-        //Register API with label
-        pub.addApi(label, api);
-
-        //Define application info
-        ApplicationDTO application = new ApplicationDTO();
-        application.setName("jwtApp");
-        application.setTier("Unlimited");
-        application.setId((int) (Math.random() * 1000));
-
-        //Register a production token with key validation info
-        KeyValidationInfo info = new KeyValidationInfo();
-        info.setApi(api);
-        info.setApplication(application);
-        info.setAuthorized(true);
-        info.setKeyType(TestConstant.KEY_TYPE_PRODUCTION);
-        info.setSubscriptionTier("Unlimited");
-
-        String configPath = "confs/http2-test.conf";
-        super.init(label, project, configPath);
-
-        jwtTokenProd = getJWT(api, application, "Unlimited", TestConstant.KEY_TYPE_PRODUCTION, 3600);
-    }
+//    @BeforeClass
+//    private void setup() throws Exception {
+//        String label = "apimTestLabel";
+//        String project = "apimTestProject";
+//        //get mock APIM Instance
+//        MockAPIPublisher pub = MockAPIPublisher.getInstance();
+//        API api = new API();
+//        api.setName("PizzaShackAPI");
+//        api.setContext("/pizzashack");
+//        api.setEndpoint(getMockServiceURLHttp("/echo"));
+//        api.setVersion("1.0.0");
+//        api.setProvider("admin");
+//        //Register API with label
+//        pub.addApi(label, api);
+//
+//        //Define application info
+//        ApplicationDTO application = new ApplicationDTO();
+//        application.setName("jwtApp");
+//        application.setTier("Unlimited");
+//        application.setId((int) (Math.random() * 1000));
+//
+//        //Register a production token with key validation info
+//        KeyValidationInfo info = new KeyValidationInfo();
+//        info.setApi(api);
+//        info.setApplication(application);
+//        info.setAuthorized(true);
+//        info.setKeyType(TestConstant.KEY_TYPE_PRODUCTION);
+//        info.setSubscriptionTier("Unlimited");
+//
+//        String configPath = "confs/http2-test.conf";
+//        super.init(label, project, configPath);
+//
+//        jwtTokenProd = getJWT(api, application, "Unlimited", TestConstant.KEY_TYPE_PRODUCTION, 3600);
+//    }
 
     @Test(description = "Test API invocation with an HTTP/2.0 request via insecure connection sending to HTTP/1.1 BE")
     public void testHTTP2RequestsViaInsecureConnectionWithHTTP1BE() throws Exception {

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/http2/HTTP2RequestsWithHTTP2BackEndTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/http2/HTTP2RequestsWithHTTP2BackEndTestCase.java
@@ -25,7 +25,6 @@ import io.netty.handler.codec.http2.HttpConversionUtil;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.micro.gateway.tests.common.BaseTestCase;
@@ -38,13 +37,11 @@ import org.wso2.micro.gateway.tests.context.Utils;
 import org.wso2.micro.gateway.tests.util.HTTP2Client.Http2ClientRequest;
 import org.wso2.micro.gateway.tests.util.HttpClientRequest;
 import org.wso2.micro.gateway.tests.util.TestConstant;
-
-import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
-
 import static org.wso2.micro.gateway.tests.util.TestConstant.GATEWAY_LISTENER_HTTPS_PORT;
 import static org.wso2.micro.gateway.tests.util.TestConstant.GATEWAY_LISTENER_HTTP_PORT;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class HTTP2RequestsWithHTTP2BackEndTestCase extends BaseTestCase {
 
@@ -52,12 +49,12 @@ public class HTTP2RequestsWithHTTP2BackEndTestCase extends BaseTestCase {
     private static final Log log = LogFactory.getLog(HTTP2RequestsWithHTTP2BackEndTestCase.class);
     protected MockHttp2Server mockHttp2Server;
     protected Http2ClientRequest http2ClientRequest;
-    private String jwtTokenProd;
+    protected String jwtTokenProd;
 
     @BeforeClass
-    private void setup() throws Exception {
-        String label = "apimTestLabel";
-        String project = "apimTestProject";
+    public void setup() throws Exception {
+        String label = "http2TestLabel";
+        String project = "http2TestProject";
         //get mock APIM Instance
         MockAPIPublisher pub = MockAPIPublisher.getInstance();
         API api = new API();
@@ -66,6 +63,15 @@ public class HTTP2RequestsWithHTTP2BackEndTestCase extends BaseTestCase {
         api.setEndpoint("https://localhost:8443");
         api.setVersion("1.0.0");
         api.setProvider("admin");
+        //Register API with label
+        pub.addApi(label, api);
+
+        API api2 = new API();
+        api2.setName("PizzaShackAPINew");
+        api2.setContext("/pizzashack1");
+        api2.setEndpoint(getMockServiceURLHttp("/echo"));
+        api2.setVersion("2.0.0");
+        api2.setProvider("admin");
         //Register API with label
         pub.addApi(label, api);
 
@@ -132,9 +138,9 @@ public class HTTP2RequestsWithHTTP2BackEndTestCase extends BaseTestCase {
         log.info("Response: " + response.getResponseMessage() + " , " + response.getResponseCode());
     }
 
-    @AfterClass
-    public void stop() throws Exception {
-        //Stop all the mock servers
-        super.finalize();
-    }
+//    @AfterClass
+//    public void stop() throws Exception {
+//        //Stop all the mock servers
+//        super.finalize();
+//    }
 }

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/http2/HTTP2RequestsWithHTTP2BackEndTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/http2/HTTP2RequestsWithHTTP2BackEndTestCase.java
@@ -137,10 +137,4 @@ public class HTTP2RequestsWithHTTP2BackEndTestCase extends BaseTestCase {
                 .doGet(getServiceURLHttp("/pizzashack/1.0.0/menu"), headers);
         log.info("Response: " + response.getResponseMessage() + " , " + response.getResponseCode());
     }
-
-//    @AfterClass
-//    public void stop() throws Exception {
-//        //Stop all the mock servers
-//        super.finalize();
-//    }
 }

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/security/APIInvokeWithBasicAuthTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/security/APIInvokeWithBasicAuthTestCase.java
@@ -19,73 +19,15 @@ package org.wso2.micro.gateway.tests.security;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.micro.gateway.tests.common.BaseTestCase;
-import org.wso2.micro.gateway.tests.common.KeyValidationInfo;
-import org.wso2.micro.gateway.tests.common.MockAPIPublisher;
 import org.wso2.micro.gateway.tests.common.MockHttpServer;
-import org.wso2.micro.gateway.tests.common.model.API;
-import org.wso2.micro.gateway.tests.common.model.ApplicationDTO;
 import org.wso2.micro.gateway.tests.util.HttpClientRequest;
-import org.wso2.micro.gateway.tests.util.TestConstant;
 
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 
-public class APIInvokeWithBasicAuthTestCase extends BaseTestCase {
-    private String prodToken, sandToken, jwtTokenProd, jwtTokenSand, expiringJwtTokenProd;
-
-    @BeforeClass
-    public void start() throws Exception {
-        String label = "apimTestLabel";
-        String project = "apimTestProject";
-        //get mock APIM Instance
-        MockAPIPublisher pub = MockAPIPublisher.getInstance();
-        API api = new API();
-        api.setName("PizzaShackAPI");
-        api.setContext("/pizzashack");
-        api.setProdEndpoint(getMockServiceURLHttp("/echo/prod"));
-        api.setSandEndpoint(getMockServiceURLHttp("/echo/sand"));
-        api.setVersion("1.0.0");
-        api.setProvider("admin");
-        //Register API with label
-        pub.addApi(label, api);
-
-        //Define application info
-        ApplicationDTO application = new ApplicationDTO();
-        application.setName("jwtApp");
-        application.setTier("Unlimited");
-        application.setId((int) (Math.random() * 1000));
-
-        //Register a production token with key validation info
-        KeyValidationInfo info = new KeyValidationInfo();
-        info.setApi(api);
-        info.setApplication(application);
-        info.setAuthorized(true);
-        info.setKeyType(TestConstant.KEY_TYPE_PRODUCTION);
-        info.setSubscriptionTier("Unlimited");
-
-        //Register a production token with key validation info
-        prodToken = pub.getAndRegisterAccessToken(info);
-
-        //Register a sandbox token with key validation info
-        KeyValidationInfo infoSand = new KeyValidationInfo();
-        infoSand.setApi(api);
-        infoSand.setApplication(application);
-        infoSand.setAuthorized(true);
-        infoSand.setKeyType(TestConstant.KEY_TYPE_SANDBOX);
-        infoSand.setSubscriptionTier("Unlimited");
-        sandToken = pub.getAndRegisterAccessToken(infoSand);
-
-        jwtTokenProd = getJWT(api, application, "Unlimited", TestConstant.KEY_TYPE_PRODUCTION, 3600);
-        jwtTokenSand = getJWT(api, application, "Unlimited", TestConstant.KEY_TYPE_SANDBOX, 3600);
-        expiringJwtTokenProd = getJWT(api, application, "Unlimited", TestConstant.KEY_TYPE_PRODUCTION, 1);
-        //generate apis with CLI and start the micro gateway server only supports basic Auth
-        super.init(label, project);
-    }
+public class APIInvokeWithBasicAuthTestCase extends APIInvokeWithOAuthTestCase {
 
     @Test(description = "Test API invocation with a JWT token")
     public void testApiInvokeFailWithJWT() throws Exception {
@@ -168,12 +110,6 @@ public class APIInvokeWithBasicAuthTestCase extends BaseTestCase {
                 .doGet(getServiceURLHttp("/pizzashack/1.0.0/basic-menu"), headers);
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), responseCode, "Response code mismatched");
-    }
-
-    @AfterClass
-    public void stop() throws Exception {
-        //Stop all the mock servers
-        super.finalize();
     }
 
 }

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/security/APIInvokeWithOAuth2andBasicAuthTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/security/APIInvokeWithOAuth2andBasicAuthTestCase.java
@@ -20,71 +20,15 @@ package org.wso2.micro.gateway.tests.security;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.micro.gateway.tests.common.BaseTestCase;
-import org.wso2.micro.gateway.tests.common.KeyValidationInfo;
-import org.wso2.micro.gateway.tests.common.MockAPIPublisher;
 import org.wso2.micro.gateway.tests.common.MockHttpServer;
-import org.wso2.micro.gateway.tests.common.model.API;
-import org.wso2.micro.gateway.tests.common.model.ApplicationDTO;
 import org.wso2.micro.gateway.tests.util.HttpClientRequest;
-import org.wso2.micro.gateway.tests.util.TestConstant;
 
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 
-public class APIInvokeWithOAuth2andBasicAuthTestCase extends BaseTestCase {
-    private String prodToken, sandToken, jwtTokenProd, jwtTokenSand, expiringJwtTokenProd;
-
-    @BeforeClass
-    public void start() throws Exception {
-        String label = "apimTestLabel";
-        String project = "apimTestProject";
-        //get mock APIM Instance
-        MockAPIPublisher pub = MockAPIPublisher.getInstance();
-        API api = new API();
-        api.setName("PizzaShackAPI");
-        api.setContext("/pizzashack");
-        api.setProdEndpoint(getMockServiceURLHttp("/echo/prod"));
-        api.setSandEndpoint(getMockServiceURLHttp("/echo/sand"));
-        api.setVersion("1.0.0");
-        api.setProvider("admin");
-        //Register API with label
-        pub.addApi(label, api);
-
-        //Define application info
-        ApplicationDTO application = new ApplicationDTO();
-        application.setName("jwtApp");
-        application.setTier("Unlimited");
-        application.setId((int) (Math.random() * 1000));
-
-        //Register a production token with key validation info
-        KeyValidationInfo info = new KeyValidationInfo();
-        info.setApi(api);
-        info.setApplication(application);
-        info.setAuthorized(true);
-        info.setKeyType(TestConstant.KEY_TYPE_PRODUCTION);
-        info.setSubscriptionTier("Unlimited");
-        //Register a production token with key validation info
-        prodToken = pub.getAndRegisterAccessToken(info);
-
-        //Register a sandbox token with key validation info
-        KeyValidationInfo infoSand = new KeyValidationInfo();
-        infoSand.setApi(api);
-        infoSand.setApplication(application);
-        infoSand.setAuthorized(true);
-        infoSand.setKeyType(TestConstant.KEY_TYPE_SANDBOX);
-        infoSand.setSubscriptionTier("Unlimited");
-        sandToken = pub.getAndRegisterAccessToken(infoSand);
-
-        jwtTokenProd = getJWT(api, application, "Unlimited", TestConstant.KEY_TYPE_PRODUCTION, 3600);
-        jwtTokenSand = getJWT(api, application, "Unlimited", TestConstant.KEY_TYPE_SANDBOX, 3600);
-        expiringJwtTokenProd = getJWT(api, application, "Unlimited", TestConstant.KEY_TYPE_PRODUCTION, 1);
-        //generate apis with CLI and start the micro gateway server
-        super.init(label, project);
-    }
+public class APIInvokeWithOAuth2andBasicAuthTestCase extends APIInvokeWithBasicAuthTestCase {
 
     @Test(description = "Test API invocation with a oauth token")
     public void testApiInvoke() throws Exception {

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/security/APIInvokeWithOAuthTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/security/APIInvokeWithOAuthTestCase.java
@@ -19,7 +19,6 @@ package org.wso2.micro.gateway.tests.security;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.micro.gateway.tests.common.BaseTestCase;
@@ -35,7 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class APIInvokeWithOAuthTestCase extends BaseTestCase {
-    private String prodToken, sandToken, jwtTokenProd, jwtTokenSand, expiringJwtTokenProd;
+    protected String prodToken, sandToken, jwtTokenProd, jwtTokenSand, expiringJwtTokenProd;
 
     @BeforeClass
     public void start() throws Exception {
@@ -158,9 +157,4 @@ public class APIInvokeWithOAuthTestCase extends BaseTestCase {
 //        Assert.assertEquals(response.getResponseCode(), responseCode, "Response code mismatched");
 //    }
 
-    @AfterClass
-    public void stop() throws Exception {
-        //Stop all the mock servers
-        super.finalize();
-    }
 }

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/security/AuthenticationFailureTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/security/AuthenticationFailureTestCase.java
@@ -21,7 +21,6 @@ package org.wso2.micro.gateway.tests.security;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import org.apache.commons.io.IOUtils;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.micro.gateway.tests.common.BaseTestCase;
@@ -32,7 +31,6 @@ import org.wso2.micro.gateway.tests.util.HttpClientRequest;
 import org.wso2.micro.gateway.tests.util.HttpResponse;
 import org.wso2.micro.gateway.tests.util.TestConstant;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.util.HashMap;
 import java.util.Map;
@@ -44,7 +42,7 @@ public class AuthenticationFailureTestCase extends BaseTestCase {
     private String invalidSubscriptionToken, invalidScopeToken;
 
     @BeforeClass
-    private void setup() throws Exception {
+    public void setup() throws Exception {
         String label = "apimTestLabel";
         String project = "apimTestProject";
         //get mock APIM Instance
@@ -72,7 +70,8 @@ public class AuthenticationFailureTestCase extends BaseTestCase {
         info1.setStringResponse(response1);
         invalidScopeToken = pub.getAndRegisterAccessToken(info1);
 
-        super.init(label, project);
+        String configPath = "confs/mutualSSL-test.conf";
+        super.init(label, project, configPath);
     }
 
     @Test(description = "Test without auth header")
@@ -117,10 +116,5 @@ public class AuthenticationFailureTestCase extends BaseTestCase {
         Assert.assertTrue(response.getData().contains("Resource forbidden"));
     }
 
-    @AfterClass
-    public void stop() throws Exception {
-        //Stop all the mock servers
-        super.finalize();
-    }
 }
 

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/security/DisableSecurityAndCustomAuthHeaderTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/security/DisableSecurityAndCustomAuthHeaderTestCase.java
@@ -18,42 +18,19 @@
 
 package org.wso2.micro.gateway.tests.security;
 
-import io.netty.handler.codec.http.HttpHeaderNames;
-import org.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.micro.gateway.tests.common.BaseTestCase;
 import org.wso2.micro.gateway.tests.common.ResponseConstants;
-import org.wso2.micro.gateway.tests.common.model.ApplicationDTO;
 import org.wso2.micro.gateway.tests.util.HttpClientRequest;
-import org.wso2.micro.gateway.tests.util.TestConstant;
-import org.wso2.micro.gateway.tests.util.TokenUtil;
 
-import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
  * This test class is used to test disable security at API/resource level and usage of custom authentication header
  */
-public class DisableSecurityAndCustomAuthHeaderTestCase extends BaseTestCase {
-    private String jwtTokenProd;
-
-    @BeforeClass
-    public void start() throws Exception {
-
-        String project = "disableSecurityProject";
-        //Define application info
-        ApplicationDTO application = new ApplicationDTO();
-        application.setName("jwtApp");
-        application.setTier("Unlimited");
-        application.setId((int) (Math.random() * 1000));
-
-        jwtTokenProd = TokenUtil.getBasicJWT(application, new JSONObject(), TestConstant.KEY_TYPE_PRODUCTION, 3600);
-        super.init(project, new String[]{"common_api.yaml", "security/disable_security.yaml"});
-    }
+public class DisableSecurityAndCustomAuthHeaderTestCase extends ScopesTestCase {
 
     @Test(description = "Test Invoking un secured resource which is specified at API level without token")
     public void testDisableSecurityAPILevel() throws Exception {

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/security/MutualSSLTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/security/MutualSSLTestCase.java
@@ -21,18 +21,9 @@ package org.wso2.micro.gateway.tests.security;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.micro.gateway.tests.common.BaseTestCase;
-import org.wso2.micro.gateway.tests.common.MockAPIPublisher;
-import org.wso2.micro.gateway.tests.common.model.API;
 
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -42,33 +33,17 @@ import java.net.UnknownHostException;
 import java.security.KeyStore;
 import java.security.SecureRandom;
 import java.util.Properties;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
 
 /**
  * Testing the pizza_shack api rest for mutualSSL feature
  */
-public class MutualSSLTestCase extends BaseTestCase {
+public class MutualSSLTestCase extends AuthenticationFailureTestCase {
 
     private static final Log log = LogFactory.getLog(MutualSSLTestCase.class);
-
-    @BeforeClass
-    private void setup() throws Exception {
-        String label = "apimTestLabel";
-        String project = "apimTestProject";
-        //get mock APIM Instance
-        MockAPIPublisher pub = MockAPIPublisher.getInstance();
-        API api = new API();
-        api.setName("PizzaShackAPI");
-        api.setContext("/pizzashack");
-        api.setProdEndpoint(getMockServiceURLHttp("/echo/prod"));
-        api.setSandEndpoint(getMockServiceURLHttp("/echo/sand"));
-        api.setVersion("1.0.0");
-        api.setProvider("admin");
-        //Register API with label
-        pub.addApi(label, api);
-
-        String configPath = "confs/mutualSSL-test.conf";
-        super.init(label, project, configPath);
-    }
 
     @Test(description = "mutual SSL is properly established with ballerina keystore and trust store")
     public void mutualSSLEstablished() throws Exception {

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/security/ScopesTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/security/ScopesTestCase.java
@@ -21,7 +21,6 @@ package org.wso2.micro.gateway.tests.security;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import org.json.JSONObject;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.micro.gateway.tests.common.BaseTestCase;
@@ -39,7 +38,7 @@ import java.util.Map;
  */
 public class ScopesTestCase extends BaseTestCase {
 
-    private String jwtTokenProd;
+    protected String jwtTokenProd;
     private String jwtTokenProdWithScopes;
     private String jwtTokenProdWithSingleScope;
     private String jwtTokenProdWithMultipleScope;
@@ -69,7 +68,7 @@ public class ScopesTestCase extends BaseTestCase {
                 .getJwtWithCustomClaims(application, new JSONObject(), TestConstant.KEY_TYPE_PRODUCTION, 3600,
                         claimMap);
         //generate apis with CLI and start the micro gateway server
-        super.init(project, new String[] { "common_api.yaml" });
+        super.init(project, new String[] { "common_api.yaml", "security/disable_security.yaml" });
     }
 
     @Test(description = "Test Invoking the resource which is protected by scopes without providing the scopes")
@@ -145,9 +144,4 @@ public class ScopesTestCase extends BaseTestCase {
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
     }
 
-    @AfterClass
-    public void stop() throws Exception {
-        //Stop all the mock servers
-        super.finalize();
-    }
 }

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/throttling/OpenApiThrottlingTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/throttling/OpenApiThrottlingTestCase.java
@@ -19,17 +19,12 @@
 package org.wso2.micro.gateway.tests.throttling;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
-import org.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.micro.gateway.tests.common.BaseTestCase;
 import org.wso2.micro.gateway.tests.common.ResponseConstants;
-import org.wso2.micro.gateway.tests.common.model.ApplicationDTO;
+import org.wso2.micro.gateway.tests.extensions.OASAPIInvokeTestCase;
 import org.wso2.micro.gateway.tests.util.HttpClientRequest;
-import org.wso2.micro.gateway.tests.util.TestConstant;
-import org.wso2.micro.gateway.tests.util.TokenUtil;
 import org.wso2.micro.gateway.tests.util.HttpResponse;
 
 import java.util.HashMap;
@@ -38,25 +33,9 @@ import java.util.Map;
 /**
  * This test class is used to test per API/Resource throttling policies.
  */
-public class OpenApiThrottlingTestCase extends BaseTestCase {
-    private String jwtTokenProd;
+public class OpenApiThrottlingTestCase extends OASAPIInvokeTestCase {
     private HttpResponse response;
     private String perResourceUrl = "petstore/v1/pet/1";
-
-    @BeforeClass
-    public void start() throws Exception {
-        String project = "OpenApiThrottlingProject";
-        //Define application info
-        ApplicationDTO application = new ApplicationDTO();
-        application.setName("jwtApp");
-        application.setTier("Unlimited");
-        application.setId((int) (Math.random() * 1000));
-
-        jwtTokenProd = TokenUtil.getBasicJWT(application, new JSONObject(),
-                TestConstant.KEY_TYPE_PRODUCTION, 3600);
-        //generate apis with CLI and start the micro gateway server
-        super.init(project, new String[]{"common_api.yaml"});
-    }
 
     @Test(description = "Test throttling with non existing policy")
     public void testThrottlingWithNonExistingPolicy() throws Exception {

--- a/tests/src/test/resources/openAPIs/endpoints/endpoint_override.yaml
+++ b/tests/src/test/resources/openAPIs/endpoints/endpoint_override.yaml
@@ -4,7 +4,7 @@ info:
     Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
     #swagger](http://swagger.io/irc/).  For this sample, you can use the api key
     `special-key` to test the authorization filters."
-  version: 1.0.0
+  version: 2.0.0
   title: PetStoreAPI
   termsOfService: http://swagger.io/terms/
   contact:
@@ -12,8 +12,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-x-wso2-basePath: /petstore/v1
-x-wso2-throttling-tier: 8PerMin
+x-wso2-basePath: /petstore/v2
 x-wso2-production-endpoints: "#/x-wso2-endpoints/myEndpoint2"
 security:
   - petstore_auth: []

--- a/tests/src/test/resources/openAPIs/endpoints/endpoint_security.yaml
+++ b/tests/src/test/resources/openAPIs/endpoints/endpoint_security.yaml
@@ -4,7 +4,7 @@ info:
     Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
     #swagger](http://swagger.io/irc/).  For this sample, you can use the api key
     `special-key` to test the authorization filters."
-  version: 1.0.0
+  version: 5.0.0
   title: PetStoreAPI
   termsOfService: http://swagger.io/terms/
   contact:
@@ -12,7 +12,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-x-wso2-basePath: /petstore/v1
+x-wso2-basePath: /petstore/v5
 x-wso2-throttling-tier: 8PerMin
 x-wso2-production-endpoints: "#/x-wso2-endpoints/myEndpoint2"
 security:

--- a/tests/src/test/resources/openAPIs/endpoints/load_balance.yaml
+++ b/tests/src/test/resources/openAPIs/endpoints/load_balance.yaml
@@ -28,7 +28,7 @@ tags:
   externalDocs:
     description: Find out more about our store
     url: http://swagger.io
-x-wso2-basePath: /petstore/v2
+x-wso2-basePath: /petstore/v4
 x-wso2-production-endpoints:
   urls:
     - https://localhost:2380/v1

--- a/tests/src/test/resources/testng.xml
+++ b/tests/src/test/resources/testng.xml
@@ -35,16 +35,9 @@
         <classes>
             <class name="org.wso2.micro.gateway.tests.apikey.APIKeyTestCase" />
             <class name="org.wso2.micro.gateway.tests.jwtRevocation.JWTRevocationSupportTestCase" />
-            <class name="org.wso2.micro.gateway.tests.security.AuthenticationFailureTestCase" />
             <class name="org.wso2.micro.gateway.tests.security.MutualSSLTestCase" />
             <class name="org.wso2.micro.gateway.tests.http2.HTTP2RequestsWithHTTP1BackEndTestCase" />
-            <class name="org.wso2.micro.gateway.tests.http2.HTTP2RequestsWithHTTP2BackEndTestCase" />
-            <class name="org.wso2.micro.gateway.tests.endpoints.ResourceLevelEndpointsTestCase" />
-            <class name="org.wso2.micro.gateway.tests.endpoints.EndpointsByReferenceTestCase" />
-            <class name="org.wso2.micro.gateway.tests.endpoints.EndpointOverrideTestCase" />
-            <class name="org.wso2.micro.gateway.tests.endpoints.MultipleEndpointsTestCase" />
             <class name="org.wso2.micro.gateway.tests.endpoints.EndpointWithSecurityTestCase" />
-            <class name="org.wso2.micro.gateway.tests.security.ScopesTestCase" />
             <class name="org.wso2.micro.gateway.tests.security.DisableSecurityAndCustomAuthHeaderTestCase" />
             <class name="org.wso2.micro.gateway.tests.grpc.BasicGrpcTestCase" />
         </classes>
@@ -54,14 +47,9 @@
         <classes>
             <!-- DistributedThrottlingTestCase should be the first since it starts message broker -->
             <class name="org.wso2.micro.gateway.tests.throttling.DistributedThrottlingTestCase"/>
-
             <class name="org.wso2.micro.gateway.tests.security.APIInvokeWithOAuth2andBasicAuthTestCase"/>
-            <class name="org.wso2.micro.gateway.tests.security.APIInvokeWithBasicAuthTestCase"/>
-            <class name="org.wso2.micro.gateway.tests.security.APIInvokeWithOAuthTestCase"/>
-
             <class name="org.wso2.micro.gateway.tests.throttling.ThrottlingTestCase"/>
             <class name="org.wso2.micro.gateway.tests.throttling.OpenApiThrottlingTestCase"/>
-            <class name="org.wso2.micro.gateway.tests.extensions.OASAPIInvokeTestCase"/>
             <!--            <class name="org.wso2.micro.gateway.tests.security.CookieAuthTestCase"/>-->
             <class name="org.wso2.micro.gateway.tests.validation.ValidationTestCase"/>
             <class name="org.wso2.micro.gateway.tests.interceptor.JavaInterceptorTestCase"/>


### PR DESCRIPTION
### Purpose
Reduce the integration test running time. This will reduce the total number of project builds from 23 to 13.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1116 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
