### PR TITLE
Fix #1258 - Add tenantwise data stores in mgw side

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/templates/main.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/main.mustache
@@ -25,6 +25,7 @@ public function main() {
     {{/each}}
     addTokenServicesFilterAnnotation();
     initThrottlePolicies();
+    future<()> gatewayNotification = start gateway:initiateNotificationJmsListener();
     gateway:initThrottleDataPublisher();
     gateway:initGlobalThrottleDataPublisher();
     gateway:startObservabilityListener();

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/api_gateway_cache.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/api_gateway_cache.bal
@@ -53,6 +53,7 @@ cache:Cache invalidTokenCache = new (genericCacheConfig);
 cache:Cache jwtCache = new (genericCacheConfig);
 cache:Cache introspectCache = new (genericCacheConfig);
 cache:Cache gatewayClaimsCache = new (genericCacheConfig);
+cache:Cache subscriptionCache = new (genericCacheConfig);
 
 cache:Cache jwtGeneratorCache = new (jwtGenerationCacheConfig);
 cache:Cache mutualSslCertificateCache = new (genericCacheConfig);
@@ -166,6 +167,23 @@ public type APIGatewayCache object {
         var isCertExist = mutualSslCertificateCache.get(cert);
         if (isCertExist is boolean) {
             return isCertExist;
+        } else {
+            return ();
+        }
+    }
+
+    public function addToSubcriptionCache(string subscriptionKey, AuthenticationContext authenticationContext) {
+        error? err = subscriptionCache.put(<@untainted>subscriptionKey, <@untainted>authenticationContext);
+        if (err is error) {
+            printError(KEY_GW_CACHE, "Error while adding subscription key " +  subscriptionKey + " to the subscription cache", err);
+        }
+        printDebug(KEY_GW_CACHE, "Added subscription information to the subscription cache. key: " + subscriptionKey);
+    }
+
+    public function retrieveFromSubcriptionCache(string subscriptionKey) returns (AuthenticationContext | ()){
+        var authenticationContext = subscriptionCache.get(subscriptionKey);
+        if (authenticationContext is AuthenticationContext) {
+            return authenticationContext;
         } else {
             return ();
         }

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/apim/pilot_data_provider.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/apim/pilot_data_provider.bal
@@ -48,6 +48,7 @@ public type PilotDataProvider object {
         self.apiStore = new(self.username, self.password, self.serviceContext, self.listOfTenants);
         self.keyMapStore = new(self.username, self.password, self.serviceContext, self.listOfTenants);
         self.appStore = new(self.username, self.password, self.serviceContext, self.listOfTenants);
+
     }
 
     # Get Api details from `ApiDataStore`.
@@ -58,8 +59,15 @@ public type PilotDataProvider object {
     # + return - `Api` object if requested Api is found. If not `()`
     public function getApi(string tenantDomain, string name, string apiVersion) returns Api | () {
         string apiKey = name + ":" + apiVersion;
-
         return self.apiStore.getApi(tenantDomain, apiKey);
+    }
+
+    public function addApi(string tenantDomain,  Api api) {
+        self.apiStore.addApi(tenantDomain, api);
+    }
+
+    public function removeApi(string tenantDomain, Api api) {
+        self.apiStore.removeApi(tenantDomain, api);
     }
 
     # Get Key Mapping details from `KeyMappingDataStore`.
@@ -69,6 +77,14 @@ public type PilotDataProvider object {
     # + return - `KeyMap` object if requested Key Mapping is found. If not `()`
     public function getKeyMapping(string tenantDomain, string consumerKey) returns KeyMap | () {
         return self.keyMapStore.getMapping(tenantDomain, consumerKey);
+    }
+
+    public function addKeyMapping(string tenantDomain,  KeyMap keyMap) {
+        self.keyMapStore.addKeyMapping(tenantDomain, keyMap);
+    }
+
+    public function removeKeyMapping(string tenantDomain, KeyMap keyMap) {
+        self.keyMapStore.removeKeyMapping(tenantDomain, keyMap);
     }
 
     # Get Subscription details from `SubscriptionDataStore`.
@@ -93,7 +109,7 @@ public type PilotDataProvider object {
 
     # Get Application details from `ApplicationDataStore`.
     #
-    # # + tenantDomain - Tenant domain to which the application belongs
+    # + tenantDomain - Tenant domain to which the application belongs
     # + appId - Application Id of the application
     # + return - `Application` object if requested Application is found. If not `()`
     public function getApplication(string tenantDomain, int appId) returns Application | () {

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/apim/pilot_dtos.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/apim/pilot_dtos.bal
@@ -20,7 +20,6 @@ public type Subscription record {|
     int appId = 1;
     string policyId = "";
     string state = "";
-    int tenantId = -1234;
     string tenantDomain = "carbon.super";
 |};
 
@@ -30,28 +29,18 @@ public type Application record {|
     string owner = "";
     string policyId = "";
     string tokenType = "";
-    int tenantId = -1234;
     string tenantDomain = "carbon.super";
     json[] groupIds?;
     json[] attributes?;
 |};
 
-public type ApplicationEvent record {|
-    int applicationId;
-    string applicationName = "";
-    string owner = "";
-    string applicationPolicy = "";
-    string tokenType = "";
-    int tenantId;
-    string tenantDomain;
-    json[] groupIds?;
-    json[] attributes?;
-|};
 
 public type KeyMap record {|
     int appId;
     string consumerKey = "";
     string keyType = "";
+    string tenantDomain = "carbon.super";
+    string keyManager = "Default";
 |};
 
 public type Api record {|
@@ -60,6 +49,7 @@ public type Api record {|
     string name = "";
     string apiVersion = "";
     string context = "";
+    string tenantDomain = "carbon.super";
     string policyId = "";
     any urlMaping?;
 |};

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
@@ -267,6 +267,8 @@ public const string BLOCKING_CONDITION_END_IP = "endingIp";
 public const string NOTIFICATION_EVENT_TYPE = "eventType";
 public const string NOTIFICATION_EVENT_TIMESTAMP = "timestamp";
 public const string NOTIFICATION_EVENT = "event";
+public const string API_CREATE_EVENT = "API_CREATE";
+public const string API_UPDATE_EVENT = "API_UPDATE";
 public const string APPLICATION_CREATE_EVENT = "APPLICATION_CREATE";
 public const string APPLICATION_UPDATE_EVENT = "APPLICATION_UPDATE";
 public const string APPLICATION_DELETE_EVENT = "APPLICATION_DELETE";
@@ -423,13 +425,14 @@ public const string KEY_SUBSCRIPTION_STORE = "SubscriptionDataStore";
 public const string KEY_API_STORE = "ApiDataStore";
 public const string KEY_KEYMAP_STORE = "KeyMappingDataStore";
 public const string KEY_APPLICATION_STORE = "ApplicationDataStore";
-public const string EVENT_HUB_INSTANCE_ID = "eventHub";
+public const string EVENT_HUB_INSTANCE_ID = "apim.eventHub";
 public const string EVENT_HUB_SERVER_URL = "serviceUrl";
 public const string EVENT_HUB_INT_CONTEXT = "internalDataContext";
 public const string EVENT_HUB_USERNAME = "admin";
 public const string EVENT_HUB_PASSWORD = "admin";
 public const string EVENT_HUB_TENANT_LIST = "listOfTenants";
 public const string EVENT_HUB_TENANT_HEADER = "xWSO2Tenant";
+public const string EVENT_HUB_LISTENER_ENDPOINTS = "eventListeningEndpoints";
 
 // end of config constants
 public const string IS_THROTTLED = "isThrottled";

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/handler_providers/jwt_auth_provider.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/handler_providers/jwt_auth_provider.bal
@@ -24,6 +24,7 @@ import ballerina/stringutils;
 # + jwtValidatorConfig - JWT validator configurations
 # + inboundJwtAuthProvider - Reference to b7a inbound auth provider
 # + subscriptionValEnabled - Validate subscription
+# + consumerKeyClaim - The claim name in which the consumer key of the application present in the jwt.
 # + claims - JWT claim set
 # + className - Transformation class Name
 # + classLoaded - Class loaded or not
@@ -125,7 +126,7 @@ public type JwtAuthProvider object {
                             }
                          }
                         return validateSubscriptions(jwtToken, cachedJwt.jwtPayload, self.subscriptionValEnabled,
-                                self.consumerKeyClaim, isGRPC);
+                                self.consumerKeyClaim, isGRPC, self.gatewayCache);
                     }
                     printDebug(KEY_JWT_AUTH_PROVIDER, "jwt not found in the jwt cache");
                     (jwt:JwtPayload | error) payload = getDecodedJWTPayload(jwtToken);
@@ -145,7 +146,7 @@ public type JwtAuthProvider object {
                                 jwtToken = authContext?.authToken.toString();
                             }
                         }
-                        return validateSubscriptions(jwtToken, payload, self.subscriptionValEnabled, self.consumerKeyClaim, isGRPC);
+                        return validateSubscriptions(jwtToken, payload, self.subscriptionValEnabled, self.consumerKeyClaim, isGRPC, self.gatewayCache);
                     }
                 }
             }
