### PR TITLE
populate api tier and api name in backend jwt header

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/jwt_generator/jwt_gen_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/jwt_generator/jwt_gen_util.bal
@@ -137,7 +137,7 @@ function createAPIDetailsMap (runtime:InvocationContext invocationContext) retur
     if (apiConfig is APIConfiguration) {
         apiDetails["apiName"] = apiConfig.name;
         apiDetails["apiVersion"] = apiConfig.apiVersion;
-        apiDetails["apiTier"] = apiConfig.apiTier;
+        apiDetails["apiTier"] = (apiConfig.apiTier != "") ? apiConfig.apiTier : UNLIMITED_TIER;
         apiDetails["apiContext"] = <string> invocationContext.attributes[API_CONTEXT];
         apiDetails["apiPublisher"] = apiConfig.publisher;
         apiDetails["subscriberTenantDomain"] = authenticationContext.subscriberTenantDomain;

--- a/components/micro-gateway-jwt-generator/src/main/java/org/wso2/micro/gateway/jwt/generator/MGWJWTGeneratorImpl.java
+++ b/components/micro-gateway-jwt-generator/src/main/java/org/wso2/micro/gateway/jwt/generator/MGWJWTGeneratorImpl.java
@@ -30,7 +30,7 @@ import java.util.UUID;
  */
 public class MGWJWTGeneratorImpl extends AbstractMGWJWTGenerator {
     private static final Logger logger = LogManager.getLogger(MGWJWTGeneratorImpl.class);
-    private static final String AUTH_APPLICATION_USER_LEVEL_TOKEN = "Application_user";
+    private static final String AUTH_APPLICATION_USER_LEVEL_TOKEN = "Application_User";
 
     public MGWJWTGeneratorImpl(String dialectURI,
                                String signatureAlgorithm,
@@ -56,11 +56,6 @@ public class MGWJWTGeneratorImpl extends AbstractMGWJWTGenerator {
         Map<String, Object> claims = new HashMap<>();
         HashMap<String, Object> customClaims = (HashMap<String, Object>) jwtInfo.get("customClaims");
         claims.put("iss", getTokenIssuer());
-        if (getTokenAudience().length == 1) {
-            claims.put("aud", getTokenAudience()[0]);
-        } else if (getTokenAudience().length != 0) {
-            claims.put("aud", arrayToJSONArray(getTokenAudience()));
-        }
         claims.put("jti", UUID.randomUUID().toString());
         claims.put("iat", (int) (currentTime / 1000));
         claims.put("exp", (int) (expireIn / 1000));
@@ -85,6 +80,9 @@ public class MGWJWTGeneratorImpl extends AbstractMGWJWTGenerator {
             if (StringUtils.isNotEmpty((CharSequence) ((HashMap) customClaims.get("application")).get("tier"))) {
                 claims.put(dialect + "/applicationtier", ((HashMap) customClaims.get("application")).get("tier"));
             }
+        }
+        if (StringUtils.isNotEmpty((CharSequence) getApiDetails().get("apiName"))) {
+            claims.put(dialect + "/apiName", getApiDetails().get("apiName"));
         }
         if (StringUtils.isNotEmpty((CharSequence) getApiDetails().get("apiContext"))) {
             claims.put(dialect + "/apicontext", getApiDetails().get("apiContext"));


### PR DESCRIPTION
### Purpose
Fix the issue where the API name property and the API tier (when the tier is unlimited) is not populated in the backend JWT. 

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1196

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
MacOS Mojave

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
