### PR TITLE
Fix #1039 - Analytics error when authentication fails

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/analytics/responsetime_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/analytics/responsetime_util.bal
@@ -99,9 +99,9 @@ public function generateRequestResponseExecutionDataEvent(http:Response response
     APIConfiguration? apiConfiguration = apiConfigAnnotationMap[context.getServiceName()];
     if (apiConfiguration is APIConfiguration) {
         if (!stringutils:equalsIgnoreCase("", <string>apiConfiguration.publisher) 
-            && stringutils:equalsIgnoreCase("", <string>requestResponseExecutionDTO.apiCreator)) {
+            && stringutils:equalsIgnoreCase("", requestResponseExecutionDTO.apiCreator)) {
             requestResponseExecutionDTO.apiCreator = <string>apiConfiguration.publisher;
-        } else if (stringutils:equalsIgnoreCase("", <string>requestResponseExecutionDTO.apiCreator)) { 
+        } else if (stringutils:equalsIgnoreCase("", requestResponseExecutionDTO.apiCreator)) {
             requestResponseExecutionDTO.apiCreator = UNKNOWN_VALUE;
         }
         requestResponseExecutionDTO.apiVersion = <string>apiConfiguration.apiVersion;
@@ -164,9 +164,7 @@ public function generateRequestResponseExecutionDataEvent(http:Response response
     requestResponseExecutionDTO.applicationOwner = <string>context.attributes[APPLICATION_OWNER_PROPERTY];
     requestResponseExecutionDTO.apiCreatorTenantDomain = <string>context.attributes[API_CREATOR_TENANT_DOMAIN_PROPERTY];
     requestResponseExecutionDTO.apiTier = <string>context.attributes[API_TIER_PROPERTY];
-
     requestResponseExecutionDTO.throttledOut = <boolean>context.attributes[CONTINUE_ON_TROTTLE_PROPERTY];
-
     requestResponseExecutionDTO.userAgent = <string>context.attributes[USER_AGENT_PROPERTY];
     requestResponseExecutionDTO.userIp = <string>context.attributes[USER_IP_PROPERTY];
     requestResponseExecutionDTO.requestTimestamp = <int>context.attributes[REQUEST_TIME_PROPERTY];

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/analytics_request_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/analytics_request_filter.bal
@@ -38,7 +38,8 @@ public type AnalyticsRequestFilter object {
             return true;
         }
         if (isAnalyticsEnabled || isGrpcAnalyticsEnabled) {
-            boolean filterFailed = <boolean>context.attributes[FILTER_FAILED];
+            runtime:InvocationContext invocationContext = runtime:getInvocationContext();
+            boolean filterFailed = <boolean>invocationContext.attributes[FILTER_FAILED];
             if (context.attributes.hasKey(IS_THROTTLE_OUT)) {
                 boolean isThrottleOut = <boolean>context.attributes[IS_THROTTLE_OUT];
                 if (isThrottleOut) {

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/analytics_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/analytics_util.bal
@@ -68,9 +68,9 @@ function populateThrottleAnalyticsDTO(http:FilterContext context) returns (Throt
     if (apiConfiguration is APIConfiguration) {
         eventDto.apiVersion = apiConfiguration.apiVersion;
         if (!stringutils:equalsIgnoreCase("", <string>apiConfiguration.publisher)
-                && stringutils:equalsIgnoreCase("", <string>eventDto.apiCreator)) {
+                && stringutils:equalsIgnoreCase("", eventDto.apiCreator)) {
             eventDto.apiCreator = <string>apiConfiguration.publisher;
-        } else if (stringutils:equalsIgnoreCase("", <string>eventDto.apiCreator)) {
+        } else if (stringutils:equalsIgnoreCase("", eventDto.apiCreator)) {
             //sets API creator if x-wso2-owner extension not specified.
             eventDto.apiCreator = UNKNOWN_VALUE;
         }
@@ -128,9 +128,9 @@ function populateFaultAnalyticsDTO(http:FilterContext context, string err) retur
         var api_Version = apiConfig.apiVersion;
         eventDto.apiVersion = api_Version;
         if (!stringutils:equalsIgnoreCase("", <string>apiConfig.publisher)
-                && stringutils:equalsIgnoreCase("", <string>eventDto.apiCreator)) {
+                && stringutils:equalsIgnoreCase("", eventDto.apiCreator)) {
             eventDto.apiCreator = <string>apiConfig.publisher;
-        } else if (stringutils:equalsIgnoreCase("", <string>eventDto.apiCreator)) {
+        } else if (stringutils:equalsIgnoreCase("", eventDto.apiCreator)) {
             //sets API creator if x-wso2-owner extension not specified.
             eventDto.apiCreator = UNKNOWN_VALUE;
         }


### PR DESCRIPTION
### Purpose
If there is an issue due to a filter failure, then that should be skipped in the analytics response path. We need to set the correct attribute to invocation context and read it in the analytics response path.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1039 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
