### PR TITLE
Make api_definitions optional for build

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
@@ -43,7 +43,6 @@ import org.wso2.apimgt.gateway.cli.utils.OpenAPICodegenUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -59,7 +58,6 @@ import java.util.List;
  */
 public class CodeGenerator {
     private static final Logger logger = LoggerFactory.getLogger(CodeGenerator.class);
-    private static PrintStream outStream = System.out;
     public static String projectName;
 
     /**
@@ -354,20 +352,6 @@ public class CodeGenerator {
         if (!dir.delete() || !temp.delete()) {
             logger.debug("Failed to delete GRPC temp files");
         }
-    }
-
-    /**
-     * Generate swagger files.
-     *
-     * @param context model context to be used by the templates
-     * @return generated source files as a list of {@link GenSrcFile}
-     * @throws IOException when code generation with specified templates fails
-     */
-    private GenSrcFile generateSwagger(BallerinaService context) throws IOException {
-        String concatTitle = context.getName();
-        String srcFile = concatTitle + GeneratorConstants.SWAGGER_FILE_SUFFIX + GeneratorConstants.JSON_EXTENSION;
-        String mainContent = getContent(context, GeneratorConstants.GENERATESWAGGER_TEMPLATE_NAME);
-        return new GenSrcFile(GenSrcFile.GenFileType.GEN_SRC, srcFile, mainContent);
     }
 
     /**

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
@@ -74,18 +74,20 @@ public class CodeGenerator {
         String projectSrcPath = CmdUtils.getProjectTargetModulePath((projectName));
         List<GenSrcFile> genFiles = new ArrayList<>();
         List<BallerinaService> serviceList = new ArrayList<>();
-        List<BallerinaService> openAPIServiceList = new ArrayList<>();
-        List<String> openAPIDirectoryLocations = new ArrayList<>();
-        String projectAPIDefGenLocation = CmdUtils.getProjectGenAPIDefinitionPath(projectName);
-        openAPIDirectoryLocations.add(CmdUtils.getProjectDirectoryPath(projectName) + File.separator
-                + CliConstants.PROJECT_API_DEFINITIONS_DIR);
         String grpcDirLocation = CmdUtils.getGrpcDefinitionsDirPath(projectName);
-        if (Files.exists(Paths.get(projectAPIDefGenLocation))) {
-            openAPIDirectoryLocations.add(projectAPIDefGenLocation);
-        }
         CodeGenerator.projectName = projectName;
         BallerinaToml ballerinaToml = new BallerinaToml();
         ballerinaToml.setToolkitHome(CmdUtils.getCLIHome());
+        List<String> openAPIDirectoryLocations = new ArrayList<>();
+        String importedApisPath = CmdUtils.getProjectGenAPIDefinitionPath(projectName);
+        String devApisPath = CmdUtils.getProjectAPIFilesDirectoryPath(projectName);
+
+        if (Files.exists(Paths.get(devApisPath))) {
+            openAPIDirectoryLocations.add(devApisPath);
+        }
+        if (Files.exists(Paths.get(importedApisPath))) {
+            openAPIDirectoryLocations.add(importedApisPath);
+        }
 
         //to store the available interceptors for validation purposes
         OpenAPICodegenUtils.setInterceptors(projectName);
@@ -116,7 +118,6 @@ public class CodeGenerator {
                         definitionContext = new BallerinaService().buildContext(openAPI, api);
                         genFiles.add(generateService(definitionContext));
                         serviceList.add(definitionContext);
-                        openAPIServiceList.add(definitionContext);
                         ballerinaToml.addDependencies(definitionContext);
                     } catch (BallerinaServiceGenException e) {
                         throw new CLIRuntimeException("Swagger definition cannot be parsed to ballerina code", e);

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GeneratorConstants.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GeneratorConstants.java
@@ -26,7 +26,6 @@ public class GeneratorConstants {
     public static final String MAIN_TEMPLATE_NAME = "main";
     public static final String BALLERINA_TOML_TEMPLATE_NAME = "ballerinaToml";
     public static final String OPEN_API_JSON_CONSTANTS = "openAPIJsonConstants";
-    public static final String GENERATESWAGGER_TEMPLATE_NAME = "generateSwagger";
     public static final String THROTTLE_POLICY_TEMPLATE_NAME = "policy";
     public static final String LISTENERS_TEMPLATE_NAME = "listeners";
     public static final String TOKEN_SERVICES = "tokenServices";
@@ -36,7 +35,6 @@ public class GeneratorConstants {
     public static final String TOML_EXTENSION = ".toml";
     public static final String JSON_EXTENSION = ".json";
     public static final String THROTTLE_POLICY_INIT_TEMPLATE_NAME = "policy_init";
-    public static final String SWAGGER_FILE_SUFFIX = "_swagger";
 
     public static final String TEMPLATES_SUFFIX = ".mustache";
     public static final String TEMPLATES_DIR_PATH_KEY = "templates.dir.path";

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/CmdUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/CmdUtils.java
@@ -458,6 +458,7 @@ public final class CmdUtils {
 
         String definitionsPath = projectDir + File.separator + CliConstants.PROJECT_API_DEFINITIONS_DIR;
         createDirectory(definitionsPath, false);
+        createFile(definitionsPath, CliConstants.KEEP_FILE, true);
         if (!StringUtils.isEmpty(apiDefinition)) {
             setApiDefinition(projectName, apiDefinition, headers, values, insecure);
         }

--- a/components/micro-gateway-cli/src/main/resources/templates/generateSwagger.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/generateSwagger.mustache
@@ -1,2 +1,0 @@
-{{{api.apiSwagger}}}
-


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
If imported APIs are available in the project, api_definitions directory should not be mandatory for the micro-gw build.
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1194

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
MacOS

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
