### PR TITLE
Read jmx_port from args and env

### DIFF
--- a/components/micro-gateway-cli/pom.xml
+++ b/components/micro-gateway-cli/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.micro.gateway.cli</artifactId>
     <packaging>jar</packaging>
-    <name>Micro Gateway Code Generator</name>
+    <name>Micro Gateway - Code Generator</name>
 
     <dependencies>
         <dependency>

--- a/components/micro-gateway-core/pom.xml
+++ b/components/micro-gateway-core/pom.xml
@@ -9,6 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>org.wso2.micro.gateway.core</artifactId>
+    <name>Micro Gateway - Core</name>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/components/micro-gateway-interceptor/pom.xml
+++ b/components/micro-gateway-interceptor/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mgw-interceptor</artifactId>
+    <name>Micro Gateway - Java Interceptor</name>
 
     <packaging>jar</packaging>
     <dependencies>

--- a/components/micro-gateway-jwt-generator/pom.xml
+++ b/components/micro-gateway-jwt-generator/pom.xml
@@ -23,6 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mgw-jwt-generator</artifactId>
+    <name>Micro Gateway - JWT Generator</name>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/components/micro-gateway-jwt-transformer/pom.xml
+++ b/components/micro-gateway-jwt-transformer/pom.xml
@@ -23,6 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mgw-jwt-transformer</artifactId>
+    <name>Micro Gateway - JWT Transformer</name>
     <dependencies>
         <dependency>
             <groupId>org.ballerinalang</groupId>

--- a/components/micro-gateway-tools/pom.xml
+++ b/components/micro-gateway-tools/pom.xml
@@ -10,6 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.micro.gateway.tools</artifactId>
     <packaging>jar</packaging>
+    <name>Micro Gateway - Tools</name>
 
     <dependencies>
         <dependency>

