### PR TITLE
Fix #1261 - Support reading configurations from interceptor library

### DIFF
--- a/components/micro-gateway-interceptor/pom.xml
+++ b/components/micro-gateway-interceptor/pom.xml
@@ -52,6 +52,10 @@
             <artifactId>ballerina-runtime-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.ballerinalang</groupId>
+            <artifactId>ballerina-config-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.json.wso2</groupId>
             <artifactId>json</artifactId>
         </dependency>

--- a/components/micro-gateway-interceptor/src/main/java/org/wso2/micro/gateway/interceptor/ConfigUtils.java
+++ b/components/micro-gateway-interceptor/src/main/java/org/wso2/micro/gateway/interceptor/ConfigUtils.java
@@ -1,0 +1,163 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.micro.gateway.interceptor;
+
+import org.ballerinalang.jvm.values.ArrayValueImpl;
+import org.ballerinalang.jvm.values.ErrorValue;
+import org.ballerinalang.jvm.values.MapValue;
+import org.ballerinalang.stdlib.config.Contains;
+import org.ballerinalang.stdlib.config.GetConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Set of utilities to read the configurations.
+ */
+public class ConfigUtils {
+
+    private static final Logger log = LoggerFactory.getLogger("ballerina");
+
+    /**
+     * Retrieves the specified configuration value as a string.
+     *
+     * @param key          The configuration to be retrieved.
+     * @param defaultValue The default value to be use in case there is no mapping for the provided key.
+     * @return Configuration value mapped by the key.
+     */
+    public static String getAsString(String key, String defaultValue) {
+        try {
+            boolean contains = Contains.contains(key);
+            if (contains) {
+                Object configValue = GetConfig.get(key, "STRING");
+                return configValue.toString();
+            }
+        } catch (ErrorValue e) {
+            log.error("Error while reading config string key : " + key, e);
+        }
+        String value = lookUpEnvVariable(key);
+        return value != null ? value : defaultValue;
+
+    }
+
+    /**
+     * Retrieves the specified configuration value as an int.
+     *
+     * @param key          The configuration to be retrieved.
+     * @param defaultValue The default value to be use in case there is no mapping for the provided key.
+     * @return Configuration value mapped by the key.
+     */
+    public static int getAsInt(String key, int defaultValue) {
+        try {
+            boolean contains = Contains.contains(key);
+            if (contains) {
+                Object configValue = GetConfig.get(key, "INT");
+                return Integer.parseInt(configValue.toString());
+            }
+        } catch (ErrorValue e) {
+            log.error("Error while reading config integer key : " + key, e);
+        }
+        String value = lookUpEnvVariable(key);
+        return value != null ? Integer.parseInt(value) : defaultValue;
+
+    }
+
+    /**
+     * Retrieves the specified configuration value as a boolean.
+     *
+     * @param key          The configuration to be retrieved.
+     * @param defaultValue The default value to be use in case there is no mapping for the provided key.
+     * @return Configuration value mapped by the key.
+     */
+    public static boolean getAsBoolean(String key, boolean defaultValue) {
+        try {
+            boolean contains = Contains.contains(key);
+            if (contains) {
+                Object configValue = GetConfig.get(key, "BOOLEAN");
+                return Boolean.parseBoolean(configValue.toString());
+            }
+        } catch (ErrorValue e) {
+            log.error("Error while reading config boolean key : " + key, e);
+        }
+        String value = lookUpEnvVariable(key);
+        return value != null ? Boolean.parseBoolean(value) : defaultValue;
+
+    }
+
+    /**
+     * Retrieves the specified configuration value as a float.
+     *
+     * @param key          The configuration to be retrieved.
+     * @param defaultValue The default value to be use in case there is no mapping for the provided key.
+     * @return Configuration value mapped by the key.
+     */
+    public static float getAsFloat(String key, float defaultValue) {
+        try {
+            boolean contains = Contains.contains(key);
+            if (contains) {
+                Object configValue = GetConfig.get(key, "FLOAT");
+                return Float.parseFloat(configValue.toString());
+            }
+        } catch (ErrorValue e) {
+            log.error("Error while reading config boolean key : " + key, e);
+        }
+        String value = lookUpEnvVariable(key);
+        return value != null ? Float.parseFloat(value) : defaultValue;
+
+    }
+
+    /**
+     * Retrieves the specified configuration value as a map. If there is no mapping, an empty map will be returned.
+     *
+     * @param key The configuration to be retrieved.
+     * @return Configuration value mapped by the key.
+     */
+    public static Map<String, String> getAsMap(String key) {
+        try {
+            MapValue configValue = (MapValue) GetConfig.get(key, "MAP");
+            return InterceptorUtils.convertBMapToMap(configValue);
+        } catch (ErrorValue e) {
+            log.error("Error while reading config boolean key : " + key, e);
+            return new HashMap<>();
+        }
+    }
+
+    /**
+     * Retrieves the specified configuration value as an array. If there is no mapping, an empty array will be returned.
+     *
+     * @param key The configuration to be retrieved.
+     * @return Configuration value mapped by the key.
+     */
+    public static List<Map<String, String>> getAsList(String key) {
+        try {
+            ArrayValueImpl configValue = (ArrayValueImpl) GetConfig.get(key, "ARRAY");
+            return InterceptorUtils.convertArrayValueToList(configValue);
+        } catch (ErrorValue e) {
+            log.error("Error while reading config boolean key : " + key, e);
+            return new ArrayList<>();
+        }
+    }
+
+    private static String lookUpEnvVariable(String key) {
+        key = key.replaceAll(".", "_");
+        return System.getenv(key);
+    }
+}

