### PR TITLE
Fix #1263 - ballerina methods to acces gateway internal cache objects

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/api_gateway_cache.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/api_gateway_cache.bal
@@ -183,6 +183,26 @@ public type APIGatewayCache object {
         jwtCacheMap[issuer] = jwtCache;
         return jwtCache;
     }
+
+    public function getApiKeyCache() returns cache:Cache {
+        return apiKeyCache;
+    }
+
+    public function getIntrospectCache() returns cache:Cache {
+        return introspectCache;
+    }
+
+    public function getJwtGeneratorCache() returns cache:Cache {
+        return jwtGeneratorCache;
+    }
+
+    public function getGatewayClaimsCache() returns cache:Cache {
+        return gatewayClaimsCache;
+    }
+
+    public function getMutualSslCertificateCache() returns cache:Cache {
+        return mutualSslCertificateCache;
+    }
 };
 
 public function getCacheObject() returns APIGatewayCache {


### PR DESCRIPTION
### Purpose
With this PR users can access the mgw internal cache objects as  below

```ballerina
gateway:APIGatewayCache apiGwCacheObject = gateway:getCacheObject();
//ex getting the introspect cache
cache:Cache introspectCache = apiGwCacheObject.getIntrospectCache();
```
Similarly other caches can be accessed using below method

```ballerina
getJWTCacheForProvider() // jwt cache
getApiKeyCache() // api key cache
getJwtGeneratorCache() // back end jwt generator cache

```

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1263 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
