### PR TITLE
Fix replacing '\' in truststore path in windows.

### DIFF
--- a/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/globalthrottle/databridge/agent/conf/AgentConfiguration.java
+++ b/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/globalthrottle/databridge/agent/conf/AgentConfiguration.java
@@ -226,7 +226,8 @@ public class AgentConfiguration {
             String placeHolder = placeHolderMatcher.group(0);
             //to remove additional symbols
             String systemPropertyKey = placeHolder.substring(2, placeHolder.length() - 1);
-            return placeHolderMatcher.replaceFirst(System.getProperty(systemPropertyKey));
+            String pathReplacement = Matcher.quoteReplacement(System.getProperty(systemPropertyKey));
+            return placeHolderMatcher.replaceFirst(pathReplacement);
         }
         return mgwTrustStorePath;
     }


### PR DESCRIPTION
### Purpose
In windows, in the truststore path, the '\' character is replaced. 

`C:\User\Menaka\wso2-mgw-3.2.0\bin => C:UserMenakawso2-mgw-3.2.0`

This has led to SSL connection issues and affected the distributed throttling scenarios. 
This PR fixes this issue.  

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/1358

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