--- a/components/micro-gateway-interceptor/src/main/java/org/wso2/micro/gateway/interceptor/InterceptorUtils.java
+++ b/components/micro-gateway-interceptor/src/main/java/org/wso2/micro/gateway/interceptor/InterceptorUtils.java
@@ -15,9 +15,12 @@
  */
 package org.wso2.micro.gateway.interceptor;
 
+import org.ballerinalang.jvm.values.ArrayValue;
 import org.ballerinalang.jvm.values.api.BMap;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -33,5 +36,15 @@ public class InterceptorUtils {
             }
         }
         return convertedMap;
+    }
+
+    protected static List<Map<String, String>> convertArrayValueToList(ArrayValue arrayValue) {
+        List<Map<String, String>> listValue = new ArrayList<>();
+        if (arrayValue != null) {
+            for (Object obj : arrayValue.getValues()) {
+                listValue.add(convertBMapToMap((BMap) obj));
+            }
+        }
+        return listValue;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -340,6 +340,11 @@
                 <version>${ballerina.platform.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.ballerinalang</groupId>
+                <artifactId>ballerina-config-api</artifactId>
+                <version>${ballerina.platform.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.moandjiezana.toml</groupId>
                 <artifactId>toml4j</artifactId>
                 <version>${toml.parser.version}</version>

--- a/tests/src/main/java/org/wso2/micro/gateway/tests/interceptor/ConfigInterceptor.java
+++ b/tests/src/main/java/org/wso2/micro/gateway/tests/interceptor/ConfigInterceptor.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.wso2.micro.gateway.tests.interceptor;
+
+import org.wso2.micro.gateway.interceptor.Caller;
+import org.wso2.micro.gateway.interceptor.ConfigUtils;
+import org.wso2.micro.gateway.interceptor.Interceptor;
+import org.wso2.micro.gateway.interceptor.Request;
+import org.wso2.micro.gateway.interceptor.Response;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implements sample interceptor for the integration test cases used to read configurations.
+ */
+public class ConfigInterceptor implements Interceptor {
+
+    private  String responseString = "";
+
+    @Override
+    public boolean interceptRequest(Caller caller, Request request) {
+        String queryParam = request.getQueryParamValue("config");
+        queryParam = (queryParam != null) ? queryParam : "";
+        switch (queryParam) {
+        case "int" :
+            int port = ConfigUtils.getAsInt("listenerConfig.httpPort", 9080);
+            responseString = Integer.toString(port);
+            break;
+        case "float":
+            float portSecured = ConfigUtils.getAsFloat("listenerConfig.httpsPort", 9080);
+            responseString = Float.toString(portSecured);
+            break;
+        case "boolean":
+            boolean analyticsEnabled = ConfigUtils.getAsBoolean("analytics.enable", true);
+            responseString = Boolean.toString(analyticsEnabled);
+            break;
+        case "array":
+            List<Map<String, String>> tokenConfig = ConfigUtils.getAsList("jwtTokenConfig");
+            responseString = tokenConfig.get(0).get("issuer");
+            break;
+        case "map":
+            Map<String, String> analytics = ConfigUtils.getAsMap("analytics");
+            responseString = analytics.get("enable");
+            break;
+        default:
+            responseString = ConfigUtils.getAsString("analytics.uploadingEndpoint", "");
+        }
+        respondFromRequest(caller);
+        return false;
+    }
+
+    @Override
+    public boolean interceptResponse(Caller caller, Response response) {
+        return true;
+    }
+
+    private void respondFromRequest(Caller caller) {
+        Response response = new Response();
+        response.setTextPayload(responseString);
+        caller.respond(response);
+    }
+}

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/interceptor/JavaInterceptorTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/interceptor/JavaInterceptorTestCase.java
@@ -87,6 +87,33 @@ public class JavaInterceptorTestCase extends InterceptorTestCase {
         Assert.assertEquals(response.getResponseCode(), 201, "Response code mismatched");
     }
 
+    @Test(description = "Test java interceptor reading the configurations")
+    public void testInterceptorConfigRead() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
+        HttpResponse response = HttpClientRequest
+                .doGet(getServiceURLHttp("/petstore/v1/user/john"), headers);
+        Assert.assertNotNull(response);
+        Assert.assertTrue(response.getData().contains("https://localhost:9444/analytics/v1.0/usage/upload-file"));
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        response = HttpClientRequest
+                .doGet(getServiceURLHttp("/petstore/v1/user/john?config=int"), headers);
+        Assert.assertTrue(response.getData().contains("9590"));
+        response = HttpClientRequest
+                .doGet(getServiceURLHttp("/petstore/v1/user/john?config=float"), headers);
+        Assert.assertTrue(response.getData().contains("9595"));
+        response = HttpClientRequest
+                .doGet(getServiceURLHttp("/petstore/v1/user/john?config=boolean"), headers);
+        Assert.assertTrue(response.getData().contains("false"));
+        response = HttpClientRequest
+                .doGet(getServiceURLHttp("/petstore/v1/user/john?config=array"), headers);
+        Assert.assertTrue(response.getData().contains("https://localhost:9443/oauth2/token"));
+        response = HttpClientRequest
+                .doGet(getServiceURLHttp("/petstore/v1/user/john?config=map"), headers);
+        Assert.assertTrue(response.getData().contains("false"));
+
+    }
+
     @AfterClass
     public void stop() throws Exception {
         //Stop all the mock servers

--- a/tests/src/test/resources/openAPIs/interceptor/interceptor.yaml
+++ b/tests/src/test/resources/openAPIs/interceptor/interceptor.yaml
@@ -500,6 +500,7 @@ paths:
       summary: Get user by user name
       description: ""
       operationId: getUserByName
+      x-wso2-request-interceptor: java:org.wso2.micro.gateway.tests.interceptor.ConfigInterceptor
       parameters:
         - name: username
           in: path


### PR DESCRIPTION
### Purpose
This PR will provide set of utility methods to read configurations from java interceptors.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1261 

### Automation tests
 - Unit tests added: No
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
