### PR TITLE
Add callhome feature for micro-gw toolkit and runtime

### DIFF
--- a/components/micro-gateway-cli/pom.xml
+++ b/components/micro-gateway-cli/pom.xml
@@ -106,6 +106,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.callhome</groupId>
+            <artifactId>core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
@@ -42,7 +42,6 @@ import org.wso2.apimgt.gateway.cli.model.config.DockerConfig;
 import org.wso2.apimgt.gateway.cli.utils.CmdUtils;
 import org.wso2.apimgt.gateway.cli.utils.ToolkitLibExtractionUtils;
 import org.wso2.callhome.CallHomeExecutor;
-import org.wso2.callhome.core.DataHolder;
 import org.wso2.callhome.utils.CallHomeInfo;
 import org.wso2.callhome.utils.MessageFormatter;
 import org.wso2.callhome.utils.Util;
@@ -58,10 +57,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * This class represents the "build" command and it holds arguments and flags specified by the user.
@@ -352,7 +347,7 @@ public class BuildCmd implements LauncherCmd {
         CallHomeExecutor.execute(callhomeinfo);
         String callHomeResponse = CallHomeExecutor.getMessage();
         String formattedMessage = MessageFormatter.formatMessage(callHomeResponse, 180);
-        outStream.print(formattedMessage);
+        outStream.println(formattedMessage);
     }
 
 

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
@@ -345,9 +345,15 @@ public class BuildCmd implements LauncherCmd {
 
         CallHomeInfo callhomeinfo = Util.createCallHomeInfo(productHome, trustStoreLocation, trustStorePassword);
         CallHomeExecutor.execute(callhomeinfo);
-        String callHomeResponse = CallHomeExecutor.getMessage();
-        String formattedMessage = MessageFormatter.formatMessage(callHomeResponse, 180);
-        outStream.println(formattedMessage);
+
+        Thread callHomeThread = new Thread(() -> {
+            String callHomeResponse = CallHomeExecutor.getMessage();
+            String formattedMessage = MessageFormatter.formatMessage(callHomeResponse, 180);
+            outStream.println(formattedMessage);
+        });
+        callHomeThread.setName("callHomeThread");
+        callHomeThread.start();
+
     }
 
 

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
@@ -95,7 +95,7 @@ public class BuildCmd implements LauncherCmd {
     private String dockerBaseImage;
 
     public void execute() {
-        runCallhome();
+        invokeCallhome();
 
         if (helpFlag) {
             String commandUsageInfo = getCommandUsageInfo("build");
@@ -338,7 +338,7 @@ public class BuildCmd implements LauncherCmd {
      * Invoke call home.
      *
      */
-    private void runCallhome() {
+    private void invokeCallhome() {
         String productHome = CmdUtils.getCLIHome();
         String trustStoreLocation = productHome + File.separator + RESTServiceConstants.DEFAULT_TRUSTSTORE_PATH;
         String trustStorePassword = RESTServiceConstants.DEFAULT_TRUSTSTORE_PASS;

--- a/components/micro-gateway-cli/src/main/resources/templates/ballerinaToml.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/ballerinaToml.mustache
@@ -26,6 +26,11 @@ target = "java8"
     [[platform.libraries]]
         module = "interceptor"
         path = "{{toolkitHome}}/lib/dependencies/json-20190722.jar"
+
+     [[platform.libraries]]
+        module = "callhome"
+        path = "{{toolkitHome}}/lib/gateway/platform/core-1.0.4.jar"
+
 {{#each libs}}
     [[platform.libraries]]
         path = "{{path}}"

--- a/components/micro-gateway-cli/src/main/resources/templates/main.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/main.mustache
@@ -1,6 +1,7 @@
 import wso2/gateway;
 
 public function main() {
+    gateway:invokeCallHome();
     int totalResourceLength = 0;
     boolean isRequestValidationEnabled  = gateway:getConfigBooleanValue(gateway:VALIDATION_CONFIG_INSTANCE_ID,
     gateway:REQUEST_VALIDATION_ENABLED, gateway:DEFAULT_REQUEST_VALIDATION_ENABLED);

--- a/components/micro-gateway-cli/src/main/resources/templates/main.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/main.mustache
@@ -1,7 +1,6 @@
 import wso2/gateway;
 
 public function main() {
-    gateway:invokeCallHome();
     int totalResourceLength = 0;
     boolean isRequestValidationEnabled  = gateway:getConfigBooleanValue(gateway:VALIDATION_CONFIG_INSTANCE_ID,
     gateway:REQUEST_VALIDATION_ENABLED, gateway:DEFAULT_REQUEST_VALIDATION_ENABLED);
@@ -30,4 +29,6 @@ public function main() {
 
     {{>jwtRevocation}}
     startupExtension();
+
+    future<()> callhome = start gateway:invokeCallHome();
 }

--- a/components/micro-gateway-core/pom.xml
+++ b/components/micro-gateway-core/pom.xml
@@ -120,6 +120,11 @@
             <artifactId>jackson-databind</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.callhome</groupId>
+            <artifactId>core</artifactId>
+            <version>${carbon.callhome.version}</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/components/micro-gateway-core/pom.xml
+++ b/components/micro-gateway-core/pom.xml
@@ -123,7 +123,6 @@
         <dependency>
             <groupId>org.wso2.carbon.callhome</groupId>
             <artifactId>core</artifactId>
-            <version>${carbon.callhome.version}</version>
         </dependency>
     </dependencies>
 

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/native/callHome.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/native/callHome.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/native/callHome.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/native/callHome.bal
@@ -15,11 +15,27 @@
 // under the License.
 
 import ballerinax/java;
+import ballerina/log;
 
 # Invoke callhome.
 #
-public function invokeCallHome() = @java:Method  {
+# + trustStoreLocation - truststore location
+# + trustStorePassword - truststore password
+public function runCallHome(handle trustStoreLocation, handle trustStorePassword ) = @java:Method  {
     name: "runCallHome",
     class: "org.wso2.micro.gateway.core.callhome.Callhome"
 } external;
 
+public function invokeCallHome() {
+    handle trustStoreLocationUnresolve = java:fromString(getConfigValue(LISTENER_CONF_INSTANCE_ID, TRUST_STORE_PATH, DEFAULT_TRUST_STORE_PATH));
+    handle trustStoreLocation = getTrustStoreLocation(trustStoreLocationUnresolve);
+    string trustStorePassword = getConfigValue(LISTENER_CONF_INSTANCE_ID, TRUST_STORE_PASSWORD, DEFAULT_TRUST_STORE_PASSWORD);
+
+    runCallHome(trustStoreLocation,java:fromString(trustStorePassword));
+}
+
+
+public function getTrustStoreLocation(handle pathsubstring) returns handle = @java:Method  {
+    name: "getTrustStoreLocation",
+    class: "org.wso2.micro.gateway.core.callhome.Callhome"
+} external;

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/native/callHome.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/native/callHome.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import ballerinax/java;
-import ballerina/log;
 
 # Invoke callhome.
 #

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/native/callHome.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/native/callHome.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/java;
+
+# Invoke callhome.
+#
+public function invokeCallHome() = @java:Method  {
+    name: "runCallHome",
+    class: "org.wso2.micro.gateway.core.callhome.Callhome"
+} external;
+

--- a/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/Constants.java
+++ b/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/Constants.java
@@ -67,4 +67,7 @@ public class Constants {
     public static final String JSONPATH_SCHEMAS = "$..components.schemas.";
     public static final String JSON_SCHEMA = ".content.application/json.schema";
     public static final String VALIDATED_STATUS = "validated";
+    public static final String RUNTIME_HOME_PATH = "mgw-runtime.home";
+    public static final String TRUST_STORE_LOCATION = "runtime/bre/security/ballerinaTruststore.p12";
+    public static final String TRUST_STORE_PASSWORD = "ballerina";
 }

--- a/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/Constants.java
+++ b/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/Constants.java
@@ -68,6 +68,4 @@ public class Constants {
     public static final String JSON_SCHEMA = ".content.application/json.schema";
     public static final String VALIDATED_STATUS = "validated";
     public static final String RUNTIME_HOME_PATH = "mgw-runtime.home";
-    public static final String TRUST_STORE_LOCATION = "runtime/bre/security/ballerinaTruststore.p12";
-    public static final String TRUST_STORE_PASSWORD = "ballerina";
 }

--- a/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/callhome/Callhome.java
+++ b/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/callhome/Callhome.java
@@ -18,32 +18,30 @@ package org.wso2.micro.gateway.core.callhome;
 
 import org.wso2.callhome.CallHomeExecutor;
 import org.wso2.callhome.utils.CallHomeInfo;
+import org.wso2.callhome.utils.MessageFormatter;
 import org.wso2.callhome.utils.Util;
 import org.wso2.micro.gateway.core.Constants;
 
-import java.io.File;
 /**
- * Invoke call home
+ * Invoke call home.
  *
  *
  */
 public class Callhome {
 
     /**
-     * run call home
+     * run call home.
      *
      */
-    public static void runCallHome() {
+    public static void runCallHome(String trustStoreLocation, String trustStorePassword) {
         String productHome = getRuntimeHome();
-        String trustStoreLocation = getTrustStoreLocation();
-        String trustStorePassword = Constants.TRUST_STORE_PASSWORD;
 
         CallHomeInfo callhomeinfo = Util.createCallHomeInfo(productHome, trustStoreLocation, trustStorePassword);
         CallHomeExecutor.execute(callhomeinfo);
     }
 
     /**
-     * Get runtime home location
+     * Get runtime home location.
      *
      * @return runtime home location
      */
@@ -52,11 +50,14 @@ public class Callhome {
     }
 
     /**
-     * Get truststore location
+     * Get truststore location.
      *
      * @return truststore location
      */
-    private static String getTrustStoreLocation() {
-        return getRuntimeHome() + File.separator + Constants.TRUST_STORE_LOCATION;
+    public static String getTrustStoreLocation(String fullpath) {
+        String homePathConst = "\\$\\{mgw-runtime.home}";
+        String homePath = System.getProperty(Constants.RUNTIME_HOME_PATH);
+        String correctPath = fullpath.replaceAll(homePathConst, homePath);
+        return correctPath;
     }
 }

--- a/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/callhome/Callhome.java
+++ b/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/callhome/Callhome.java
@@ -18,7 +18,6 @@ package org.wso2.micro.gateway.core.callhome;
 
 import org.wso2.callhome.CallHomeExecutor;
 import org.wso2.callhome.utils.CallHomeInfo;
-import org.wso2.callhome.utils.MessageFormatter;
 import org.wso2.callhome.utils.Util;
 import org.wso2.micro.gateway.core.Constants;
 

--- a/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/callhome/Callhome.java
+++ b/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/callhome/Callhome.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.micro.gateway.core.callhome;
+
+import org.wso2.callhome.CallHomeExecutor;
+import org.wso2.callhome.utils.CallHomeInfo;
+import org.wso2.callhome.utils.Util;
+import org.wso2.micro.gateway.core.Constants;
+
+import java.io.File;
+/**
+ * Invoke call home
+ *
+ *
+ */
+public class Callhome {
+
+    /**
+     * run call home
+     *
+     */
+    public static void runCallHome() {
+        String productHome = getRuntimeHome();
+        String trustStoreLocation = getTrustStoreLocation();
+        String trustStorePassword = Constants.TRUST_STORE_PASSWORD;
+
+        CallHomeInfo callhomeinfo = Util.createCallHomeInfo(productHome, trustStoreLocation, trustStorePassword);
+        CallHomeExecutor.execute(callhomeinfo);
+    }
+
+    /**
+     * Get runtime home location
+     *
+     * @return runtime home location
+     */
+    private static String getRuntimeHome() {
+        return System.getProperty(Constants.RUNTIME_HOME_PATH);
+    }
+
+    /**
+     * Get truststore location
+     *
+     * @return truststore location
+     */
+    private static String getTrustStoreLocation() {
+        return getRuntimeHome() + File.separator + Constants.TRUST_STORE_LOCATION;
+    }
+}

--- a/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/callhome/Callhome.java
+++ b/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/callhome/Callhome.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -23,14 +23,11 @@ import org.wso2.micro.gateway.core.Constants;
 
 /**
  * Invoke call home.
- *
- *
  */
 public class Callhome {
 
     /**
      * run call home.
-     *
      */
     public static void runCallHome(String trustStoreLocation, String trustStorePassword) {
         String productHome = getRuntimeHome();

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -104,7 +104,6 @@
         <dependency>
             <groupId>org.wso2.carbon.callhome</groupId>
             <artifactId>core</artifactId>
-            <version>${carbon.callhome.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -101,6 +101,11 @@
             <artifactId>jackson-annotations</artifactId>
             <version>${jackson-core.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.callhome</groupId>
+            <artifactId>core</artifactId>
+            <version>${carbon.callhome.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/distribution/resources/updates/product_linux.txt
+++ b/distribution/resources/updates/product_linux.txt
@@ -1,0 +1,1 @@
+${product.name}-toolkit-linux-${product.version}

--- a/distribution/resources/updates/product_macos.txt
+++ b/distribution/resources/updates/product_macos.txt
@@ -1,0 +1,1 @@
+${product.name}-toolkit-macos-${product.version}

--- a/distribution/resources/updates/product_windows.txt
+++ b/distribution/resources/updates/product_windows.txt
@@ -1,0 +1,1 @@
+${product.name}-toolkit-windows-${product.version}

--- a/distribution/src/main/assembly/gw_runtimes/gw_runtime_linux.xml
+++ b/distribution/src/main/assembly/gw_runtimes/gw_runtime_linux.xml
@@ -83,6 +83,13 @@
             <outputDirectory>wso2am-micro-gw-linux-${project.version}</outputDirectory>
             <destName>version.txt</destName>
         </file>
+        <file>
+            <source>${basedir}/resources/updates/product.txt</source>
+            <outputDirectory>wso2am-micro-gw-linux-${project.version}/updates</outputDirectory>
+            <filtered>true</filtered>
+            <fileMode>644</fileMode>
+            <destName>product.txt</destName>
+        </file>
     </files>
     <dependencySets>
         <dependencySet>

--- a/distribution/src/main/assembly/gw_runtimes/gw_runtime_macos.xml
+++ b/distribution/src/main/assembly/gw_runtimes/gw_runtime_macos.xml
@@ -83,6 +83,13 @@
             <outputDirectory>wso2am-micro-gw-macos-${project.version}</outputDirectory>
             <destName>version.txt</destName>
         </file>
+        <file>
+            <source>${basedir}/resources/updates/product.txt</source>
+            <outputDirectory>wso2am-micro-gw-macos-${project.version}/updates</outputDirectory>
+            <filtered>true</filtered>
+            <fileMode>644</fileMode>
+            <destName>product.txt</destName>
+        </file>
     </files>
     <dependencySets>
         <dependencySet>

--- a/distribution/src/main/assembly/gw_runtimes/gw_runtime_windows.xml
+++ b/distribution/src/main/assembly/gw_runtimes/gw_runtime_windows.xml
@@ -82,6 +82,13 @@
             <outputDirectory>wso2am-micro-gw-windows-${project.version}</outputDirectory>
             <destName>version.txt</destName>
         </file>
+        <file>
+            <source>${basedir}/resources/updates/product.txt</source>
+            <outputDirectory>wso2am-micro-gw-windows-${project.version}/updates</outputDirectory>
+            <filtered>true</filtered>
+            <fileMode>644</fileMode>
+            <destName>product.txt</destName>
+        </file>
     </files>
     <dependencySets>
         <dependencySet>

--- a/distribution/src/main/assembly/linux_bin.xml
+++ b/distribution/src/main/assembly/linux_bin.xml
@@ -138,6 +138,7 @@
                 <include>org.wso2.am.microgw:org.wso2.micro.gateway.cli:jar</include>
                 <include>com.moandjiezana.toml:toml4j:jar</include>
                 <include>com.beust:jcommander:jar</include>
+                <include>org.wso2.carbon.callhome:core</include>
             </includes>
         </dependencySet>
         <dependencySet>

--- a/distribution/src/main/assembly/linux_bin.xml
+++ b/distribution/src/main/assembly/linux_bin.xml
@@ -116,10 +116,11 @@
             <fileMode>644</fileMode>
         </file>
         <file>
-            <source>${basedir}/resources/updates/product.txt</source>
+            <source>${basedir}/resources/updates/product_linux.txt</source>
             <outputDirectory>wso2am-micro-gw-toolkit-linux-${project.version}/updates</outputDirectory>
             <filtered>true</filtered>
             <fileMode>644</fileMode>
+            <destName>product.txt</destName>
         </file>
         <file>
             <source>${basedir}/resources/version.txt</source>

--- a/distribution/src/main/assembly/macos_bin.xml
+++ b/distribution/src/main/assembly/macos_bin.xml
@@ -147,6 +147,7 @@
                 <include>org.wso2.am.microgw:org.wso2.micro.gateway.cli:jar</include>
                 <include>com.moandjiezana.toml:toml4j:jar</include>
                 <include>com.beust:jcommander:jar</include>
+                <include>org.wso2.carbon.callhome:core</include>
             </includes>
         </dependencySet>
         <dependencySet>

--- a/distribution/src/main/assembly/macos_bin.xml
+++ b/distribution/src/main/assembly/macos_bin.xml
@@ -125,10 +125,11 @@
             <fileMode>644</fileMode>
         </file>
         <file>
-            <source>${basedir}/resources/updates/product.txt</source>
+            <source>${basedir}/resources/updates/product_macos.txt</source>
             <outputDirectory>wso2am-micro-gw-toolkit-macos-${project.version}/updates</outputDirectory>
             <filtered>true</filtered>
             <fileMode>644</fileMode>
+            <destName>product.txt</destName>
         </file>
         <file>
             <source>${basedir}/resources/version.txt</source>

--- a/distribution/src/main/assembly/windows_bin.xml
+++ b/distribution/src/main/assembly/windows_bin.xml
@@ -115,10 +115,11 @@
             <fileMode>644</fileMode>
         </file>
         <file>
-            <source>${basedir}/resources/updates/product.txt</source>
+            <source>${basedir}/resources/updates/product_windows.txt</source>
             <outputDirectory>wso2am-micro-gw-toolkit-windows-${project.version}/updates</outputDirectory>
             <filtered>true</filtered>
             <fileMode>644</fileMode>
+            <destName>product.txt</destName>
         </file>
         <file>
             <source>${basedir}/resources/version.txt</source>

--- a/distribution/src/main/assembly/windows_bin.xml
+++ b/distribution/src/main/assembly/windows_bin.xml
@@ -148,6 +148,8 @@
                 <include>org.slf4j:slf4j-jdk14</include>
                 <include>org.apache.commons:commons-lang3</include>
                 <include>commons-pool.wso2:commons-pool</include>
+                <include>org.wso2.carbon.callhome:core</include>
+                <include>org.wso2.carbon.callhome:core</include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/distribution/src/main/assembly/windows_bin.xml
+++ b/distribution/src/main/assembly/windows_bin.xml
@@ -137,6 +137,7 @@
                 <include>org.wso2.am.microgw:org.wso2.micro.gateway.cli:jar</include>
                 <include>com.moandjiezana.toml:toml4j:jar</include>
                 <include>com.beust:jcommander:jar</include>
+                <include>org.wso2.carbon.callhome:core</include>
             </includes>
         </dependencySet>
         <dependencySet>
@@ -148,8 +149,6 @@
                 <include>org.slf4j:slf4j-jdk14</include>
                 <include>org.apache.commons:commons-lang3</include>
                 <include>commons-pool.wso2:commons-pool</include>
-                <include>org.wso2.carbon.callhome:core</include>
-                <include>org.wso2.carbon.callhome:core</include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/pom.xml
+++ b/pom.xml
@@ -411,6 +411,11 @@
                 <artifactId>jackson-databind</artifactId>
                 <version>${fasterxml.jackson.databind.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.callhome</groupId>
+                <artifactId>core</artifactId>
+                <version>${carbon.callhome.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <build>
@@ -609,6 +614,7 @@
         <everit.version>1.5.0.wso2.v1</everit.version>
         <fasterxml.jackson.databind.version>2.9.10</fasterxml.jackson.databind.version>
         <org.json.version>20190722</org.json.version>
+        <carbon.callhome.version>1.0.4</carbon.callhome.version>
     </properties>
 
 </project>


### PR DESCRIPTION
### Purpose
$Subject as this will Introduce CallHome feature for micro-gw toolkit and runtime.
toollkit: invoke callhome  while building the project
runtime: invoke callhome  when starting the micro-gw

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
