### PR TITLE
Fix JWT revocation not working with APIM 3.1.0

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/handler_providers/jwt_auth_provider.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/handler_providers/jwt_auth_provider.bal
@@ -80,7 +80,7 @@ public type JwtAuthProvider object {
                 setErrorMessageToInvocationContext(API_AUTH_INVALID_CREDENTIALS);
                 return handleVar;
             }
-            boolean isBlacklisted = false;
+            boolean isRevoked = false;
             string? jti = "";
 
             runtime:AuthenticationContext? authContext = invocationContext?.authenticationContext;
@@ -105,17 +105,17 @@ public type JwtAuthProvider object {
                             if (status is boolean) {
                                 if (status) {
                                     printDebug(KEY_JWT_AUTH_PROVIDER, "JTI token found in the invalid token map.");
-                                    isBlacklisted = true;
+                                    isRevoked = true;
                                 } else {
                                     printDebug(KEY_JWT_AUTH_PROVIDER, "JTI token not found in the invalid token map.");
-                                    isBlacklisted = false;
+                                    isRevoked = false;
                                 }
                             } else {
                                 printDebug(KEY_JWT_AUTH_PROVIDER, "JTI token not found in the invalid token map.");
-                                isBlacklisted = false;
+                                isRevoked = false;
                             }
-                            if (isBlacklisted) {
-                                printDebug(KEY_JWT_AUTH_PROVIDER, "JWT Authentication Handler value for, is token black listed: " + isBlacklisted.toString());
+                            if (isRevoked) {
+                                printDebug(KEY_JWT_AUTH_PROVIDER, "JWT Authentication Handler value for, is token black listed: " + isRevoked.toString());
                                 printDebug(KEY_JWT_AUTH_PROVIDER, "JWT Token is revoked");
                                 setErrorMessageToInvocationContext(API_AUTH_INVALID_CREDENTIALS);
                                 return false;

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/revocation/revoked_jwt_retriever_task.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/revocation/revoked_jwt_retriever_task.bal
@@ -86,9 +86,17 @@ service revokedJwtRetrievalService = service {
                 printDebug(REVOKED_JWT_RETIEVAL_TASK, "Revoked token list recieved: " + revokedJwts.toJsonString());
                 if (revokedJwts is json[]) {
                     foreach var revokedJwt in revokedJwts {
-                        string signature = revokedJwt.jwt_signature.toString();
-                        string expiryTime = revokedJwt.expiry_time.toString();
-                        revokedMap[signature] = expiryTime;
+                        json|error signature = revokedJwt.jwt_signature;
+                        // jwt_signature is jwtSignature in APIM 3.1.0
+                        if (signature is error) {
+                            signature = revokedJwt.jwtSignature;
+                        }
+                        json|error expiryTime = revokedJwt.expiry_time;
+                        // expiry_time is expiryTime in APIM 3.1.0
+                        if (expiryTime is error) {
+                            expiryTime = revokedJwt.expiryTime;
+                        }
+                        revokedMap[signature.toString()] = expiryTime.toString();
                     }
                     if (revokedMap.length() > 0) {
                         var status = addToRevokedTokenMap(revokedMap);

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/revocation/revoked_token_map.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/revocation/revoked_token_map.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/stringutils;
 
 map<string> revokedTokenMap = {};
 
@@ -22,7 +23,13 @@ public function getRevokedTokenMap() returns map<string> {
 
 public function addToRevokedTokenMap(map<string> revokedTokens) returns (boolean | ()) {
     foreach var [revokedTokenKey, revokedTokenValue] in revokedTokens.entries() {
-        revokedTokenMap[<string>revokedTokenKey] = <@untainted>revokedTokenValue;
+        string tokenKey = <string>revokedTokenKey;
+        // Support for APIM 3.1.0 jwt revocation scenario.
+        string[] jwtComponents = stringutils:split(tokenKey, "\\.");
+        if (jwtComponents.length() == 3) {
+            tokenKey = jwtComponents[2];
+        }
+        revokedTokenMap[tokenKey] = <@untainted>revokedTokenValue;
     }
     return true;
 }

--- a/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/globalthrottle/databridge/agent/conf/AgentConfiguration.java
+++ b/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/globalthrottle/databridge/agent/conf/AgentConfiguration.java
@@ -226,7 +226,9 @@ public class AgentConfiguration {
             String placeHolder = placeHolderMatcher.group(0);
             //to remove additional symbols
             String systemPropertyKey = placeHolder.substring(2, placeHolder.length() - 1);
-            return placeHolderMatcher.replaceFirst(System.getProperty(systemPropertyKey));
+            //To support windows path (replaces \ with \\ internally)
+            String replacement = Matcher.quoteReplacement(System.getProperty(systemPropertyKey));
+            return placeHolderMatcher.replaceFirst(replacement);
         }
         return mgwTrustStorePath;
     }

--- a/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/globalthrottle/databridge/agent/conf/AgentConfiguration.java
+++ b/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/globalthrottle/databridge/agent/conf/AgentConfiguration.java
@@ -226,9 +226,7 @@ public class AgentConfiguration {
             String placeHolder = placeHolderMatcher.group(0);
             //to remove additional symbols
             String systemPropertyKey = placeHolder.substring(2, placeHolder.length() - 1);
-            //To support windows path (replaces \ with \\ internally)
-            String replacement = Matcher.quoteReplacement(System.getProperty(systemPropertyKey));
-            return placeHolderMatcher.replaceFirst(replacement);
+            return placeHolderMatcher.replaceFirst(System.getProperty(systemPropertyKey));
         }
         return mgwTrustStorePath;
     }


### PR DESCRIPTION
### Purpose
JWT revocation does not work with APIM 3.1.0 due to the below reasons.

- Payload parameters are different
- JMS payloads are different

This PR fixes this issue and enables to use JWT revocation with APIM 3.1.0 and MGW 3.2.0

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/1364

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
