### PR TITLE
Fix #1150 #1162 #1164 - Java interceptor json array, oauth2 context missmatch and caching issues

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/utils.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/utils.bal
@@ -90,6 +90,13 @@ public function getKeyValidationRequestObject(runtime:InvocationContext context,
         apiVersion = <string>apiConfig.apiVersion;
     }
     apiKeyValidationRequest.apiVersion = apiVersion;
+    if (!contains(apiContext, apiVersion)) {
+        if (hasSuffix(apiContext, PATH_SEPERATOR)) {
+            apiContext = apiContext + apiVersion;
+        } else {
+            apiContext = apiContext + PATH_SEPERATOR + apiVersion;
+        }
+    }
     apiKeyValidationRequest.context = apiContext;
     apiKeyValidationRequest.requiredAuthenticationLevel = ANY_AUTHENTICATION_LEVEL;
     apiKeyValidationRequest.clientDomain = "*";

--- a/components/micro-gateway-interceptor/src/main/java/org/wso2/micro/gateway/interceptor/Entity.java
+++ b/components/micro-gateway-interceptor/src/main/java/org/wso2/micro/gateway/interceptor/Entity.java
@@ -33,6 +33,7 @@ import org.ballerinalang.mime.util.MimeConstants;
 import org.ballerinalang.mime.util.MimeUtil;
 import org.ballerinalang.stdlib.io.channels.base.Channel;
 import org.ballerinalang.stdlib.io.utils.IOConstants;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -162,11 +163,23 @@ public class Entity {
      * @throws InterceptorException If error while getting json payload.
      */
     public JSONObject getJson() throws InterceptorException {
-        constructPayloadBlockingCallBack(AbstractGetPayloadHandler.SourceType.JSON);
-        if (entityObj.getNativeData(MimeConstants.MESSAGE_DATA_SOURCE) != null) {
-            String jsonPayload = MimeUtil
-                    .getMessageAsString(entityObj.getNativeData(MimeConstants.MESSAGE_DATA_SOURCE));
-            return new JSONObject(jsonPayload);
+        String jsonObject = getJsonStringPayload();
+        if (jsonObject != null) {
+            return new JSONObject(jsonObject);
+        }
+        return null;
+    }
+
+    /**
+     * Extracts `json array` payload from the entity. If the content type is not JSON, an exception will be thrown.
+     *
+     * @return The `json array` payload of the request.
+     * @throws InterceptorException If error while getting json payload.
+     */
+    public JSONArray getJsonArray() throws InterceptorException {
+        String jsonObject = getJsonStringPayload();
+        if (jsonObject != null) {
+            return new JSONArray(jsonObject);
         }
         return null;
     }
@@ -260,6 +273,16 @@ public class Entity {
     }
 
     /**
+     * Sets a json array{@link JSONArray} as the payload to the entity.
+     *
+     * @param jsonArrayPayload {@link JSONArray} The json payload.
+     */
+    public void setJson(JSONArray jsonArrayPayload) {
+        MimeEntityBody
+                .setJson(entityObj, JSONParser.parse(jsonArrayPayload.toString()), MimeConstants.APPLICATION_JSON);
+    }
+
+    /**
      * Sets a xml to the entity.
      *
      * @param xmlPayload The xml {@link BXML} payload.
@@ -347,6 +370,15 @@ public class Entity {
             callback.notifyFailure();
             throw new InterceptorException(msg, e);
         }
+    }
+
+    private String getJsonStringPayload() throws InterceptorException {
+        constructPayloadBlockingCallBack(AbstractGetPayloadHandler.SourceType.JSON);
+        if (entityObj.getNativeData(MimeConstants.MESSAGE_DATA_SOURCE) != null) {
+            return MimeUtil
+                    .getMessageAsString(entityObj.getNativeData(MimeConstants.MESSAGE_DATA_SOURCE));
+        }
+        return null;
     }
 
 }

--- a/components/micro-gateway-interceptor/src/main/java/org/wso2/micro/gateway/interceptor/Request.java
+++ b/components/micro-gateway-interceptor/src/main/java/org/wso2/micro/gateway/interceptor/Request.java
@@ -24,6 +24,7 @@ import org.ballerinalang.jvm.values.api.BXML;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.net.http.nativeimpl.ExternRequest;
 import org.ballerinalang.stdlib.io.channels.base.Channel;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.nio.channels.ByteChannel;
@@ -259,6 +260,16 @@ public class Request {
     }
 
     /**
+     * Extracts `json array` payload from the request. If the content type is not JSON, an exception will be thrown.
+     *
+     * @return The `json` {@link JSONArray} payload of the request. Null if json body is not found in the request.
+     * @throws InterceptorException If error while getting json payload.
+     */
+    public JSONArray getJsonArrayPayload() throws InterceptorException {
+        return getEntity().getJsonArray();
+    }
+
+    /**
      * Extracts `xml` payload from the request. If the content type is not XML, an exception will be thrown.
      *
      * @return {@link BXML} The `xml` payload of the request.
@@ -317,6 +328,16 @@ public class Request {
      */
     public void setJsonPayload(JSONObject jsonPayload) {
         getEntityWithoutBody().setJson(jsonPayload);
+        setEntity(entity);
+    }
+
+    /**
+     * Sets a json array {@link JSONArray} as the payload to the request.
+     *
+     * @param jsonArrayPayload {@link JSONArray} The json array payload.
+     */
+    public void setJsonPayload(JSONArray jsonArrayPayload) {
+        getEntityWithoutBody().setJson(jsonArrayPayload);
         setEntity(entity);
     }
 

--- a/components/micro-gateway-interceptor/src/main/java/org/wso2/micro/gateway/interceptor/Response.java
+++ b/components/micro-gateway-interceptor/src/main/java/org/wso2/micro/gateway/interceptor/Response.java
@@ -22,6 +22,7 @@ import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.net.http.ValueCreatorUtils;
 import org.ballerinalang.net.http.nativeimpl.ExternResponse;
 import org.ballerinalang.stdlib.io.channels.base.Channel;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.nio.channels.ByteChannel;
@@ -175,6 +176,16 @@ public class Response {
     }
 
     /**
+     * Extracts `json array` payload from the response. If the content type is not JSON, an exception will be thrown.
+     *
+     * @return The `json` {@link JSONArray} payload of the request. Null if json body is not found in the response.
+     * @throws InterceptorException If error while getting json array payload.
+     */
+    public JSONArray getJsonArrayPayload() throws InterceptorException {
+        return getEntity().getJsonArray();
+    }
+
+    /**
      * Extracts `xml` payload from the response. If the content type is not XML, an exception will be thrown.
      *
      * @return {@link BXML} The `xml` payload of the response.
@@ -254,6 +265,16 @@ public class Response {
      */
     public void setJsonPayload(JSONObject jsonPayload) {
         getEntity().setJson(jsonPayload);
+        setEntity(entity);
+    }
+
+    /**
+     * Sets a json array as the payload.
+     *
+     * @param jsonArrayPayload {@link JSONArray} The json payload.
+     */
+    public void setJsonPayload(JSONArray jsonArrayPayload) {
+        getEntity().setJson(jsonArrayPayload);
         setEntity(entity);
     }
 

--- a/tests/src/main/java/org/wso2/micro/gateway/tests/interceptor/TestInterceptor.java
+++ b/tests/src/main/java/org/wso2/micro/gateway/tests/interceptor/TestInterceptor.java
@@ -55,7 +55,11 @@ public class TestInterceptor implements Interceptor {
         appendResponseString(request.getQueryParamValue("test"));
         if ("application/json".equals(contentType)) {
             try {
-                appendResponseString(request.getJsonPayload().toString());
+                if (request.hasHeader("X_JWT")) {
+                    appendResponseString(request.getJsonArrayPayload().toString());
+                } else {
+                    appendResponseString(request.getJsonPayload().toString());
+                }
             } catch (InterceptorException e) {
                 log.error("Error while getting json payload ", e);
             }

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/common/ResponseConstants.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/common/ResponseConstants.java
@@ -55,6 +55,9 @@ public class ResponseConstants {
     public static final String JSON_RESPONSE = ":application/json:Accept:Cache-Control:Connection:Content-Length"
             + ":content-type:Host:Pragma::/petstore/v1/user?test=value1&test2=value2:POST:1.1:"
             + "{test2=value2, test=value1}:value1:{\"hello\":\"world\"}";
+    public static final String JSON_ARRAY_RESPONSE = ":application/json:Accept:Cache-Control:Connection:Content-Length"
+            + ":content-type:Host:Pragma:X_JWT::/petstore/v1/user?test=value1&test2=value2:POST:1.1:{test2=value2, "
+            + "test=value1}:value1:[{\"name\":\"foo\",\"age\":\"20\"},{\"name\":\"bar\",\"age\":\"30\"}]";
     public static final String XML_RESPONSE = ":text/xml:Accept:Cache-Control:Connection:Content-Length"
             + ":content-type:Host:Pragma::/petstore/v1/user?test=value1&test2=value2:POST:1.1:"
             + "{test2=value2, test=value1}:value1:<test><msg>hello</msg></test>";

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/interceptor/JavaInterceptorTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/interceptor/JavaInterceptorTestCase.java
@@ -32,6 +32,8 @@ import java.util.Map;
  */
 public class JavaInterceptorTestCase extends InterceptorTestCase {
 
+    private final String jsonArrayPayload = "[{'name' : 'foo', 'age': '20'}, "
+            + "{'name': 'bar', 'age' : '30'}]";
     @Test(description = "Test java interceptor request data retrieval with json payload")
     public void testGetRequestJsonBodyInterceptor() throws Exception {
         Map<String, String> headers = new HashMap<>();
@@ -41,6 +43,14 @@ public class JavaInterceptorTestCase extends InterceptorTestCase {
                 .doPost(getServiceURLHttp("/petstore/v1/user?test=value1&test2=value2"), "{'hello':'world'}", headers);
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getData(), ResponseConstants.JSON_RESPONSE);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+
+        //test json array payloads
+        headers.put("X_JWT", "true");
+        response = HttpClientRequest
+                .doPost(getServiceURLHttp("/petstore/v1/user?test=value1&test2=value2"), jsonArrayPayload, headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getData(), ResponseConstants.JSON_ARRAY_RESPONSE);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
     }
 


### PR DESCRIPTION
This will fix the following issues
- add new method to set and get json array objects using java interceptors
- Fix the issue of subscription validation failure when apis are push to APIM using apictl
- Fix the caching issue when used oauth2 opaque tokens

### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1150 
Fixes #1162 
Fixes #1164 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
