### PR TITLE
Fix #1258 - Add individual service calls when validating subscriptions

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/api_gateway_cache.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/api_gateway_cache.bal
@@ -54,6 +54,7 @@ cache:Cache jwtCache = new (genericCacheConfig);
 cache:Cache introspectCache = new (genericCacheConfig);
 cache:Cache gatewayClaimsCache = new (genericCacheConfig);
 cache:Cache subscriptionCache = new (genericCacheConfig);
+cache:Cache invalidSubscriptionCache = new(genericCacheConfig);
 
 cache:Cache jwtGeneratorCache = new (jwtGenerationCacheConfig);
 cache:Cache mutualSslCertificateCache = new (genericCacheConfig);
@@ -187,5 +188,38 @@ public type APIGatewayCache object {
         } else {
             return ();
         }
+    }
+
+    public function addToInvalidSubcriptionCache(string subscriptionKey, AuthenticationContext authenticationContext) {
+        error? err = invalidSubscriptionCache.put(<@untainted>subscriptionKey, <@untainted>authenticationContext);
+        if (err is error) {
+            printError(KEY_GW_CACHE, "Error while adding subscription key " +  subscriptionKey + " to the subscription cache", err);
+        }
+        printDebug(KEY_GW_CACHE, "Added subscription information to the subscription cache. key: " + subscriptionKey);
+    }
+
+    public function retrieveFromInvalidSubcriptionCache(string subscriptionKey) returns (AuthenticationContext | ()){
+        var authenticationContext = invalidSubscriptionCache.get(subscriptionKey);
+        if (authenticationContext is AuthenticationContext) {
+            return authenticationContext;
+        } else {
+            return ();
+        }
+    }
+
+    public function removeFromInvalidSubcriptionCache(string subscriptionKey) {
+        error? err = invalidSubscriptionCache.invalidate(subscriptionKey);
+        if (err is error) {
+            printError(KEY_GW_CACHE, "Error while removing subscription key from invalid subscription cache : " + subscriptionKey , err);
+        }
+        printDebug(KEY_GW_CACHE, "Removed from the invalid subscription cache. Subscription key: " + subscriptionKey);
+    }
+
+    public function removeAllFromInvalidSubcriptionCache() {
+        error? err = invalidSubscriptionCache.invalidateAll();
+        if (err is error) {
+            printError(KEY_GW_CACHE, "Error while invalidating all entries from invalid subscription cache" , err);
+        }
+        printDebug(KEY_GW_CACHE, "Removed all entries from the invalid subscription cache.");
     }
 };

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
@@ -492,6 +492,7 @@ const string KEY_JWT_AUTH_PROVIDER = "JWTAuthProvider";
 public const string KEY_GRPC_ANALYTICS = "gRPCAnalytics";
 const string API_KEY_UTIL = "APIKeyUtil";
 const string JWT_UTIL = "JWTUtil";
+const string KEY_PILOT_UTIL = "PilotUtil";
 const string API_KEY_PROVIDER = "APIKeyProvider";
 public const string TOKEN_SERVICE = "TokenService";
 public const string HEALTH_CHECK_SERVICE = "HealthCheckService";

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/jwt_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/jwt_util.bal
@@ -52,7 +52,7 @@ public function isAllowedKey(string token, jwt:JwtPayload payload, boolean isVal
         authenticationContext.username = username;
     }
     string|string[]? audiencePayload = payload?.aud;
-    printDebug(JWT_UTIL,"Audiemce value retrieved : " + audiencePayload.toString());
+    printDebug(JWT_UTIL,"Audience value retrieved : " + audiencePayload.toString());
     string consumerKey = "";
     if (customClaims is map<json> && customClaims.hasKey(appKeyClaim)) {
         consumerKey = customClaims.get(appKeyClaim).toString();


### PR DESCRIPTION
### Purpose
After checking the subscription dat in data stores if they are not available we need to a service call and check whether the subscription dat is updated in the database.
This service call is done due to following reasone
1. If the jms message is dropped upon new subscription addition.
2. If a request comes before subscription data is pulled during the startup.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1258 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
