### PR TITLE
Make the jms and throttle publishers start asynchronously.

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/policies/throttle_policy_initializer.bal
+++ b/components/micro-gateway-cli/src/main/resources/policies/throttle_policy_initializer.bal
@@ -1,8 +1,6 @@
 import ballerina/runtime;
 import wso2/gateway;
 
-future<()> ftr = start initThrottlePolicies();
-
 function initThrottlePolicies() {
     boolean globalThrottlingEnabled = gateway:initiateThrottlingJmsListener();
 

--- a/components/micro-gateway-cli/src/main/resources/templates/main.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/main.mustache
@@ -1,5 +1,8 @@
 import wso2/gateway;
+import ballerina/lang.'object;
+import ballerina/io;
 
+const string MAIN_MUSTACHE = "Main";
 public function main() {
     gateway:initNativeImpLog4jConfig();
     int totalResourceLength = 0;
@@ -24,10 +27,6 @@ public function main() {
     initInterceptorIndexes{{cut qualifiedServiceName " "}}();
     {{/each}}
     addTokenServicesFilterAnnotation();
-    initThrottlePolicies();
-    future<()> gatewayNotification = start gateway:initiateNotificationJmsListener();
-    gateway:initThrottleDataPublisher();
-    gateway:initGlobalThrottleDataPublisher();
     gateway:startObservabilityListener();
 
     {{>jwtRevocation}}
@@ -35,3 +34,27 @@ public function main() {
 
     future<()> callhome = start gateway:invokeCallHome();
 }
+
+listener ObjectName jmsListener = new(); // This will be your normal listeners like http listner...
+type ObjectName object {
+    *'object:Listener;
+    public function __attach(service s, string? name) returns error? {
+    }
+    public function __detach(service s) returns error? {
+    }
+    public function __start() returns error? {
+        gateway:printDebug(MAIN_MUSTACHE, "Initializing throttling policies");
+        _ = start initThrottlePolicies();
+        gateway:printDebug(MAIN_MUSTACHE, "Initializing Notification JMS Listener");
+        _ = start gateway:initiateNotificationJmsListener();
+        gateway:printDebug(MAIN_MUSTACHE, "Initializing Throttle Data Publisher");
+        _ = start gateway:initThrottleDataPublisher();
+        gateway:printDebug(MAIN_MUSTACHE, "Initializing Global Throttle Data Publisher");
+        _ = start gateway:initGlobalThrottleDataPublisher();
+    }
+    public function __gracefulStop() returns error? {
+    }
+    public function __immediateStop() returns error? {
+    }
+};
+

--- a/components/micro-gateway-cli/src/main/resources/templates/main.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/main.mustache
@@ -1,6 +1,5 @@
 import wso2/gateway;
 import ballerina/lang.'object;
-import ballerina/io;
 
 const string MAIN_MUSTACHE = "Main";
 public function main() {
@@ -44,13 +43,13 @@ type ObjectName object {
     }
     public function __start() returns error? {
         gateway:printDebug(MAIN_MUSTACHE, "Initializing throttling policies");
-        _ = start initThrottlePolicies();
+        initThrottlePolicies();
         gateway:printDebug(MAIN_MUSTACHE, "Initializing Notification JMS Listener");
         _ = start gateway:initiateNotificationJmsListener();
         gateway:printDebug(MAIN_MUSTACHE, "Initializing Throttle Data Publisher");
-        _ = start gateway:initThrottleDataPublisher();
+        gateway:initThrottleDataPublisher();
         gateway:printDebug(MAIN_MUSTACHE, "Initializing Global Throttle Data Publisher");
-        _ = start gateway:initGlobalThrottleDataPublisher();
+        gateway:initGlobalThrottleDataPublisher();
     }
     public function __gracefulStop() returns error? {
     }

--- a/components/micro-gateway-cli/src/main/resources/templates/policy_init.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/policy_init.mustache
@@ -2,9 +2,8 @@ import wso2/gateway;
 
 
 function initThrottlePolicies() {
-    future<()> ftr = start gateway:initializeThrottleSubscription();
-    boolean globalThrottlingEnabled = gateway:initiateThrottlingJmsListener();
-
+    future<()> ftrThrottleSubscription = start gateway:initializeThrottleSubscription();
+   _ = start gateway:initiateThrottlingJmsListener();
 }
 
 function getDeployedPolicies() returns map<json> {

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/throttle_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/throttle_util.bal
@@ -76,10 +76,10 @@ public function publishNonThrottleEvent(RequestStreamDTO throttleEvent) {
 
 public function initializeThrottleSubscription() {
     isStreamsInitialized = true;
-    printDebug(KEY_THROTTLE_UTIL, "Successfully subscribed to global throttle stream.");
     if(enabledGlobalTMEventPublishing) {
         registerkeyTemplateRetrievalTask();
         registerBlockingConditionRetrievalTask();
+        printDebug(KEY_THROTTLE_UTIL, "Successfully subscribed to global throttle stream.");
     }
 }
 

--- a/distribution/resources/conf/default-micro-gw.conf.template
+++ b/distribution/resources/conf/default-micro-gw.conf.template
@@ -473,12 +473,18 @@
   # timestamp skew in milliseconds which added when checking the token validity period
   timestampSkew = 5000
 
+# Configurations for retrieving API and subscription data from API Manager.
 [apim.eventHub]
+  # Enable/ Disable the feature
   enable = false
+  # The API Manager URL
   service_url = "https://localhost:9443"
+  # The internal data REST API context.
   internalDataContext="/internal/data/v1/"
+  # User name and password of the internal data api.
   username="admin"
   password="admin"
+  # The message broker connection URL.
   eventListeningEndpoints = "amqp://admin:admin@carbon/carbon?brokerlist='tcp://localhost:5672'"
 
 # API Manager default credentials
@@ -488,5 +494,5 @@ password = "admin"
 
 # Token validation configuration
 [security]
-  # Enable/ Disable subscription validation for tokens.
+  # Enable/ Disable subscription validation for opaque (reference) tokens.
   validateSubscriptions = false


### PR DESCRIPTION
### Purpose
The current future<()> usage does not provide true asynchronous functionality when the gateway starting up. This PR fixes this issue and introduces async jms connection initialization.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/1348

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
