### PR TITLE
Migrate xds apis to v3

### DIFF
--- a/envoy.yaml
+++ b/envoy.yaml
@@ -8,33 +8,38 @@ admin:
 dynamic_resources:
   ads_config:
     api_type: GRPC
+    transport_api_version: V3
     grpc_services:
-    - envoy_grpc:
-        cluster_name: xds_cluster
-  cds_config:
-    api_config_source:
-      api_type: GRPC
-      grpc_services:
       - envoy_grpc:
           cluster_name: xds_cluster
+  cds_config:
+    resource_api_version: V3
+    api_config_source:
+      api_type: GRPC
+      transport_api_version: V3
+      grpc_services:
+        - envoy_grpc:
+            cluster_name: xds_cluster
       set_node_on_first_message_only: true
   lds_config:
+    resource_api_version: V3
     api_config_source:
       api_type: GRPC
+      transport_api_version: V3
       grpc_services:
-      - envoy_grpc:
-          cluster_name: xds_cluster
+        - envoy_grpc:
+            cluster_name: xds_cluster
       set_node_on_first_message_only: true
 node:
   cluster: service_greeter
   id: test-id
 static_resources:
   clusters:
-  - connect_timeout: 1s
-    hosts:
-    - socket_address:
-        address: 172.17.0.1
-        port_value: 18000
-    http2_protocol_options: {}
-    name: xds_cluster
-    type: STRICT_DNS
+    - connect_timeout: 1s
+      hosts:
+        - socket_address:
+            address: 172.17.0.1
+            port_value: 18000
+      http2_protocol_options: {}
+      name: xds_cluster
+      type: STRICT_DNS

