### PR TITLE
Fix #1056 - Toolkit fails when toolkit path contains spaces

### DIFF
--- a/distribution/resources/bin/gateway
+++ b/distribution/resources/bin/gateway
@@ -181,7 +181,7 @@ java_cmd_tools () {
       -XX:HeapDumpPath="$GW_HOME/heap-dump.hprof" \
       $JAVA_OPTS \
       -classpath "$METRIC_CLASSPATH" \
-      org.wso2.micro.gateway.tools.Main $1 $2| tee -a $GW_HOME/logs/microgateway.log
+      org.wso2.micro.gateway.tools.Main "$1" "$2" | tee -a "$GW_HOME/logs/microgateway.log"
 }
 
 java_cmd_gateway () {
@@ -190,11 +190,11 @@ java_cmd_gateway () {
     -XX:+HeapDumpOnOutOfMemoryError \
     -XX:HeapDumpPath="$GW_HOME/heap-dump.hprof" \
     $JAVA_OPTS \
-    -Dmgw-runtime.home=${GW_HOME} \
-    -Dballerina.home=${GW_HOME}/runtime \
+    -Dmgw-runtime.home="${GW_HOME}" \
+    -Dballerina.home="${GW_HOME}/runtime" \
     -Djava.util.logging.config.class="org.ballerinalang.logging.util.LogConfigReader" \
     -Djava.util.logging.manager="org.ballerinalang.logging.BLogManager" \
-    -jar $args --api.usage.data.path=$GW_HOME/api-usage-data --b7a.config.file=$CONFIG_FILE 2>&1 | tee -a $GW_HOME/logs/microgateway.log
+    -jar $args --api.usage.data.path="$GW_HOME/api-usage-data" --b7a.config.file="$CONFIG_FILE" 2>&1 | tee -a "$GW_HOME/logs/microgateway.log"
 }
 
 java_cmd_gateway_background () {
@@ -205,11 +205,11 @@ java_cmd_gateway_background () {
     -XX:+HeapDumpOnOutOfMemoryError \
     -XX:HeapDumpPath="$GW_HOME/heap-dump.hprof" \
     $JAVA_OPTS \
-    -Dmgw-runtime.home=${GW_HOME} \
-    -Dballerina.home=${GW_HOME}/runtime \
+    -Dmgw-runtime.home="${GW_HOME}" \
+    -Dballerina.home="${GW_HOME}/runtime" \
     -Djava.util.logging.config.class="org.ballerinalang.logging.util.LogConfigReader" \
     -Djava.util.logging.manager="org.ballerinalang.logging.BLogManager" \
-    -jar $args --api.usage.data.path=$GW_HOME/api-usage-data --b7a.config.file=$CONFIG_FILE 2>&1 | tee -a $GW_HOME/logs/microgateway.log
+    -jar $args --api.usage.data.path="$GW_HOME/api-usage-data" --b7a.config.file="$CONFIG_FILE" 2>&1 | tee -a "$GW_HOME/logs/microgateway.log"
 EOF
 }
 
@@ -284,7 +284,7 @@ else
 fi
 
 if [ ! "$CMD" = "stop" ]; then
-    java_cmd_tools "$CONFIG_FILE $CONFIG_OUT_FILE"
+    java_cmd_tools "$CONFIG_FILE" "$CONFIG_OUT_FILE"
   if [ -f "$CONFIG_OUT_FILE" ]; then
       if [ "$OBSERVABILITY_FLAG" != "true" ]; then
           if [ $(sed -n '1p' $CONFIG_OUT_FILE) == "true" ]; then
@@ -308,7 +308,7 @@ if [ "$CMD" = "start" ]; then
       exit 0
     fi
   fi
-  rm -f file $GW_HOME/bin/gateway.pid
+  rm -f file "$GW_HOME/bin/gateway.pid"
 
   java_cmd_gateway_background
 

--- a/distribution/resources/bin/micro-gw
+++ b/distribution/resources/bin/micro-gw
@@ -298,12 +298,12 @@ if [ "$IS_BUILD_COMMAND" = true ] && [ "$CMD_PRO_NAME_VAL" != "" ] && [ "$MICRO_
         $JAVA_OPTS \
         -classpath "$CLI_CLASSPATH" \
         -Djava.security.egd=file:/dev/./urandom \
-        -Dballerina.home=$BALLERINA_HOME \
+        -Dballerina.home="$BALLERINA_HOME" \
         -Djava.util.logging.config.class="org.wso2.apimgt.gateway.cli.logging.CLILogConfigReader" \
         -Djava.util.logging.manager="org.wso2.apimgt.gateway.cli.logging.CLILogManager" \
         -Dfile.encoding=UTF8 \
         -Dtemplates.dir.path="$MICROGW_HOME/resources/templates" \
-        -Dcli.home=$MICROGW_HOME \
+        -Dcli.home="$MICROGW_HOME" \
         -DVERBOSE_ENABLED=$VERBOSE_ENABLED \
         org.wso2.apimgt.gateway.cli.cmd.Main "$@"
 
@@ -326,7 +326,7 @@ if [ "$IS_BUILD_COMMAND" = true ] && [ "$CMD_PRO_NAME_VAL" != "" ] && [ "$MICRO_
 
         update_cli_classpath
         MICRO_GW_LABEL_PROJECT_DIR="$MICRO_GW_PROJECT_DIR/$CMD_PRO_NAME_VAL"
-        pushd $MICRO_GW_LABEL_PROJECT_DIR/target/gen > /dev/null
+        pushd "$MICRO_GW_LABEL_PROJECT_DIR"/target/gen > /dev/null
             # clean the .jar files of target folder
             if ls $MICRO_GW_LABEL_PROJECT_DIR/target/*.jar 1> /dev/null 2>&1; then
                 rm -f $MICRO_GW_LABEL_PROJECT_DIR/target/*.jar
@@ -338,10 +338,10 @@ if [ "$IS_BUILD_COMMAND" = true ] && [ "$CMD_PRO_NAME_VAL" != "" ] && [ "$MICRO_
 
             if [ $exit_code -eq 0 ]; then
                 # move all executable ballerina build outputs to MGW_PROJECT/target directory
-                mv $MICRO_GW_LABEL_PROJECT_DIR/target/gen/target/bin/*.jar $TARGET_PATH 2> /dev/null
+                mv "$MICRO_GW_LABEL_PROJECT_DIR"/target/gen/target/bin/*.jar "$TARGET_PATH" 2> /dev/null
             fi
 
-            if [ -f $TARGET_PATH ]; then
+            if [ -f "$TARGET_PATH" ]; then
                 printf "\n${GREEN}${BOLD}BUILD SUCCESSFUL${NC}\n"
                 printf  "${BOLD}Target: ${TARGET_PATH}${NC}\n"
             else
@@ -359,12 +359,12 @@ else
         $JAVA_OPTS \
         -classpath "$CLI_CLASSPATH" \
         -Djava.security.egd=file:/dev/./urandom \
-        -Dballerina.home=$BALLERINA_HOME \
+        -Dballerina.home="$BALLERINA_HOME" \
         -Djava.util.logging.config.class="org.wso2.apimgt.gateway.cli.logging.CLILogConfigReader" \
         -Djava.util.logging.manager="org.wso2.apimgt.gateway.cli.logging.CLILogManager" \
         -Dfile.encoding=UTF8 \
         -Dtemplates.dir.path="$MICROGW_HOME/resources/templates" \
-        -Dcli.home=$MICROGW_HOME \
+        -Dcli.home="$MICROGW_HOME" \
         -DVERBOSE_ENABLED=$VERBOSE_ENABLED \
         org.wso2.apimgt.gateway.cli.cmd.Main "$@"
 fi


### PR DESCRIPTION
### Purpose
Fix the issue if the toolkit extracted in a path where it contains spaces, or the project is created in a path where it contains the spaces.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1056 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