--- a/components/micro-gateway-tools/src/main/java/org/wso2/micro/gateway/tools/GetConfig.java
+++ b/components/micro-gateway-tools/src/main/java/org/wso2/micro/gateway/tools/GetConfig.java
@@ -6,14 +6,18 @@ import org.wso2.micro.gateway.tools.model.Config;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Extern function wso2.gateway:getConfigurations.
  */
 public class GetConfig {
+    private static final String CONF_JMX_PORT = "jmx_port";
+    private static final String CONF_METRICS_ENABLED = "metrics_enabled";
 
     /**
-     * reading the configurations from micro-gw.conf.
+     * Reading the configurations from micro-gw.conf.
      *
      * @param confFilePath Path of the micro-gw conf file
      * @param fileWritePath File path of the txt file
@@ -36,6 +40,131 @@ public class GetConfig {
                 writer.println(jmxPort);
             }
         }
+    }
+
+    /**
+     * Read configuration from program arguments, env variables and toml configuration file.
+     * Then these configuration values will be put into a newline separated file for easier reading from the
+     * scripts.
+     * @param args program argument list.
+     *             0th index should be the path to config file.
+     *             1st index should be the path to output file.
+     *             rest of the arguments can contain any arbitrary commandline configuration properties
+     * @throws IOException When toml config file reading fails
+     */
+    public void getConfigurations(String[] args) throws IOException {
+        String confFilePath = args [0];
+        String fileWritePath = args [1];
+        Map<String, String> configs = new HashMap<>();
+
+        getConfigsFromArgs(args, configs);
+        if (!isComplete(configs)) {
+            getConfigsFromEnv(configs);
+        }
+
+        if (!isComplete(configs)) {
+            getConfigsFromFile(confFilePath, configs);
+        }
+
+        if (isComplete(configs)) {
+            writeToFile(configs, fileWritePath);
+        }
+    }
+
+    private Map<String, String> getConfigsFromFile(String confFilePath, Map<String, String> currentConfigs) {
+        File configFile = new File (confFilePath);
+        Toml toml = new Toml();
+        toml.read(configFile);
+        Config config = toml.to(Config.class);
+        String isMetricsEnabled;
+        String jmxPort;
+
+        if (config.getB7a() != null && config.getB7a().getObservability() != null &&
+                config.getB7a().getObservability().getMetrics() != null) {
+            isMetricsEnabled = String.valueOf(config.getB7a().getObservability().getMetrics().isEnabled());
+            jmxPort = String.valueOf(config.getB7a().getObservability().getMetrics().getPrometheus().getJmxPort());
+            currentConfigs.putIfAbsent(CONF_METRICS_ENABLED, isMetricsEnabled);
+            currentConfigs.putIfAbsent(CONF_JMX_PORT, jmxPort);
+        }
+
+        return currentConfigs;
+    }
+
+    private Map<String, String> getConfigsFromEnv(Map<String, String> currentConfigs) {
+        final String confMetricsEnabledEnv = "b7a_observability_metrics_enabled";
+        final String confJmxPortEnv = "b7a_observability_metrics_prometheus_jmx_port";
+        String isMetricsEnabled;
+        String jmxPort;
+        isMetricsEnabled = System.getenv(confMetricsEnabledEnv);
+        jmxPort = System.getenv(confJmxPortEnv);
+
+        if (isMetricsEnabled != null) {
+            currentConfigs.putIfAbsent(CONF_METRICS_ENABLED, isMetricsEnabled);
+        }
+        if (jmxPort != null) {
+            currentConfigs.putIfAbsent(CONF_JMX_PORT, jmxPort);
+        }
+        return currentConfigs;
+    }
+
+    private Map<String, String> getConfigsFromArgs(String[] args, Map<String, String> currentConfigs) {
+        final String confMetricsEnabledArg = "--b7a.observability.metrics.enabled=";
+        final String confJmxPortArg = "--b7a.observability.metrics.prometheus.jmx_port=";
+        String isMetricsEnabled = null;
+        String jmxPort = null;
+
+        for (String arg: args) {
+            // checking variable value to avoid unwanted map lookup
+            if (isMetricsEnabled == null) {
+                String tmp = getConfigValue(arg, confMetricsEnabledArg);
+                if (tmp != null) {
+                    isMetricsEnabled = tmp;
+                    currentConfigs.put(CONF_METRICS_ENABLED, isMetricsEnabled);
+                }
+            }
+            if (jmxPort == null) {
+                String tmp = getConfigValue(arg, confJmxPortArg);
+                if (tmp != null) {
+                    jmxPort = tmp;
+                    currentConfigs.put(CONF_JMX_PORT, jmxPort);
+                }
+            }
+
+            if (isMetricsEnabled != null && jmxPort != null) {
+                break;
+            }
+        }
+
+        return currentConfigs;
+    }
+
+    private String getConfigValue (String config, String key) {
+        if (config.startsWith(key)) {
+            String[] arr = config.split(key);
+            if (arr.length == 2) {
+                return arr[1];
+            }
+        }
+
+        return null;
+    }
+
+    private void writeToFile(Map<String, String> configs, String filePath) throws IOException {
+        File txtConfigs = new File(filePath);
+        try (PrintWriter writer = new PrintWriter(txtConfigs, "UTF-8")) {
+            // writing configs one by one to preserve required order in the output.
+            if (configs.containsKey(CONF_METRICS_ENABLED)) {
+                writer.println(configs.get(CONF_METRICS_ENABLED));
+            }
+            if (configs.containsKey(CONF_JMX_PORT)) {
+                writer.println(configs.get(CONF_JMX_PORT));
+            }
+        }
+
+    }
+
+    private boolean isComplete(Map<String, String> configs) {
+        return configs.containsKey(CONF_METRICS_ENABLED) && configs.containsKey(CONF_JMX_PORT);
     }
 
 }

