### PR TITLE
Make call home function run asynchronously with time out

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/Main.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/Main.java
@@ -49,6 +49,8 @@ public class Main {
             invokedCmd = getInvokedCmd(args);
             invokedCmd.ifPresent(LauncherCmd::execute);
             CmdUtils.printMessagesToConsole();
+            CmdUtils.printCallHomeMessage();
+            Runtime.getRuntime().exit(0);
         } catch (CliLauncherException e) {
             err.println(e.getMessages());
             Throwable cause = e.getCause();

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/CmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/CmdUtils.java
@@ -89,6 +89,7 @@ public final class CmdUtils {
     private static final PrintStream OUT = System.out;
     private static final PrintStream ERR = System.err;
     private static String consoleMessages = "";
+    private static String callHomeMessage = "";
 
     private CmdUtils() {
 
@@ -1308,6 +1309,16 @@ public final class CmdUtils {
     public static void printMessagesToConsole() {
         if (!"".equals(consoleMessages)) {
             OUT.println(consoleMessages);
+        }
+    }
+
+    public static void setCallHomeMessage(String message) {
+        callHomeMessage = message;
+    }
+
+    public static void printCallHomeMessage() {
+        if (!"".equals(callHomeMessage)) {
+            OUT.println(callHomeMessage);
         }
     }
 


### PR DESCRIPTION
### Purpose
There can be test failures due to call home is running in separate thread and not returning the proper exit code. We need to make sure program exits with correct exit code

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
