### PR TITLE
Fix issue #1303 - Analytics report generation is not working when define audience 

### DIFF
--- a/distribution/resources/conf/micro-gw.conf
+++ b/distribution/resources/conf/micro-gw.conf
@@ -19,7 +19,6 @@
 
 [[jwtTokenConfig]]
   issuer = "https://localhost:9443/oauth2/token"
-  audience = "http://org.wso2.apimgt/gateway"
   certificateAlias = "wso2apim310"
   validateSubscription = false
 


### PR DESCRIPTION

### Purpose
Analytics report generation is not working when define audience MGW config file

### Issues

Fixes #1303

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