--- a/components/micro-gateway-tools/src/main/java/org/wso2/micro/gateway/tools/GetConfig.java
+++ b/components/micro-gateway-tools/src/main/java/org/wso2/micro/gateway/tools/GetConfig.java
@@ -57,13 +57,13 @@ public class GetConfig {
         String fileWritePath = args [1];
         Map<String, String> configs = new HashMap<>();
 
-        getConfigsFromArgs(args, configs);
+        extractConfigsFromArgs(args, configs);
         if (!isComplete(configs)) {
-            getConfigsFromEnv(configs);
+            extractConfigsFromEnv(configs);
         }
 
         if (!isComplete(configs)) {
-            getConfigsFromFile(confFilePath, configs);
+            extractConfigsFromFile(confFilePath, configs);
         }
 
         if (isComplete(configs)) {
@@ -71,7 +71,7 @@ public class GetConfig {
         }
     }
 
-    private Map<String, String> getConfigsFromFile(String confFilePath, Map<String, String> currentConfigs) {
+    private void extractConfigsFromFile(String confFilePath, Map<String, String> currentConfigs) {
         File configFile = new File (confFilePath);
         Toml toml = new Toml();
         toml.read(configFile);
@@ -86,11 +86,9 @@ public class GetConfig {
             currentConfigs.putIfAbsent(CONF_METRICS_ENABLED, isMetricsEnabled);
             currentConfigs.putIfAbsent(CONF_JMX_PORT, jmxPort);
         }
-
-        return currentConfigs;
     }
 
-    private Map<String, String> getConfigsFromEnv(Map<String, String> currentConfigs) {
+    private void extractConfigsFromEnv(Map<String, String> currentConfigs) {
         final String confMetricsEnabledEnv = "b7a_observability_metrics_enabled";
         final String confJmxPortEnv = "b7a_observability_metrics_prometheus_jmx_port";
         String isMetricsEnabled;
@@ -104,10 +102,9 @@ public class GetConfig {
         if (jmxPort != null) {
             currentConfigs.putIfAbsent(CONF_JMX_PORT, jmxPort);
         }
-        return currentConfigs;
     }
 
-    private Map<String, String> getConfigsFromArgs(String[] args, Map<String, String> currentConfigs) {
+    private void extractConfigsFromArgs(String[] args, Map<String, String> currentConfigs) {
         final String confMetricsEnabledArg = "--b7a.observability.metrics.enabled=";
         final String confJmxPortArg = "--b7a.observability.metrics.prometheus.jmx_port=";
         String isMetricsEnabled = null;
@@ -134,8 +131,6 @@ public class GetConfig {
                 break;
             }
         }
-
-        return currentConfigs;
     }
 
     private String getConfigValue (String config, String key) {

--- a/components/micro-gateway-tools/src/main/java/org/wso2/micro/gateway/tools/Main.java
+++ b/components/micro-gateway-tools/src/main/java/org/wso2/micro/gateway/tools/Main.java
@@ -5,15 +5,14 @@ package org.wso2.micro.gateway.tools;
  */
 public class Main {
     public static void main(String[] args) {
-            String confFilePath = args [0];
-            String fileWritePath = args [1];
-            GetConfig getConfig = new GetConfig();
-            try {
-                getConfig.getConfigurations(confFilePath, fileWritePath);
-            } catch (Exception ex) {
-                // if some error occurs we are using printStackTrace as we have logged that error from the shell
-                ex.printStackTrace();
-                System.exit(1);
-            }
+        GetConfig getConfig = new GetConfig();
+
+        try {
+            getConfig.getConfigurations(args);
+        } catch (Exception ex) {
+            // if some error occurs we are using printStackTrace as we have logged that error from the shell
+            ex.printStackTrace();
+            System.exit(1);
+        }
     }
 }

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>components</artifactId>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
-    <name>Micro Gateway Components</name>
+    <name>Micro Gateway - Components</name>
 
     <modules>
         <module>micro-gateway-interceptor</module>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -29,7 +29,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>wso2am-micro-gw</artifactId>
     <packaging>pom</packaging>
-    <name>WSO2 Micro Gateway - Distribution </name>
+    <name>Micro Gateway - Distribution </name>
     <description>WSO2 Micro Gateway Distribution</description>
 
     <dependencies>

--- a/distribution/resources/bin/gateway
+++ b/distribution/resources/bin/gateway
@@ -181,7 +181,7 @@ java_cmd_tools () {
       -XX:HeapDumpPath="$GW_HOME/heap-dump.hprof" \
       $JAVA_OPTS \
       -classpath "$METRIC_CLASSPATH" \
-      org.wso2.micro.gateway.tools.Main "$1" "$2" | tee -a "$GW_HOME/logs/microgateway.log"
+      org.wso2.micro.gateway.tools.Main "$1" "$2" $args | tee -a "$GW_HOME/logs/microgateway.log"
 }
 
 java_cmd_gateway () {
@@ -265,23 +265,10 @@ OBSERVABILITY_FLAG="false"
 CONFIG_FILE="$MGW_CONF_DIR/micro-gw.conf"
 K8S_MOUNT_PATH="/home/ballerina/conf/ballerina.conf"
 # if externally config map mounted conf found then use that as the config file location. This happens when used with k8s
-if [ -f "$K8S_MOUNT_PATH" ]
-then
+if [ -f "$K8S_MOUNT_PATH" ]; then
 	CONFIG_FILE="$K8S_MOUNT_PATH"
 fi
 CONFIG_OUT_FILE="$GW_HOME/.config"
-
-if [[ $b7a_observability_metrics_enabled == "true" ]]; then
-    OBSERVABILITY_FLAG="true"
-else
-    for c in $*
-    do
-        if [ "$c" = "--b7a.observability.enabled=true" ] || [ "$c" = "--b7a.observability.metrics.enabled=true" ]; then
-            OBSERVABILITY_FLAG="true"
-            break
-        fi
-    done
-fi
 
 # setup log4j configuration file to debug native implementation
 LOG4J_CONFIGURATION_FILE="${GW_HOME}/conf/log4j2.properties"

--- a/distribution/resources/bin/gateway.bat
+++ b/distribution/resources/bin/gateway.bat
@@ -79,12 +79,6 @@ CALL :buildBalArgs %*
 
 CALL :runTools %CONF_FILE% %CONF_OUT_FILE%
 
-IF "%b7a_observability_metrics_enabled%"=="true" (
-    SET IS_METRICS_ENABLED=T
-) ELSE (
-    CAll :isMetricsEnabled %*
-)
-
 IF EXIST %CONF_OUT_FILE% (
     IF "%IS_METRICS_ENABLED%"=="F" (
         FOR /F "delims=" %%i IN (%CONF_OUT_FILE%) DO (
@@ -195,7 +189,7 @@ REM arg0: command and other arguments to pass to tool library
         %JAVA_OPTS% ^
         -classpath %METRIC_CLASSPATH%
 
-    "%JAVA_HOME%\bin\java.exe" %JAVA_CMD% org.wso2.micro.gateway.tools.Main "%~1" "%~2"
+    "%JAVA_HOME%\bin\java.exe" %JAVA_CMD% org.wso2.micro.gateway.tools.Main "%~1" "%~2" %BAL_ARGS%
 
     EXIT /B %ERRORLEVEL%
 
@@ -225,29 +219,6 @@ REM We need to issolate the jar file path and wrap it with quotes
         SET BAL_ARGS=%BAL_ARGS% %first%
     )
     GOTO :buildBalArgs
-
-REM Find metrics is enabled or not via cmd args
-:isMetricsEnabled
-    SET first=%~1
-    IF "%first%"=="" EXIT /B 0
-    SET keyFound=F
-    IF "%first%"=="--b7a.observability.enabled" (
-        SET keyFound=T
-    ) ELSE "%first%"=="--b7a.observability.metrics.enabled" (
-        SET keyFound=T
-    )
-
-    IF "%keyFound%"=="T" (
-        IF "%~2"=="true" SET IS_METRICS_ENABLED=T
-        EXIT /B 0
-    )
-    IF "%first:~0,2%"=="--" (
-        SHIFT
-        SHIFT
-    ) ELSE (
-        SHIFT
-    )
-    GOTO :isMetricsEnabled
 
 REM add the system variable containing log4j properties file
 :setLog4jProperties

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -26,7 +26,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>test-integration</artifactId>
-    <name>Micro-GW - Test Integration</name>
+    <name>Micro Gateway - Test Integration</name>
 
 
     <dependencies>


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
Startup tool lib was only reading the `jmx_port` config from the config file. When config is provided as program arg or env variable it was not picked up.
This fix will enable looking up for both program args and env vars for the configuration. This is implemented in the tool lib to make logic generic for both *nix and windows platforms.
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1201

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
MacOS

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