--- a/internal/pkg/mgw/mgw.go
+++ b/internal/pkg/mgw/mgw.go
@@ -17,14 +17,14 @@
 package mgw
 
 import (
-	endpointservice "github.com/envoyproxy/go-control-plane/envoy/service/endpoint/v3"
-	clusterservice "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
-	routeservice "github.com/envoyproxy/go-control-plane/envoy/service/route/v3"
-	listenerservice "github.com/envoyproxy/go-control-plane/envoy/service/listener/v3"
-	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	endpointservicev3 "github.com/envoyproxy/go-control-plane/envoy/service/endpoint/v3"
+	clusterservicev3 "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
+	routeservicev3 "github.com/envoyproxy/go-control-plane/envoy/service/route/v3"
+	listenerservicev3 "github.com/envoyproxy/go-control-plane/envoy/service/listener/v3"
+	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	cachev3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	xds "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+	xdsv3 "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 
 	mgwconfig "github.com/wso2/micro-gw/configs/confTypes"
 	apiserver "github.com/wso2/micro-gw/internal/pkg/api"
@@ -81,9 +81,9 @@ func init() {
 type IDHash struct{}
 
 // ID uses the node ID field
-func (IDHash) ID(node *core.Node) string {
+func (IDHash) ID(node *corev3.Node) string {
 	if node == nil {
-		return ""
+		return "unknown"
 	}
 	return node.Id
 }
@@ -100,7 +100,7 @@ const grpcMaxConcurrentStreams = 1000000
  * @param server   Xds server instance
  * @param port   Management server port
  */
-func RunManagementServer(ctx context.Context, server xds.Server, port uint) {
+func RunManagementServer(ctx context.Context, server xdsv3.Server, port uint) {
 	var grpcOptions []grpc.ServerOption
 	grpcOptions = append(grpcOptions, grpc.MaxConcurrentStreams(grpcMaxConcurrentStreams))
 	grpcServer := grpc.NewServer()
@@ -111,11 +111,11 @@ func RunManagementServer(ctx context.Context, server xds.Server, port uint) {
 	}
 
 	// register services
-	discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, server)
-	endpointservice.RegisterEndpointDiscoveryServiceServer(grpcServer, server)
-	clusterservice.RegisterClusterDiscoveryServiceServer(grpcServer, server)
-	routeservice.RegisterRouteDiscoveryServiceServer(grpcServer, server)
-	listenerservice.RegisterListenerDiscoveryServiceServer(grpcServer, server)
+	discoveryv3.RegisterAggregatedDiscoveryServiceServer(grpcServer, server)
+	endpointservicev3.RegisterEndpointDiscoveryServiceServer(grpcServer, server)
+	clusterservicev3.RegisterClusterDiscoveryServiceServer(grpcServer, server)
+	routeservicev3.RegisterRouteDiscoveryServiceServer(grpcServer, server)
+	listenerservicev3.RegisterListenerDiscoveryServiceServer(grpcServer, server)
 
 	logger.LoggerMgw.Info("port: ",port, " management server listening")
 	//log.Fatalf("", Serve(lis))
@@ -188,7 +188,7 @@ func Run(conf *mgwconfig.Config) {
 
 	cache = cachev3.NewSnapshotCache(mode != Ads, IDHash{}, nil)
 
-	srv := xds.NewServer(ctx, cache, nil)
+	srv := xdsv3.NewServer(ctx, cache, nil)
 
 	//als := &myals.AccessLogService{}
 	//go RunAccessLogServer(ctx, als, alsPort)

--- a/internal/pkg/oasparser/configGenerator.go
+++ b/internal/pkg/oasparser/configGenerator.go
@@ -20,9 +20,9 @@ package oasparser
 
 import (
 
-	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 
 	swgger "github.com/wso2/micro-gw/internal/pkg/oasparser/swaggerOperator"
@@ -51,9 +51,9 @@ func GetProductionSources(location string) ([]types.Resource, []types.Resource, 
 	}
 
 	var (
-		routesP    []*route.Route
-		clustersP  []*cluster.Cluster
-		endpointsP []*core.Address
+		routesP    []*routev3.Route
+		clustersP  []*clusterv3.Cluster
+		endpointsP []*corev3.Address
 	)
 
 	for _, swagger := range mgwSwaggers {
@@ -103,9 +103,9 @@ func GetSandboxSources(location string) ([]types.Resource, []types.Resource, []t
 	}
 	//fmt.Println(mgwSwagger)
 	var (
-		routesS    []*route.Route
-		clustersS  []*cluster.Cluster
-		endpointsS []*core.Address
+		routesS    []*routev3.Route
+		clustersS  []*clusterv3.Cluster
+		endpointsS []*corev3.Address
 	)
 
 	for _, swagger := range mgwSwaggers {

--- a/internal/pkg/oasparser/configGenerator.go
+++ b/internal/pkg/oasparser/configGenerator.go
@@ -19,14 +19,17 @@ package oasparser
 //package envoy_config_generator
 
 import (
-	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	v2route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
-	logger "github.com/wso2/micro-gw/internal/loggers"
-	enovoy "github.com/wso2/micro-gw/internal/pkg/oasparser/envoyCodegen"
-	"github.com/wso2/micro-gw/internal/pkg/oasparser/models/envoy"
+
 	swgger "github.com/wso2/micro-gw/internal/pkg/oasparser/swaggerOperator"
+	enovoy "github.com/wso2/micro-gw/internal/pkg/oasparser/envoyCodegen"
+	logger "github.com/wso2/micro-gw/internal/loggers"
+	"github.com/wso2/micro-gw/internal/pkg/oasparser/models/envoy"
+
 	"strings"
 )
 
@@ -48,8 +51,8 @@ func GetProductionSources(location string) ([]types.Resource, []types.Resource, 
 	}
 
 	var (
-		routesP    []*v2route.Route
-		clustersP  []*v2.Cluster
+		routesP    []*route.Route
+		clustersP  []*cluster.Cluster
 		endpointsP []*core.Address
 	)
 
@@ -100,8 +103,8 @@ func GetSandboxSources(location string) ([]types.Resource, []types.Resource, []t
 	}
 	//fmt.Println(mgwSwagger)
 	var (
-		routesS    []*v2route.Route
-		clustersS  []*v2.Cluster
+		routesS    []*route.Route
+		clustersS  []*cluster.Cluster
 		endpointsS []*core.Address
 	)
 

--- a/internal/pkg/oasparser/envoyCodegen/httpFilters.go
+++ b/internal/pkg/oasparser/envoyCodegen/httpFilters.go
@@ -17,10 +17,10 @@
 package envoyCodegen
 
 import (
-	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	ext_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
-	router "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	hcmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	ext_authv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+	routerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
 	logger "github.com/wso2/micro-gw/internal/loggers"
@@ -32,11 +32,11 @@ import (
  *
  * @return []*hcm.HttpFilter  Http filter set as a array
  */
-func getHttpFilters() []*hcm.HttpFilter {
+func getHttpFilters() []*hcmv3.HttpFilter {
 	//extAauth := GetExtAauthzHttpFilter()
 	router := getRouterHttpFilter()
 
-	httpFilters := []*hcm.HttpFilter{
+	httpFilters := []*hcmv3.HttpFilter{
 		//&extAauth,
 		&router,
 	}
@@ -49,9 +49,9 @@ func getHttpFilters() []*hcm.HttpFilter {
  *
  * @return hcm.HttpFilter  Http filter instance
  */
-func getRouterHttpFilter() hcm.HttpFilter {
+func getRouterHttpFilter() hcmv3.HttpFilter {
 
-	routeFilterConf := router.Router{
+	routeFilterConf := routerv3.Router{
 		DynamicStats:             nil,
 		StartChildSpan:           false,
 		UpstreamLog:              nil,
@@ -68,9 +68,9 @@ func getRouterHttpFilter() hcm.HttpFilter {
 		logger.LoggerOasparser.Error("Error marshaling route filter configs. ", err)
 	}
 
-	filter := hcm.HttpFilter{
+	filter := hcmv3.HttpFilter{
 		Name:                 wellknown.Router,
-		ConfigType:           &hcm.HttpFilter_TypedConfig{TypedConfig: routeFilterTypedConf},
+		ConfigType:           &hcmv3.HttpFilter_TypedConfig{TypedConfig: routeFilterTypedConf},
 		XXX_NoUnkeyedLiteral: struct{}{},
 		XXX_unrecognized:     nil,
 		XXX_sizecache:        0,
@@ -84,16 +84,16 @@ func getRouterHttpFilter() hcm.HttpFilter {
  *
  * @return hcm.HttpFilter  Http filter instance
  */
-func getExtAauthzHttpFilter() hcm.HttpFilter {
-	extAuthzConfig := &ext_auth.ExtAuthz{
-		WithRequestBody: &ext_auth.BufferSettings{
+func getExtAauthzHttpFilter() hcmv3.HttpFilter {
+	extAuthzConfig := &ext_authv3.ExtAuthz{
+		WithRequestBody: &ext_authv3.BufferSettings{
 			MaxRequestBytes:     1024,
 			AllowPartialMessage: false,
 		},
-		Services: &ext_auth.ExtAuthz_GrpcService{
-			GrpcService: &core.GrpcService{
-				TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-					EnvoyGrpc: &core.GrpcService_EnvoyGrpc{
+		Services: &ext_authv3.ExtAuthz_GrpcService{
+			GrpcService: &corev3.GrpcService{
+				TargetSpecifier: &corev3.GrpcService_EnvoyGrpc_{
+					EnvoyGrpc: &corev3.GrpcService_EnvoyGrpc{
 						ClusterName: "ext-authz",
 					},
 				},
@@ -104,9 +104,9 @@ func getExtAauthzHttpFilter() hcm.HttpFilter {
 	if err2 != nil {
 		logger.LoggerOasparser.Error(err2)
 	}
-	extAuthzFilter := hcm.HttpFilter{
+	extAuthzFilter := hcmv3.HttpFilter{
 		Name: "envoy.filters.http.ext_authz",
-		ConfigType: &hcm.HttpFilter_TypedConfig{
+		ConfigType: &hcmv3.HttpFilter_TypedConfig{
 			TypedConfig: ext,
 		},
 	}

--- a/internal/pkg/oasparser/envoyCodegen/routesWithClusters.go
+++ b/internal/pkg/oasparser/envoyCodegen/routesWithClusters.go
@@ -17,11 +17,11 @@
 package envoyCodegen
 
 import (
-	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	envoy_type_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_type_matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 
 	swag_operator "github.com/wso2/micro-gw/internal/pkg/oasparser/swaggerOperator"
 	logger "github.com/wso2/micro-gw/internal/loggers"
@@ -49,23 +49,23 @@ import (
  * @return []*v2.Cluster  Sandbox clusters
  * @return []*core.Address  Sandbox endpoints
  */
-func CreateRoutesWithClusters(mgwSwagger apiDefinition.MgwSwagger) ([]*route.Route, []*cluster.Cluster, []*core.Address, []*route.Route, []*cluster.Cluster, []*core.Address) {
+func CreateRoutesWithClusters(mgwSwagger apiDefinition.MgwSwagger) ([]*routev3.Route, []*clusterv3.Cluster, []*corev3.Address, []*routev3.Route, []*clusterv3.Cluster, []*corev3.Address) {
 	var (
-		routesProd           []*route.Route
-		clustersProd         []*cluster.Cluster
+		routesProd           []*routev3.Route
+		clustersProd         []*clusterv3.Cluster
 		endpointProd         []apiDefinition.Endpoint
 		apiLevelEndpointProd []apiDefinition.Endpoint
-		apilevelClusterProd  cluster.Cluster
+		apilevelClusterProd  clusterv3.Cluster
 		cluster_refProd      string
-		endpointsProd        []*core.Address
+		endpointsProd        []*corev3.Address
 
-		routesSand           []*route.Route
-		clustersSand         []*cluster.Cluster
+		routesSand           []*routev3.Route
+		clustersSand         []*clusterv3.Cluster
 		endpointSand         []apiDefinition.Endpoint
 		apiLevelEndpointSand []apiDefinition.Endpoint
-		apilevelClusterSand  cluster.Cluster
+		apilevelClusterSand  clusterv3.Cluster
 		cluster_refSand      string
-		endpointsSand        []*core.Address
+		endpointsSand        []*corev3.Address
 	)
 	//check API level sandbox endpoints availble
 	if swag_operator.IsEndpointsAvailable(mgwSwagger.GetSandEndpoints()) {
@@ -153,7 +153,7 @@ func CreateRoutesWithClusters(mgwSwagger apiDefinition.MgwSwagger) ([]*route.Rou
  * @param address   Address which has host and port
  * @return v2.Cluster  Cluster instance
  */
-func createCluster(address core.Address, clusterName string) cluster.Cluster {
+func createCluster(address corev3.Address, clusterName string) clusterv3.Cluster {
 	logger.LoggerOasparser.Debug("creating a cluster....")
 	conf, errReadConfig := configs.ReadConfigs()
 	if errReadConfig != nil {
@@ -161,20 +161,20 @@ func createCluster(address core.Address, clusterName string) cluster.Cluster {
 	}
 
 	h := &address
-	cluster := cluster.Cluster{
+	cluster := clusterv3.Cluster{
 		Name:                 clusterName,
 		ConnectTimeout:       ptypes.DurationProto(conf.Envoy.ClusterTimeoutInSeconds* time.Second),
-		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STRICT_DNS},
-		DnsLookupFamily:      cluster.Cluster_V4_ONLY,
-		LbPolicy:             cluster.Cluster_ROUND_ROBIN,
-		LoadAssignment: &endpoint.ClusterLoadAssignment{
+		ClusterDiscoveryType: &clusterv3.Cluster_Type{Type: clusterv3.Cluster_STRICT_DNS},
+		DnsLookupFamily:      clusterv3.Cluster_V4_ONLY,
+		LbPolicy:             clusterv3.Cluster_ROUND_ROBIN,
+		LoadAssignment: &endpointv3.ClusterLoadAssignment{
 			ClusterName: clusterName,
-			Endpoints: []*endpoint.LocalityLbEndpoints{
+			Endpoints: []*endpointv3.LocalityLbEndpoints{
 				{
-					LbEndpoints: []*endpoint.LbEndpoint{
+					LbEndpoints: []*endpointv3.LbEndpoint{
 						{
-							HostIdentifier: &endpoint.LbEndpoint_Endpoint{
-								Endpoint: &endpoint.Endpoint{
+							HostIdentifier: &endpointv3.LbEndpoint_Endpoint{
+								Endpoint: &endpointv3.Endpoint{
 									Address: h,
 								},
 							},
@@ -197,20 +197,20 @@ func createCluster(address core.Address, clusterName string) cluster.Cluster {
  * @param clusterName  Name of the cluster
  * @return v2route.Route  Route instance
  */
-func createRoute(xWso2Basepath string,endpoint apiDefinition.Endpoint, resourcePath string, clusterName string) route.Route {
+func createRoute(xWso2Basepath string,endpoint apiDefinition.Endpoint, resourcePath string, clusterName string) routev3.Route {
 	logger.LoggerOasparser.Debug("creating a route....")
 	var (
-		router route.Route
-		action *route.Route_Route
-		match *route.RouteMatch
+		router routev3.Route
+		action *routev3.Route_Route
+		match *routev3.RouteMatch
 	)
 	routePath := GenerateRoutePaths(xWso2Basepath,endpoint.GetBasepath(), resourcePath)
 
-	match = &route.RouteMatch{
-		PathSpecifier: &route.RouteMatch_SafeRegex{
-			SafeRegex: &envoy_type_matcher.RegexMatcher{
-				EngineType: &envoy_type_matcher.RegexMatcher_GoogleRe2{
-					GoogleRe2: &envoy_type_matcher.RegexMatcher_GoogleRE2{
+	match = &routev3.RouteMatch{
+		PathSpecifier: &routev3.RouteMatch_SafeRegex{
+			SafeRegex: &envoy_type_matcherv3.RegexMatcher{
+				EngineType: &envoy_type_matcherv3.RegexMatcher_GoogleRe2{
+					GoogleRe2: &envoy_type_matcherv3.RegexMatcher_GoogleRE2{
 						MaxProgramSize: nil,
 					},
 				},
@@ -221,15 +221,15 @@ func createRoute(xWso2Basepath string,endpoint apiDefinition.Endpoint, resourceP
 
 
 	if xWso2Basepath != "" {
-		action = &route.Route_Route{
-			Route: &route.RouteAction{
-				HostRewriteSpecifier: &route.RouteAction_HostRewriteLiteral{
+		action = &routev3.Route_Route{
+			Route: &routev3.RouteAction{
+				HostRewriteSpecifier: &routev3.RouteAction_HostRewriteLiteral{
 					HostRewriteLiteral: endpoint.GetHost(),
 				},
-				RegexRewrite: &envoy_type_matcher.RegexMatchAndSubstitute{
-					Pattern: &envoy_type_matcher.RegexMatcher{
-						EngineType: &envoy_type_matcher.RegexMatcher_GoogleRe2{
-							GoogleRe2: &envoy_type_matcher.RegexMatcher_GoogleRE2{
+				RegexRewrite: &envoy_type_matcherv3.RegexMatchAndSubstitute{
+					Pattern: &envoy_type_matcherv3.RegexMatcher{
+						EngineType: &envoy_type_matcherv3.RegexMatcher_GoogleRe2{
+							GoogleRe2: &envoy_type_matcherv3.RegexMatcher_GoogleRE2{
 								MaxProgramSize: nil,
 							},
 						},
@@ -237,25 +237,25 @@ func createRoute(xWso2Basepath string,endpoint apiDefinition.Endpoint, resourceP
 					},
 					Substitution: endpoint.GetBasepath(),
 				},
-				ClusterSpecifier: &route.RouteAction_Cluster{
+				ClusterSpecifier: &routev3.RouteAction_Cluster{
 					Cluster: clusterName,
 				},
 			},
 		}
 	} else {
-		action =  &route.Route_Route{
-			Route: &route.RouteAction{
-				HostRewriteSpecifier: &route.RouteAction_HostRewriteLiteral{
+		action =  &routev3.Route_Route{
+			Route: &routev3.RouteAction{
+				HostRewriteSpecifier: &routev3.RouteAction_HostRewriteLiteral{
 					HostRewriteLiteral: endpoint.GetHost(),
 				},
-				ClusterSpecifier: &route.RouteAction_Cluster{
+				ClusterSpecifier: &routev3.RouteAction_Cluster{
 					Cluster: clusterName,
 				},
 			},
 		}
 	}
 
-	router = route.Route{
+	router = routev3.Route{
 		Name: "routename",
 		Match: match,
 		Action: action,

--- a/internal/pkg/oasparser/models/envoy/envoyNode.go
+++ b/internal/pkg/oasparser/models/envoy/envoyNode.go
@@ -17,9 +17,11 @@
 package envoy
 
 import (
-	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	v2route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 )
 
@@ -30,17 +32,17 @@ type EnvoyNode struct {
 	endpoints []types.Resource
 }
 
-func (envoy *EnvoyNode) SetListener(listener *v2.Listener) {
+func (envoy *EnvoyNode) SetListener(listener *listener.Listener) {
 	envoy.listeners = []types.Resource{listener}
 }
 
-func (envoy *EnvoyNode) SetClusters(clusters []*v2.Cluster) {
+func (envoy *EnvoyNode) SetClusters(clusters []*cluster.Cluster) {
 	for _, clusterP := range clusters {
 		envoy.clusters = append(envoy.clusters, clusterP)
 	}
 }
 
-func (envoy *EnvoyNode) SetRoutes(routes []*v2route.Route) {
+func (envoy *EnvoyNode) SetRoutes(routes []*route.Route) {
 	for _, routes := range routes {
 		envoy.routes = append(envoy.routes, routes)
 	}

--- a/internal/pkg/oasparser/models/envoy/envoyNode.go
+++ b/internal/pkg/oasparser/models/envoy/envoyNode.go
@@ -17,10 +17,10 @@
 package envoy
 
 import (
-	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 )
@@ -32,23 +32,23 @@ type EnvoyNode struct {
 	endpoints []types.Resource
 }
 
-func (envoy *EnvoyNode) SetListener(listener *listener.Listener) {
+func (envoy *EnvoyNode) SetListener(listener *listenerv3.Listener) {
 	envoy.listeners = []types.Resource{listener}
 }
 
-func (envoy *EnvoyNode) SetClusters(clusters []*cluster.Cluster) {
+func (envoy *EnvoyNode) SetClusters(clusters []*clusterv3.Cluster) {
 	for _, clusterP := range clusters {
 		envoy.clusters = append(envoy.clusters, clusterP)
 	}
 }
 
-func (envoy *EnvoyNode) SetRoutes(routes []*route.Route) {
+func (envoy *EnvoyNode) SetRoutes(routes []*routev3.Route) {
 	for _, routes := range routes {
 		envoy.routes = append(envoy.routes, routes)
 	}
 }
 
-func (envoy *EnvoyNode) SetEndpoints(endpoints []*core.Address) {
+func (envoy *EnvoyNode) SetEndpoints(endpoints []*corev3.Address) {
 	for _, endpoint := range endpoints {
 		envoy.endpoints = append(envoy.endpoints, endpoint)
 	}

--- a/resources/apis/test2.yaml
+++ b/resources/apis/test2.yaml
@@ -1,6 +1,6 @@
 openapi: "3.0"
 info:
-  description: "This is a samle server etsore srvr      e  [hp://wagger.o](htp//swag.o)  n [.es()s y cn  p  `sie`    n"
+  description: "This is a samle server etsore sr      e  [hp//wagger.o](htp//swag.o)  n [.es()s y cn  p  `sie`    n"
   version: "1.0.0"
   title: "Swagger Petstore"
 

--- a/resources/apis/test2.yaml
+++ b/resources/apis/test2.yaml
@@ -1,6 +1,6 @@
 openapi: "3.0"
 info:
-  description: "This is a samle server etsore sr      e  [hp//wagger.o](htp//swag.o)  n [.es()s y cn  p  `sie`    n"
+  description: "This is a samle server etsore sr      e  [hp/wagger.o](htp//swag.o)  n [.es()s y cn  p  `sie`    n"
   version: "1.0.0"
   title: "Swagger Petstore"
 


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
Currently the control plane has implemented using v2 apis. But envoy will deprecated v2 apis from q4 in 2020. As $subject this will migrate to control plane xds v2 apis to v3. and also replace all the deprecated configurations.

When migrating to v3 apis, I have done the follwing steps.

- Migrate transport apis to v3 [1]

- Migrate resource apis to v3 [1]

- Change the boostrap configs to v3 [2,3]


[1] -  https://www.envoyproxy.io/docs/envoy/latest/faq/api/envoy_v3
[2] -  https://www.envoyproxy.io/docs/envoy/v1.14.1/configuration/overview/xds_api.html?highlight=transport_api_version#grpc-streaming-endpoints
[3] - https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/config_source.proto.html?highlight=resource_api_version

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1297

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
