### PR TITLE
Fixes the api name replacement issue in microgateway.

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GeneratorConstants.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/constants/GeneratorConstants.java
@@ -58,6 +58,9 @@ public class GeneratorConstants {
     public static final String RESOURCE_LEVEL_PREFIX = "res_";
     public static final String APP_LEVEL_PREFIX = "app_";
     public static final String SUB_LEVEL_PREFIX = "sub_";
+    public static final String HYPHEN = "_hyphen_";
+    public static final String DOT = "_dot_";
+    public static final String SPACE = "_space_";
 
     /**
      * Enum defining the available types of throttle policies.

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/CodegenUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/CodegenUtils.java
@@ -124,7 +124,12 @@ public final class CodegenUtils {
         if (key == null) {
             return null;
         }
-        key = key.replaceAll("(\\.)|(-)|(\\{)|(})|(\\s)|(/)", "_");
+        //Replacing special characters with some tokens to avoid parsing issues during code generation
+        key = key.replaceAll("(\\{)|(})|(/)", "_");
+        //Following are handled individually, so that they can be reverted back, to keep the api name unchanged
+        key = key.replaceAll("(-)", GeneratorConstants.HYPHEN);
+        key = key.replaceAll("(\\.)", GeneratorConstants.DOT);
+        key = key.replaceAll("(\\s)", GeneratorConstants.SPACE);
         if (key.contains("*")) {
             key = key.replaceAll("\\*", UUID.randomUUID().toString().replaceAll("-", "_"));
         }

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/utils.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/utils.bal
@@ -210,12 +210,15 @@ public function getTenantDomain(http:FilterContext context) returns (string) {
 
 public function getApiName(http:FilterContext context) returns (string) {
     string serviceName = context.getServiceName();
-    string apiName = split(serviceName, "__")[0];
+    //Here removing the version from the api name, generic pattern is <apiname>__<apiversion>
+    string apiVersion = split(serviceName, "__").pop();
+    string apiName = strings:substring(serviceName, 0, strings:length(serviceName) - strings:length(apiVersion) - 2);
 
-    if (contains(apiName, "_")) {
-        apiName = replaceAll(apiName, "_", "-");
-    }
-
+    //Before code generation some special characters are replaced with corresponding tokens to avoid parsing issues
+    //Here, replacing them with actual characters to keep the api name as user given value
+    apiName = replaceAll(apiName, "_hyphen_", "-");
+    apiName = replaceAll(apiName, "_dot_", ".");
+    apiName = replaceAll(apiName, "_space_", " ");
     return apiName;
 }
 


### PR DESCRIPTION
### Purpose
Fixes the API name modification issue during the code generation process. '_' are being replaced by '-' and API names are split by '__'. This PR fixes that issue.

### Issues
Fixes #1264

### Automation tests
 - Unit tests added: No

### Tested environments
OS: Ubuntu  - 18.04
JDK: 1.8.0_251

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
