### PR TITLE
Fix #1181 #1184 - Support adding custom filters

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/BuildCmd.java
@@ -38,6 +38,7 @@ import org.wso2.apimgt.gateway.cli.exception.ConfigParserException;
 import org.wso2.apimgt.gateway.cli.model.config.Config;
 import org.wso2.apimgt.gateway.cli.model.config.ContainerConfig;
 import org.wso2.apimgt.gateway.cli.model.config.DockerConfig;
+import org.wso2.apimgt.gateway.cli.model.config.Filter;
 import org.wso2.apimgt.gateway.cli.utils.CmdUtils;
 import org.wso2.apimgt.gateway.cli.utils.ToolkitLibExtractionUtils;
 import org.wso2.callhome.CallHomeExecutor;
@@ -56,6 +57,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -269,6 +272,7 @@ public class BuildCmd implements LauncherCmd {
             }
             String deploymentConfigPath = CmdUtils.getDeploymentConfigLocation(projectName);
             ContainerConfig containerConfig = TOMLConfigParser.parse(deploymentConfigPath, ContainerConfig.class);
+            sortFilterBasedOnPosition(containerConfig);
             createDockerImageFromCLI(projectName, containerConfig);
             CmdUtils.setContainerConfig(containerConfig);
 
@@ -374,5 +378,12 @@ public class BuildCmd implements LauncherCmd {
         });
         callHomeThread.setName("callHomeThread");
         callHomeThread.start();
