### PR TITLE
Avoid overriding backend auth responses

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/templates/service.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/service.mustache
@@ -122,15 +122,12 @@ service {{cut qualifiedServiceName " "}} on {{#api.transport}}{{#equals . "http"
         {{^@root.isJavaRequestInterceptor}}
             {{@root.requestInterceptor}}(outboundEp, req);
             if (invocationContext.attributes.hasKey(gateway:RESPOND_DONE) && <boolean>invocationContext.attributes[gateway:RESPOND_DONE]) {
-                invocationContext.attributes[gateway:DID_EP_RESPOND] = true;
                 return;
             }
         {{/@root.isJavaRequestInterceptor}}
         } else {
             if (!gateway:invokeRequestInterceptor({{operationId}}_api_request_interceptor_index, outboundEp, req)) {
                 if (respondFromJavaInterceptor{{cut qualifiedServiceName " "}}(invocationContext, <@untainted>outboundEp)) {
-                    invocationContext.attributes[gateway:DID_EP_RESPOND] = true;
-
                     // return only if  interceptor returned false and respond is called from interceptor.
                     return;
                 }
@@ -141,15 +138,12 @@ service {{cut qualifiedServiceName " "}} on {{#api.transport}}{{#equals . "http"
         {{^isJavaRequestInterceptor}}
             {{requestInterceptor}}(outboundEp, req);
             if (invocationContext.attributes.hasKey(gateway:RESPOND_DONE) && <boolean>invocationContext.attributes[gateway:RESPOND_DONE]) {
-                invocationContext.attributes[gateway:DID_EP_RESPOND] = true;
                 return;
             }
         {{/isJavaRequestInterceptor}}
         } else {
             if(!gateway:invokeRequestInterceptor({{operationId}}_request_interceptor_index, outboundEp, req)) {
                 if (respondFromJavaInterceptor{{cut qualifiedServiceName " "}}(invocationContext, <@untainted>outboundEp)) {
-                    invocationContext.attributes[gateway:DID_EP_RESPOND] = true;
-
                     // return only if interceptor returned false and respond is called from interceptor.
                     return;
                 }
@@ -262,15 +256,12 @@ service {{cut qualifiedServiceName " "}} on {{#api.transport}}{{#equals . "http"
             {{^isJavaResponseInterceptor}}
                 {{responseInterceptor}} (outboundEp, clientResponse);
                 if (invocationContext.attributes.hasKey(gateway:RESPOND_DONE) && <boolean>invocationContext.attributes[gateway:RESPOND_DONE]) {
-                    invocationContext.attributes[gateway:DID_EP_RESPOND] = true;
                     return;
                 }
             {{/isJavaResponseInterceptor}}
             } else {
                 if (!gateway:invokeResponseInterceptor({{operationId}}_response_interceptor_index, outboundEp, clientResponse)) {
                     if (respondFromJavaInterceptor{{cut qualifiedServiceName " "}}(invocationContext, <@untainted>outboundEp)) {
-                        invocationContext.attributes[gateway:DID_EP_RESPOND] = true;
-
                         // return only if interceptor returned false and respond is called from interceptor.
                         return;
                     }
@@ -283,15 +274,12 @@ service {{cut qualifiedServiceName " "}} on {{#api.transport}}{{#equals . "http"
             {{^@root.isJavaResponseInterceptor}}
                 {{@root.responseInterceptor}} (outboundEp, clientResponse);
                 if (invocationContext.attributes.hasKey(gateway:RESPOND_DONE) && <boolean>invocationContext.attributes[gateway:RESPOND_DONE]) {
-                    invocationContext.attributes[gateway:DID_EP_RESPOND] = true;
                     return;
                 }
             {{/@root.isJavaResponseInterceptor}}
             } else {
                 if (!gateway:invokeResponseInterceptor({{operationId}}_api_response_interceptor_index, outboundEp, clientResponse)) {
                     if (respondFromJavaInterceptor{{cut qualifiedServiceName " "}}(invocationContext, <@untainted>outboundEp)) {
-                        invocationContext.attributes[gateway:DID_EP_RESPOND] = true;
-
                         // return only if interceptor returned false and respond is called from interceptor.
                         return;
                     }

--- a/components/micro-gateway-cli/src/main/resources/templates/service.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/service.mustache
@@ -121,13 +121,16 @@ service {{cut qualifiedServiceName " "}} on {{#api.transport}}{{#equals . "http"
         if({{operationId}}_api_request_interceptor_index == -1) {
         {{^@root.isJavaRequestInterceptor}}
             {{@root.requestInterceptor}}(outboundEp, req);
-            if(invocationContext.attributes.hasKey(gateway:RESPOND_DONE) && <boolean>invocationContext.attributes[gateway:RESPOND_DONE]) {
+            if (invocationContext.attributes.hasKey(gateway:RESPOND_DONE) && <boolean>invocationContext.attributes[gateway:RESPOND_DONE]) {
+                invocationContext.attributes[gateway:DID_EP_RESPOND] = true;
                 return;
             }
         {{/@root.isJavaRequestInterceptor}}
         } else {
-            if(!gateway:invokeRequestInterceptor({{operationId}}_api_request_interceptor_index, outboundEp, req)) {
-                if(respondFromJavaInterceptor{{cut qualifiedServiceName " "}}(invocationContext, <@untainted>outboundEp)) {
+            if (!gateway:invokeRequestInterceptor({{operationId}}_api_request_interceptor_index, outboundEp, req)) {
+                if (respondFromJavaInterceptor{{cut qualifiedServiceName " "}}(invocationContext, <@untainted>outboundEp)) {
+                    invocationContext.attributes[gateway:DID_EP_RESPOND] = true;
+
                     // return only if  interceptor returned false and respond is called from interceptor.
                     return;
                 }
@@ -137,14 +140,17 @@ service {{cut qualifiedServiceName " "}} on {{#api.transport}}{{#equals . "http"
         if({{operationId}}_request_interceptor_index == -1) {
         {{^isJavaRequestInterceptor}}
             {{requestInterceptor}}(outboundEp, req);
-            if(invocationContext.attributes.hasKey(gateway:RESPOND_DONE) && <boolean>invocationContext.attributes[gateway:RESPOND_DONE]) {
+            if (invocationContext.attributes.hasKey(gateway:RESPOND_DONE) && <boolean>invocationContext.attributes[gateway:RESPOND_DONE]) {
+                invocationContext.attributes[gateway:DID_EP_RESPOND] = true;
                 return;
             }
         {{/isJavaRequestInterceptor}}
         } else {
             if(!gateway:invokeRequestInterceptor({{operationId}}_request_interceptor_index, outboundEp, req)) {
-                if(respondFromJavaInterceptor{{cut qualifiedServiceName " "}}(invocationContext, <@untainted>outboundEp)) {
-                    // return only if  interceptor returned false and respond is called from interceptor.
+                if (respondFromJavaInterceptor{{cut qualifiedServiceName " "}}(invocationContext, <@untainted>outboundEp)) {
+                    invocationContext.attributes[gateway:DID_EP_RESPOND] = true;
+
+                    // return only if interceptor returned false and respond is called from interceptor.
                     return;
                 }
             }
@@ -255,13 +261,16 @@ service {{cut qualifiedServiceName " "}} on {{#api.transport}}{{#equals . "http"
             if({{operationId}}_response_interceptor_index == -1) {
             {{^isJavaResponseInterceptor}}
                 {{responseInterceptor}} (outboundEp, clientResponse);
-                if(invocationContext.attributes.hasKey(gateway:RESPOND_DONE) && <boolean>invocationContext.attributes[gateway:RESPOND_DONE]) {
+                if (invocationContext.attributes.hasKey(gateway:RESPOND_DONE) && <boolean>invocationContext.attributes[gateway:RESPOND_DONE]) {
+                    invocationContext.attributes[gateway:DID_EP_RESPOND] = true;
                     return;
                 }
             {{/isJavaResponseInterceptor}}
             } else {
-                if(!gateway:invokeResponseInterceptor({{operationId}}_response_interceptor_index, outboundEp, clientResponse)) {
-                    if(respondFromJavaInterceptor{{cut qualifiedServiceName " "}}(invocationContext, <@untainted>outboundEp)) {
+                if (!gateway:invokeResponseInterceptor({{operationId}}_response_interceptor_index, outboundEp, clientResponse)) {
+                    if (respondFromJavaInterceptor{{cut qualifiedServiceName " "}}(invocationContext, <@untainted>outboundEp)) {
+                        invocationContext.attributes[gateway:DID_EP_RESPOND] = true;
+
                         // return only if interceptor returned false and respond is called from interceptor.
                         return;
                     }
@@ -270,21 +279,26 @@ service {{cut qualifiedServiceName " "}} on {{#api.transport}}{{#equals . "http"
             {{~#if @root.responseInterceptor}}
             {{#equals @root.responseInterceptor responseInterceptor}}
             {{else}}
-            if({{operationId}}_api_response_interceptor_index == -1) {
+            if ({{operationId}}_api_response_interceptor_index == -1) {
             {{^@root.isJavaResponseInterceptor}}
                 {{@root.responseInterceptor}} (outboundEp, clientResponse);
-                if(invocationContext.attributes.hasKey(gateway:RESPOND_DONE) && <boolean>invocationContext.attributes[gateway:RESPOND_DONE]) {
+                if (invocationContext.attributes.hasKey(gateway:RESPOND_DONE) && <boolean>invocationContext.attributes[gateway:RESPOND_DONE]) {
+                    invocationContext.attributes[gateway:DID_EP_RESPOND] = true;
                     return;
                 }
             {{/@root.isJavaResponseInterceptor}}
             } else {
-                if(!gateway:invokeResponseInterceptor({{operationId}}_api_response_interceptor_index, outboundEp, clientResponse)) {
-                    if(respondFromJavaInterceptor{{cut qualifiedServiceName " "}}(invocationContext, <@untainted>outboundEp)) {
+                if (!gateway:invokeResponseInterceptor({{operationId}}_api_response_interceptor_index, outboundEp, clientResponse)) {
+                    if (respondFromJavaInterceptor{{cut qualifiedServiceName " "}}(invocationContext, <@untainted>outboundEp)) {
+                        invocationContext.attributes[gateway:DID_EP_RESPOND] = true;
+
                         // return only if interceptor returned false and respond is called from interceptor.
                         return;
                     }
                 }
             }{{/equals}}{{/if}}
+
+            invocationContext.attributes[gateway:DID_EP_RESPOND] = true;
             var outboundResult = outboundEp->respond(clientResponse);
             if (outboundResult is error) {
                 log:printError("Error when sending response", err = outboundResult);

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
@@ -130,6 +130,7 @@ public const string PASSWORD = "password";
 public const string ENABLE = "enable";
 public const string REQUIRE = "require";
 public const string SHA_PREFIX = "@sha";
+public const string DID_EP_RESPOND = "didEpRespond";
 
 //throttle policy prefixes
 public const string RESOURCE_LEVEL_PREFIX = "res_";

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/authz_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/authz_filter.bal
@@ -78,7 +78,10 @@ public type OAuthzFilter object {
 public function doAuthzFilterResponse(http:Response response, http:FilterContext context) returns boolean {
     // In authorization filter we have specifically set the error payload since we are using ballerina in built
     // authzFilter
-    if (response.statusCode == FORBIDDEN) {
+    map<any> attributes = runtime:getInvocationContext().attributes;
+    boolean didEpRespond = attributes.hasKey(DID_EP_RESPOND) && <boolean>attributes[DID_EP_RESPOND];
+
+    if (response.statusCode == FORBIDDEN && !didEpRespond) {
         if (runtime:getInvocationContext().attributes[ERROR_CODE] is ()) {
             if (context.attributes[ERROR_CODE] is ()) {
                 setAuthorizationFailureMessage(response, context);

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/authz_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/authz_filter.bal
@@ -78,10 +78,15 @@ public type OAuthzFilter object {
 public function doAuthzFilterResponse(http:Response response, http:FilterContext context) returns boolean {
     // In authorization filter we have specifically set the error payload since we are using ballerina in built
     // authzFilter
+    // when unauthorized response is coming from a backend/interceptor,
+    // we should avoid sending mgw unauthorized error response to the client
     map<any> attributes = runtime:getInvocationContext().attributes;
+    // check if the response is coming from the backend.
     boolean didEpRespond = attributes.hasKey(DID_EP_RESPOND) && <boolean>attributes[DID_EP_RESPOND];
+    // check if the response is coming from an interceptor.
+    boolean isRespondDone = attributes.hasKey(RESPOND_DONE) && <boolean>attributes[RESPOND_DONE];
 
-    if (response.statusCode == FORBIDDEN && !didEpRespond) {
+    if (response.statusCode == FORBIDDEN && !didEpRespond && !isRespondDone) {
         if (runtime:getInvocationContext().attributes[ERROR_CODE] is ()) {
             if (context.attributes[ERROR_CODE] is ()) {
                 setAuthorizationFailureMessage(response, context);

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/pre_authn_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/pre_authn_filter.bal
@@ -45,10 +45,16 @@ public type PreAuthnFilter object {
             printDebug(KEY_PRE_AUTHN_FILTER, "Skip all filter annotation set in the service. Skip the filter");
             return true;
         }
-        map<any> attributes = runtime:getInvocationContext().attributes;
-        boolean didEpRespond = attributes.hasKey(DID_EP_RESPOND) && <boolean>attributes[DID_EP_RESPOND];
 
-        if (response.statusCode == 401 && !didEpRespond) {
+        // when unauthenticated response is coming from a backend/interceptor,
+        // we should avoid sending mgw unauthenticated error response to the client
+        map<any> attributes = runtime:getInvocationContext().attributes;
+        // check if the response is coming from the backend.
+        boolean didEpRespond = attributes.hasKey(DID_EP_RESPOND) && <boolean>attributes[DID_EP_RESPOND];
+        // check if the response is coming from an interceptor.
+        boolean isRespondDone = attributes.hasKey(RESPOND_DONE) && <boolean>attributes[RESPOND_DONE];
+
+        if (response.statusCode == 401 && !didEpRespond && !isRespondDone) {
             runtime:InvocationContext invocationContext = runtime:getInvocationContext();
             //This handles the case where the empty Bearer/Basic value provided for authorization header. If all the
             //auth handlers are invoked and returning 401 without proper error message in the context means, invalid

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/pre_authn_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/pre_authn_filter.bal
@@ -45,7 +45,10 @@ public type PreAuthnFilter object {
             printDebug(KEY_PRE_AUTHN_FILTER, "Skip all filter annotation set in the service. Skip the filter");
             return true;
         }
-        if (response.statusCode == 401) {
+        map<any> attributes = runtime:getInvocationContext().attributes;
+        boolean didEpRespond = attributes.hasKey(DID_EP_RESPOND) && <boolean>attributes[DID_EP_RESPOND];
+
+        if (response.statusCode == 401 && !didEpRespond) {
             runtime:InvocationContext invocationContext = runtime:getInvocationContext();
             //This handles the case where the empty Bearer/Basic value provided for authorization header. If all the
             //auth handlers are invoked and returning 401 without proper error message in the context means, invalid

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/common/MockBackEndServer.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/common/MockBackEndServer.java
@@ -207,6 +207,42 @@ public class MockBackEndServer extends Thread {
                 exchange.getResponseBody().write(response);
                 exchange.close();
             });
+            httpServer.createContext(contextWithSecurity2 + "/store/order/1", exchange -> {
+                byte[] response;
+                if(exchange.getRequestHeaders().containsKey("Authorization") &&
+                        exchange.getRequestHeaders().get("Authorization").toString().contains("Basic YWRtaW46YWRtaW4="))
+                {
+                    response = ResponseConstants.storeInventoryResponse.getBytes();
+                    exchange.getResponseHeaders().set(HttpHeaderNames.CONTENT_TYPE.toString(),
+                            TokenManagementConstants.CONTENT_TYPE_APPLICATION_JSON);
+                    exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length);
+                } else {
+                    response = ResponseConstants.AUTHENTICATION_FAILURE_RESPONSE.getBytes();
+                    exchange.getResponseHeaders().set(HttpHeaderNames.CONTENT_TYPE.toString(),
+                            TokenManagementConstants.CONTENT_TYPE_APPLICATION_JSON);
+                    exchange.sendResponseHeaders(HttpURLConnection.HTTP_UNAUTHORIZED, response.length);
+                }
+                exchange.getResponseBody().write(response);
+                exchange.close();
+            });
+            httpServer.createContext(contextWithSecurity2 + "/user/john", exchange -> {
+                byte[] response;
+                if(exchange.getRequestHeaders().containsKey("Authorization") &&
+                        exchange.getRequestHeaders().get("Authorization").toString().contains("Basic YWRtaW46YWRtaW4="))
+                {
+                    response = ResponseConstants.userResponse.getBytes();
+                    exchange.getResponseHeaders().set(HttpHeaderNames.CONTENT_TYPE.toString(),
+                            TokenManagementConstants.CONTENT_TYPE_APPLICATION_JSON);
+                    exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length);
+                } else {
+                    response = ResponseConstants.AUTHZ_FAILURE_RESPONSE.getBytes();
+                    exchange.getResponseHeaders().set(HttpHeaderNames.CONTENT_TYPE.toString(),
+                            TokenManagementConstants.CONTENT_TYPE_APPLICATION_JSON);
+                    exchange.sendResponseHeaders(HttpURLConnection.HTTP_FORBIDDEN, response.length);
+                }
+                exchange.getResponseBody().write(response);
+                exchange.close();
+            });
             httpServer.createContext(contextWithSecurity2 + "/pet/findByTags", exchange -> {
                 byte[] response;
                 if(exchange.getRequestHeaders().containsKey("Authorization") &&

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/common/ResponseConstants.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/common/ResponseConstants.java
@@ -44,6 +44,7 @@ public class ResponseConstants {
             "\"message\":\"Internal server error occured\", \"description\":\"POLICY ENFORCEMENT ERROR\"}}";
     public static final String AUTHENTICATION_FAILURE_RESPONSE = "{\"fault\":\"Authorization credentials are not " +
             "provided.\"}";
+    public static final String AUTHZ_FAILURE_RESPONSE = "{\"fault\":\"Forbidden.\"}";
     public static final String PER_RESOURCE_REQUEST_INTERCEPTOR_RESPONSE = "{\"Intercept\":{\"RequestCode\":" +
             "\"e123\", \"message\":\"Successfully intercepted\", \"description\":\"Description\"}}";
     public static final String RESPONSE_INTERCEPTOR_RESPONSE_HEDAER = "ResponseHeader";
@@ -51,6 +52,7 @@ public class ResponseConstants {
             "\"message\":\"Successfully intercepted\", \"description\":\"Description\"}}";
     public static final String PER_APIRESPONSE_HEADER = "PerAPIResponse_Header";
     public static final String PAYLOAD = "payload";
+    public static final String userResponse = "{ \"name\": \"john\" }";
 
     public static final String JSON_RESPONSE = ":application/json:Accept:Cache-Control:Connection:Content-Length"
             + ":content-type:Host:Pragma::/petstore/v1/user?test=value1&test2=value2:POST:1.1:"

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/endpoints/EndpointWithSecurityTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/endpoints/EndpointWithSecurityTestCase.java
@@ -52,7 +52,7 @@ public class EndpointWithSecurityTestCase extends MultipleEndpointsTestCase {
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
     }
 
-    @Test(description = "Test Invoking the resource which endpoint defined at API level using references")
+    @Test(description = "Test invoking a resource with authentication failure.")
     public void testSecureEndpointWithAuthnFailure() throws Exception {
         Map<String, String> headers = new HashMap<>();
         //test endpoint with token
@@ -65,7 +65,7 @@ public class EndpointWithSecurityTestCase extends MultipleEndpointsTestCase {
     }
 
 
-    @Test(description = "Test Invoking the resource which endpoint defined at API level using references")
+    @Test(description = "Test Invoking a resource with authorization failure.")
     public void testSecureEndpointWithAuthzFailure() throws Exception {
         Map<String, String> headers = new HashMap<>();
         //test endpoint with token

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/endpoints/EndpointWithSecurityTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/endpoints/EndpointWithSecurityTestCase.java
@@ -52,6 +52,31 @@ public class EndpointWithSecurityTestCase extends MultipleEndpointsTestCase {
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
     }
 
+    @Test(description = "Test Invoking the resource which endpoint defined at API level using references")
+    public void testSecureEndpointWithAuthnFailure() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        //test endpoint with token
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
+        org.wso2.micro.gateway.tests.util.HttpResponse response = HttpClientRequest
+                .doGet(getServiceURLHttp("petstore/v5/store/order/1"), headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getData(), ResponseConstants.AUTHENTICATION_FAILURE_RESPONSE);
+        Assert.assertEquals(response.getResponseCode(), 401, "Response code mismatched");
+    }
+
+
+    @Test(description = "Test Invoking the resource which endpoint defined at API level using references")
+    public void testSecureEndpointWithAuthzFailure() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        //test endpoint with token
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
+        org.wso2.micro.gateway.tests.util.HttpResponse response = HttpClientRequest
+                .doGet(getServiceURLHttp("petstore/v5/user/john"), headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getData(), ResponseConstants.AUTHZ_FAILURE_RESPONSE);
+        Assert.assertEquals(response.getResponseCode(), 403, "Response code mismatched");
+    }
+
     @Test(description = "Test Invoking the load balanced endpoints in resource level using references")
     public void testLoadBalancedSecureEndpointResourceLevel() throws Exception {
         Map<String, String> headers = new HashMap<>();

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/endpoints/EndpointsByReferenceTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/endpoints/EndpointsByReferenceTestCase.java
@@ -58,7 +58,9 @@ public class EndpointsByReferenceTestCase extends BaseTestCase {
                 "--myEndpoint1_prod_basic_password=admin",
                 "--myEndpoint2_prod_basic_password=admin",
                 "--myEndpoint3_prod_basic_password=admin",
-                "--myEndpoint4_prod_basic_password=admin"
+                "--myEndpoint4_prod_basic_password=admin",
+                "--myEndpoint5_prod_basic_password=invalid",
+                "--myEndpoint6_prod_basic_password=wrong",
         };
         //generate apis with CLI and start the micro gateway server
         super.init(project, new String[] { "endpoints/endpoints_by_reference.yaml", "endpoints/endpoint_override.yaml",

--- a/tests/src/test/resources/openAPIs/endpoints/endpoint_security.yaml
+++ b/tests/src/test/resources/openAPIs/endpoints/endpoint_security.yaml
@@ -326,6 +326,7 @@ paths:
     get:
       tags:
         - store
+      x-wso2-production-endpoints: "#/x-wso2-endpoints/myEndpoint5"
       summary: Find purchase order by ID
       description: For valid response try integer IDs with value >= 1 and <= 10. Other
         values will generated exceptions
@@ -474,6 +475,7 @@ paths:
     get:
       tags:
         - user
+      x-wso2-production-endpoints: "#/x-wso2-endpoints/myEndpoint6"
       summary: Get user by user name
       description: ""
       operationId: getUserByName
@@ -723,6 +725,18 @@ x-wso2-endpoints:
   - myEndpoint4:
       urls:
         - https://non.existant.host:2380/v1Basic
+        - https://localhost:2380/v2Basic
+      securityConfig:
+        type: basic
+        username: admin
+  - myEndpoint5:
+      urls:
+        - https://localhost:2380/v2Basic
+      securityConfig:
+        type: basic
+        username: admin
+  - myEndpoint6:
+      urls:
         - https://localhost:2380/v2Basic
       securityConfig:
         type: basic


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
Avoid MGW from sending its own auth failure responses when backends and interceptors respond with auth failures.
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1233

### Automation tests
 - Unit tests added: No
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
MacOS

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
