### PR TITLE
Fix multiple jms subscription

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/services/throttle_event_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/services/throttle_event_listener.bal
@@ -84,7 +84,7 @@ public function startSubscriberService() returns @tainted jms:MessageConsumer | 
             return session;
         } else {
             jms:Destination dest = check session->createTopic("throttleData");
-            jms:MessageConsumer | error subscriberEndpoint = trap session->createDurableSubscriber(dest, "sub-1");
+            jms:MessageConsumer | error subscriberEndpoint = trap session->createConsumer(dest, "");
             if (subscriberEndpoint is error) {
                 printError(KEY_THROTTLE_UTIL, "Error while creating the jms subscriber.", subscriberEndpoint);
             } else {

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/services/throttle_event_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/services/throttle_event_listener.bal
@@ -84,7 +84,7 @@ public function startSubscriberService() returns @tainted jms:MessageConsumer | 
             return session;
         } else {
             jms:Destination dest = check session->createTopic("throttleData");
-            jms:MessageConsumer | error subscriberEndpoint = trap session->createConsumer(dest, "");
+            jms:MessageConsumer | error subscriberEndpoint = trap session->createConsumer(dest);
             if (subscriberEndpoint is error) {
                 printError(KEY_THROTTLE_UTIL, "Error while creating the jms subscriber.", subscriberEndpoint);
             } else {


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
There was an issue when multiple JMS subcribers (two mgw nodes) trying to connect to same TM for distributed throttling. Changing the subscriber type fixes the issue.
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1227 

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
MacOS

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
