### PR TITLE
Fixed the Base64 encoding padding issue

### DIFF
--- a/components/micro-gateway-jwt-generator/src/main/java/org/wso2/micro/gateway/jwt/generator/AbstractMGWJWTGenerator.java
+++ b/components/micro-gateway-jwt-generator/src/main/java/org/wso2/micro/gateway/jwt/generator/AbstractMGWJWTGenerator.java
@@ -349,7 +349,7 @@ public abstract class AbstractMGWJWTGenerator {
      * Used for base64 encoding.
      */
     public String encode(byte[] stringToBeEncoded) {
-        return java.util.Base64.getUrlEncoder().encodeToString(stringToBeEncoded);
+        return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(stringToBeEncoded);
     }
 
     /**


### PR DESCRIPTION
### Purpose

Removing padding created from base64 URL encoding in the generated token.
### Fix
Fixes #1277 
---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