@@ -158,11 +159,11 @@ public type JwtAuthProvider object {
 };
 
 public function validateSubscriptions(string jwtToken, jwt:JwtPayload payload, boolean subscriptionValEnabled,
-                            string consumerKeyClaim, boolean isGRPC) returns @tainted (boolean | auth:Error) {
+                            string consumerKeyClaim, boolean isGRPC, APIGatewayCache gatewayCache) returns @tainted (boolean | auth:Error) {
     boolean subscriptionValidated = false;
     map<json>? customClaims = payload?.customClaims;
 
-    subscriptionValidated = isAllowedKey(jwtToken, payload, subscriptionValEnabled, consumerKeyClaim);
+    subscriptionValidated = isAllowedKey(jwtToken, payload, subscriptionValEnabled, consumerKeyClaim, gatewayCache);
     if (subscriptionValidated || !subscriptionValEnabled || isGRPC) {
         printDebug(KEY_JWT_AUTH_PROVIDER, "Subscriptions validated.");
         return true;

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/services/throttle_event_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/services/throttle_event_listener.bal
@@ -133,14 +133,7 @@ public function initiateThrottlingJmsListener() returns boolean {
         jms:MessageConsumer | error topicSubscriber = trap startSubscriberService();
         if (topicSubscriber is jms:MessageConsumer) {
             printDebug(KEY_THROTTLE_EVENT_LISTENER, "subscriber service for global throttling is started.");
-            jms:MessageConsumer | error gatewayNotificationSubscriber = trap startGatewayNotificationSubscriberService();
-            if (gatewayNotificationSubscriber is jms:MessageConsumer) {
-                printDebug(KEY_THROTTLE_EVENT_LISTENER, "subscriber service for gateway notifications is started.");
-                return true;
-            } else {
-                printError(KEY_THROTTLE_EVENT_LISTENER, "Error while starting subscriber service for gateway notofications.");
-                return false;
-            }
+            return true;
         } else {
             printError(KEY_THROTTLE_EVENT_LISTENER, "Error while starting subscriber service for global throttling");
             return false;

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/jwt_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/jwt_util.bal
@@ -29,8 +29,10 @@ public function isAllowedKey(string token, jwt:JwtPayload payload, boolean isVal
     //If application claim present in the jwt then its a self contained token. Can validate from the
     //claims present in the token
     if (customClaims is map<json> && customClaims.hasKey(APPLICATION)) {
-        subscribedAPIList = customClaims.get(SUBSCRIBED_APIS);
-        if(subscribedAPIList is json[]) {
+        if (customClaims.hasKey(SUBSCRIBED_APIS)) {
+            subscribedAPIList = customClaims.get(SUBSCRIBED_APIS);
+        }
+        if (subscribedAPIList is json[]) {
             return handleSubscribedAPIs(token, payload, subscribedAPIList, isValidationEnabled);
         } else if (isValidationEnabled){
             return false;

--- a/distribution/resources/conf/default-micro-gw.conf.template
+++ b/distribution/resources/conf/default-micro-gw.conf.template
@@ -90,13 +90,6 @@
       clientId = ""
       clientSecret = ""
 
-[eventHub]
-  serviceUrl="https://localhost:9443"
-  internalDataContext="/internal/data/v1/"
-  username="admin"
-  password="admin"
-  listOfTenants = ["carbon.super"]
-
 # JWT token authorization configurations. You can provide multiple JWT issuers
 # Issuer 1
 [[jwtTokenConfig]]
@@ -464,3 +457,12 @@
 [server]
   # timestamp skew in milliseconds which added when checking the token validity period
   timestampSkew = 5000
+
+[apim.eventHub]
+  enable = false
+  service_url = "https://localhost:9443"
+  internalDataContext="/internal/data/v1/"
+  username="admin"
+  password="admin"
+  eventListeningEndpoints = "amqp://admin:admin@carbon/carbon?brokerlist='tcp://localhost:5672'"
+  listOfTenants = ["carbon.super"]

--- a/distribution/resources/conf/micro-gw.conf
+++ b/distribution/resources/conf/micro-gw.conf
@@ -19,7 +19,6 @@
 
 [[jwtTokenConfig]]
   issuer = "https://localhost:9443/oauth2/token"
-  audience = "http://org.wso2.apimgt/gateway"
   certificateAlias = "wso2apim310"
   validateSubscription = false
   consumerKeyClaim = "aud"
@@ -53,9 +52,11 @@
       receiverURL = "tcp://localhost:9611"
       authURL = "ssl://localhost:9711"
 
-[eventHub]
-  serviceUrl="https://localhost:9443"
+[apim.eventHub]
+  enable = false
+  service_url = "https://localhost:9443"
   internalDataContext="/internal/data/v1/"
   username="admin"
   password="admin"
+  eventListeningEndpoints = "amqp://admin:admin@carbon/carbon?brokerlist='tcp://localhost:5672'"
   listOfTenants = ["carbon.super"]


### PR DESCRIPTION
### Purpose
Add tenant wise data store configurations
Include the following pilot configrations

```toml
[apim.eventHub]
  enable = false
  service_url = "https://localhost:9443"
  internalDataContext="/internal/data/v1/"
  username="admin"
  password="admin"
  eventListeningEndpoints = "amqp://admin:admin@carbon/carbon?brokerlist='tcp://localhost:5672'"
  listOfTenants = ["carbon.super"]
```

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1258 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
