### PR TITLE
Read the api definition content and pass in to the OpenAPIV3Parser.

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/codegen/CodeGenerator.java
@@ -97,8 +97,8 @@ public class CodeGenerator {
                             fileName.toString().endsWith(CliConstants.YAML_EXTENSION));
                 }).forEach(path -> {
                     try {
-                        OpenAPI openAPI = new OpenAPIV3Parser().read(path.toString());
                         String openAPIContent = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+                        OpenAPI openAPI = new OpenAPIV3Parser().readContents(openAPIContent).getOpenAPI();
                         String openAPIAsJson = OpenAPICodegenUtils.getOpenAPIAsJson(openAPI, openAPIContent, path);
                         String openAPIContentAsJson = openAPIAsJson;
                         if (path.toString().endsWith(CliConstants.YAML_EXTENSION)) {


### PR DESCRIPTION
### Purpose
Fix the swagger parsing issue when the api definition file has spaces in the file name.


### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/1292

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