+    }
+
+    private void sortFilterBasedOnPosition(ContainerConfig containerConfig) {
+        if (containerConfig.getFilters() != null) {
+            Comparator<Filter> compareByPosition = Comparator.comparing(Filter::getPosition);
+            Collections.sort(containerConfig.getFilters(), compareByPosition);
+        }
     }
 }

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
@@ -175,16 +175,8 @@ public class CodeGenerator {
         String tomlPath = CmdUtils.getProjectTargetGenDirectoryPath(projectName)
                 + File.separator + CliConstants.BALLERINA_TOML_FILE;
         CodegenUtils.writeFile(Paths.get(tomlPath), toml.getContent());
-
-        CmdUtils.copyFilesToSources(CmdUtils.getProjectExtensionsDirectoryPath(projectName)
-                        + File.separator + CliConstants.GW_DIST_EXTENSION_FILTER,
-                projectSrcPath + File.separator + CliConstants.GW_DIST_EXTENSION_FILTER);
-        CmdUtils.copyFilesToSources(CmdUtils.getProjectExtensionsDirectoryPath(projectName)
-                        + File.separator + CliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION,
-                projectSrcPath + File.separator + CliConstants.GW_DIST_TOKEN_REVOCATION_EXTENSION);
-        CmdUtils.copyFilesToSources(CmdUtils.getProjectExtensionsDirectoryPath(projectName)
-                        + File.separator + CliConstants.GW_DIST_START_UP_EXTENSION,
-                projectSrcPath + File.separator + CliConstants.GW_DIST_START_UP_EXTENSION);
+        // copy the files inside the extensions folder.
+        CmdUtils.copyFolder(CmdUtils.getProjectExtensionsDirectoryPath(projectName), projectSrcPath);
     }
 
     private BallerinaService generateDefinitionContext(OpenAPI openAPI, String openAPIContent, Path path,

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/config/ContainerConfig.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/config/ContainerConfig.java
@@ -17,13 +17,24 @@
  */
 package org.wso2.apimgt.gateway.cli.model.config;
 
+import java.util.List;
+
 /**
- * Configuration for containerized deployment.
- * Docker and k8s.
+ * Configuration dto object for project level configurations and containerized deployment.
+ * Custom Filters, Docker and k8s.
  */
 public class ContainerConfig {
+    private List<Filter> filters;
     private Docker docker;
     private Kubernetes kubernetes;
+
+    public List<Filter> getFilters() {
+        return filters;
+    }
+
+    public void setFilters(List<Filter> filters) {
+        this.filters = filters;
+    }
 
     public Docker getDocker() {
         return docker;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/config/Filter.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/config/Filter.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.apimgt.gateway.cli.model.config;
+
+/**
+ * Configuration data holder.
+ * Holds custom filter data specified in deployment-config.toml.
+ */
+public class Filter {
+
+    String name;
+    String variableName;
+    Integer position;
+
+    public String getName() {
+        this.variableName = name.toLowerCase();
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getVariableName() {
+        return variableName;
+    }
+
+    public void setVariableName(String variableName) {
+        this.variableName = variableName;
+    }
+
+    public Integer getPosition() {
+        return position;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
+    }
+}

--- a/components/micro-gateway-cli/src/main/resources/templates/listeners.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/listeners.mustache
@@ -7,7 +7,7 @@ import ballerina/config;
 {{else if containerConfig.kubernetes.kubernetesServiceHttps.enable}}import ballerina/kubernetes;
 {{else if containerConfig.kubernetes.kubernetesServiceHttp.enable}}import ballerina/kubernetes;{{/if}}
 
-
+const string KEY_LISTENER_INIT = "ListenerInit";
 //Throttle tier data initiation
 // todo: can remove this since this is not used
 {{#if config.mutualSSL.certificateDetails}}
@@ -113,7 +113,7 @@ public function getFilters() returns (http:RequestFilter|http:ResponseFilter) []
 
     boolean isObservable = gateway:getConfigBooleanValue(gateway:MICRO_GATEWAY_METRICS, gateway:ENABLED, false)
         || gateway:getConfigBooleanValue(gateway:MICRO_GATEWAY_TRACING, gateway:ENABLED, false);
-    
+
     if (isObservable) {
         preAuthnFilter = new gateway:PreAuthnFilterWrapper();
         throttleFilter = new gateway:ThrottleFilterWrapper(deployedPolicies);
@@ -133,7 +133,41 @@ public function getFilters() returns (http:RequestFilter|http:ResponseFilter) []
     // Extension filter
     ExtensionFilter extensionFilter = new;
 
-    return [grpcFilter, preAuthnFilter, authorizationFilter, validationRequestFilter, throttleFilter,
-            analyticsFilter, validationResponseFilter, extensionFilter];
+    (http:RequestFilter|http:ResponseFilter)[] defaultFilters = [grpcFilter, preAuthnFilter, authorizationFilter,
+        validationRequestFilter, throttleFilter, analyticsFilter, validationResponseFilter, extensionFilter];
+
+    (http:RequestFilter|http:ResponseFilter)[] customFilters = [];
+    int[] customFilterIndexes = [];
+    (http:RequestFilter|http:ResponseFilter)[] allFilters = defaultFilters.slice(0,defaultFilters.length());
+{{#containerConfig.filters}}
+    {{name}} {{variableName}} = new;
+    customFilterIndexes[{{@index}}] = {{position}};
+    customFilters[{{@index}}] = {{variableName}};
+    allFilters.push({{variableName}}) ;
+{{/containerConfig.filters}}
+
+    int customFilterIndex = 0;
+    int authFilterPosition = gateway:getAuthFilterPosition();
+
+    foreach var filterIndex in customFilterIndexes {
+        shiftArray(allFilters, filterIndex, customFilters[customFilterIndex]);
+        if (filterIndex <= authFilterPosition) {
+            authFilterPosition = authFilterPosition + 1;
+        }
+        customFilterIndex = customFilterIndex +1;
+    }
+
+    gateway:setAuthFilterPosition(authFilterPosition);
+    gateway:printDebug(KEY_LISTENER_INIT, allFilters.toString());
+    return allFilters;
+}
+
+function shiftArray((http:RequestFilter|http:ResponseFilter)[] allFilters, int position,
+    (http:RequestFilter|http:ResponseFilter) customFilter) {
+    int filterArrayLength = allFilters.length();
+    foreach int currentIndex in position ..< filterArrayLength {
+        allFilters[filterArrayLength-currentIndex-1+position] = allFilters[filterArrayLength-currentIndex-2+position];
+    }
+    allFilters[position] = customFilter;
 }
 

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
@@ -443,3 +443,5 @@ public const string API_PUBLISHER = "api_publisher";
 public const string API_NAME = "api_name";
 public const string MATCHING_RESOURCE = "matching_resource";
 
+
+public const int DEFAULT_AUTH_FILTER_POSITION = 2;

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/listeners/api_gateway_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/listeners/api_gateway_listener.bal
@@ -23,6 +23,7 @@ import ballerina/stringutils;
 
 boolean isConfigInitiated = false;
 boolean isDebugEnabled = false;
+int authFilterPosition = DEFAULT_AUTH_FILTER_POSITION;
 
 public type APIGatewayListener object {
     *lang:Listener;
@@ -85,7 +86,7 @@ function initiateAuthenticationHandlers(http:ListenerConfiguration config) {
     http:ListenerAuth auth = {
          authHandlers: getAuthHandlers(), //set empty array
          mandateSecureSocket: false,
-         position: 2
+         position: authFilterPosition
     };
     config.auth = auth;
 }
@@ -283,4 +284,16 @@ public function getKeepAliveValue() returns http:KeepAlive {
     } else {
         return http:KEEPALIVE_NEVER;
     }
+}
+
+public function setAuthFilterPosition(int position) {
+    // This check is to avoid modifying auth position twice because of both http and https listener modifying the index.
+    if(authFilterPosition ==  DEFAULT_AUTH_FILTER_POSITION) {
+        authFilterPosition = position;
+    }
+    printDebug(KEY_GW_LISTNER, "Auth filter position in the filter chain: " + authFilterPosition.toString());
+}
+
+public function getAuthFilterPosition() returns int {
+    return authFilterPosition;
 }

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/listeners/api_gateway_secure_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/listeners/api_gateway_secure_listener.bal
@@ -74,7 +74,7 @@ function initiateGatewaySecureConfigurations(http:ListenerConfiguration config) 
     //after the gateway cache objects are initialized.
     http:ListenerAuth auth = {
          authHandlers: getAuthHandlers(), //set empty array
-         position: 2
+         position: authFilterPosition
     };
     config.auth = auth;
     config.secureSocket = secureSocket;


### PR DESCRIPTION
### Purpose
With this fix specifying custom filters are supported. Developer can define custom filters and the position of that filter[1] in the filter chain in the deployment-config.toml, and then
add that filter inside the extension folder of the project.

[1]  - 
```toml
[[filters]]
    name = "CustomFilter"
    position = 5
[[filters]]
    name = "CustomFilterNew"
    position = 2
```

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1181 
Fixes #1184 

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
