### PR TITLE
Fix JWT revocation not working with APIM 3.1.0

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/ImportCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/ImportCmd.java
@@ -280,7 +280,7 @@ public class ImportCmd implements LauncherCmd {
             CmdUtils.saveSwaggerDefinitionForMultipleAPIs(projectName, apis,
                     !restVersion.startsWith(CliConstants.REST_API_V1_PREFIX));
         } catch (Exception e) {
-            throw new CLIInternalException("Exception occurred during codeGeneration process: " + e.getMessage());
+            throw new CLIInternalException("Exception occurred during codeGeneration process", e);
         }
         //todo: check if the files has been changed using hash utils
 

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/ImportCmd.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/cmd/ImportCmd.java
@@ -280,7 +280,7 @@ public class ImportCmd implements LauncherCmd {
             CmdUtils.saveSwaggerDefinitionForMultipleAPIs(projectName, apis,
                     !restVersion.startsWith(CliConstants.REST_API_V1_PREFIX));
         } catch (Exception e) {
-            throw new CLIInternalException("Exception occurred during codeGeneration process");
+            throw new CLIInternalException("Exception occurred during codeGeneration process: " + e.getMessage());
         }
         //todo: check if the files has been changed using hash utils
 

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/apim/pilot_utils.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/apim/pilot_utils.bal
@@ -156,7 +156,7 @@ function validateSubscriptionFromDataStores(string token, string consumerKey, st
             setErrorMessageToInvocationContext(API_AUTH_FORBIDDEN);
         }
     } else {
-        printDebug(KEY_PILOT_UTIL, "API envent hub is disabled. Can not fetch subscription data.");
+        printDebug(KEY_PILOT_UTIL, "API Event hub is disabled. Can not fetch subscription data.");
     }
     return [authenticationContext,isAllowed];
 }

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/handler_providers/jwt_auth_provider.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/handler_providers/jwt_auth_provider.bal
@@ -77,7 +77,7 @@ public type JwtAuthProvider object {
                 setErrorMessageToInvocationContext(API_AUTH_INVALID_CREDENTIALS);
                 return handleVar;
             }
-            boolean isBlacklisted = false;
+            boolean isRevoked = false;
             string? jti = "";
 
             runtime:AuthenticationContext? authContext = invocationContext?.authenticationContext;
@@ -102,17 +102,17 @@ public type JwtAuthProvider object {
                             if (status is boolean) {
                                 if (status) {
                                     printDebug(KEY_JWT_AUTH_PROVIDER, "JTI token found in the invalid token map.");
-                                    isBlacklisted = true;
+                                    isRevoked = true;
                                 } else {
                                     printDebug(KEY_JWT_AUTH_PROVIDER, "JTI token not found in the invalid token map.");
-                                    isBlacklisted = false;
+                                    isRevoked = false;
                                 }
                             } else {
                                 printDebug(KEY_JWT_AUTH_PROVIDER, "JTI token not found in the invalid token map.");
-                                isBlacklisted = false;
+                                isRevoked = false;
                             }
-                            if (isBlacklisted) {
-                                printDebug(KEY_JWT_AUTH_PROVIDER, "JWT Authentication Handler value for, is token black listed: " + isBlacklisted.toString());
+                            if (isRevoked) {
+                                printDebug(KEY_JWT_AUTH_PROVIDER, "JWT Authentication Handler value for, is token black listed: " + isRevoked.toString());
                                 printDebug(KEY_JWT_AUTH_PROVIDER, "JWT Token is revoked");
                                 setErrorMessageToInvocationContext(API_AUTH_INVALID_CREDENTIALS);
                                 return false;

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/handler_providers/jwt_auth_provider.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/handler_providers/jwt_auth_provider.bal
@@ -98,10 +98,16 @@ public type JwtAuthProvider object {
                         if (jti is string) {
                             printDebug(KEY_JWT_AUTH_PROVIDER, "jti claim found in the jwt");
                             printDebug(KEY_JWT_AUTH_PROVIDER, "Checking for the JTI in the gateway invalid revoked token map.");
-                            var status = retrieveFromRevokedTokenMap(jti);
-                            if (status is boolean) {
-                                if (status) {
+                            var statusJTI = retrieveFromRevokedTokenMap(jti);
+                            // To support APIM 3.1.0, check the signature in the revoked jwt map.
+                            printDebug(KEY_JWT_AUTH_PROVIDER, "Checking for the Signature in the gateway invalid revoked token map.");
+                            var statusSig = retrieveFromRevokedTokenMap(stringutils:split(credential, "\\.")[2]);
+                            if (statusJTI is boolean && statusSig is boolean) {
+                                if (statusJTI) {
                                     printDebug(KEY_JWT_AUTH_PROVIDER, "JTI token found in the invalid token map.");
+                                    isRevoked = true;
+                                } else if (statusSig) {
+                                    printDebug(KEY_JWT_AUTH_PROVIDER, "JWT Signature found in the invalid token map.");
                                     isRevoked = true;
                                 } else {
                                     printDebug(KEY_JWT_AUTH_PROVIDER, "JTI token not found in the invalid token map.");
@@ -112,7 +118,7 @@ public type JwtAuthProvider object {
                                 isRevoked = false;
                             }
                             if (isRevoked) {
-                                printDebug(KEY_JWT_AUTH_PROVIDER, "JWT Authentication Handler value for, is token black listed: " + isRevoked.toString());
+                                printDebug(KEY_JWT_AUTH_PROVIDER, "JWT Authentication Handler value for, is token revoked : " + isRevoked.toString());
                                 printDebug(KEY_JWT_AUTH_PROVIDER, "JWT Token is revoked");
                                 setErrorMessageToInvocationContext(API_AUTH_INVALID_CREDENTIALS);
                                 return false;

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/handler_providers/jwt_auth_provider.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/handler_providers/jwt_auth_provider.bal
@@ -103,19 +103,13 @@ public type JwtAuthProvider object {
                             printDebug(KEY_JWT_AUTH_PROVIDER, "Checking for the Signature in the gateway invalid revoked token map.");
                             var statusSig = retrieveFromRevokedTokenMap(stringutils:split(credential, "\\.")[2]);
                             if (statusJTI is boolean && statusSig is boolean) {
-                                if (statusJTI) {
-                                    printDebug(KEY_JWT_AUTH_PROVIDER, "JTI token found in the invalid token map.");
-                                    isRevoked = true;
-                                } else if (statusSig) {
-                                    printDebug(KEY_JWT_AUTH_PROVIDER, "JWT Signature found in the invalid token map.");
+                                if (statusJTI || statusSig) {
+                                    printDebug(KEY_JWT_AUTH_PROVIDER, "JTI or Signature found in the invalid token map.");
                                     isRevoked = true;
                                 } else {
-                                    printDebug(KEY_JWT_AUTH_PROVIDER, "JTI token not found in the invalid token map.");
+                                    printDebug(KEY_JWT_AUTH_PROVIDER, "JTI or Signature not found in the invalid token map.");
                                     isRevoked = false;
                                 }
-                            } else {
-                                printDebug(KEY_JWT_AUTH_PROVIDER, "JTI token not found in the invalid token map.");
-                                isRevoked = false;
                             }
                             if (isRevoked) {
                                 printDebug(KEY_JWT_AUTH_PROVIDER, "JWT Authentication Handler value for, is token revoked : " + isRevoked.toString());

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/revocation/revoked_jwt_retriever_task.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/revocation/revoked_jwt_retriever_task.bal
@@ -86,9 +86,17 @@ service revokedJwtRetrievalService = service {
                 printDebug(REVOKED_JWT_RETIEVAL_TASK, "Revoked token list recieved: " + revokedJwts.toJsonString());
                 if (revokedJwts is json[]) {
                     foreach var revokedJwt in revokedJwts {
-                        string signature = revokedJwt.jwt_signature.toString();
-                        string expiryTime = revokedJwt.expiry_time.toString();
-                        revokedMap[signature] = expiryTime;
+                        json|error signature = revokedJwt.jwt_signature;
+                        // jwt_signature is jwtSignature in APIM 3.1.0
+                        if (signature is error) {
+                            signature = revokedJwt.jwtSignature;
+                        }
+                        json|error expiryTime = revokedJwt.expiry_time;
+                        // expiry_time is expiryTime in APIM 3.1.0
+                        if (expiryTime is error) {
+                            expiryTime = revokedJwt.expiryTime;
+                        }
+                        revokedMap[signature.toString()] = expiryTime.toString();
                     }
                     if (revokedMap.length() > 0) {
                         var status = addToRevokedTokenMap(revokedMap);

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/revocation/revoked_token_map.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/revocation/revoked_token_map.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/stringutils;
 
 map<string> revokedTokenMap = {};
 
@@ -22,7 +23,13 @@ public function getRevokedTokenMap() returns map<string> {
 
 public function addToRevokedTokenMap(map<string> revokedTokens) returns (boolean | ()) {
     foreach var [revokedTokenKey, revokedTokenValue] in revokedTokens.entries() {
-        revokedTokenMap[<string>revokedTokenKey] = <@untainted>revokedTokenValue;
+        string tokenKey = <string>revokedTokenKey;
+        // Support for APIM 3.1.0 jwt revocation scenario.
+        string[] jwtComponents = stringutils:split(tokenKey, "\\.");
+        if (jwtComponents.length() == 3) {
+            tokenKey = jwtComponents[2];
+        }
+        revokedTokenMap[tokenKey] = <@untainted>revokedTokenValue;
     }
     return true;
 }

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/analytics_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/analytics_util.bal
@@ -186,9 +186,7 @@ function initializegRPCAnalytics() {
     gRPCReconnectTime = <int>getConfigIntValue(GRPC_ANALYTICS, GRPC_RETRY_TIME_MILLISECONDS, DEFAULT_GRPC_RECONNECT_TIME_IN_MILLES);
     printDebug(KEY_GRPC_ANALYTICS, "gRPC endpoint URL : " + endpointURL);
     printDebug(KEY_GRPC_ANALYTICS, "gRPC keyStore file : " + <string>getConfigValue(LISTENER_CONF_INSTANCE_ID, KEY_STORE_PATH, DEFAULT_KEY_STORE_PATH));
-    printDebug(KEY_GRPC_ANALYTICS, "gRPC keyStore password  : " + <string>getConfigValue(LISTENER_CONF_INSTANCE_ID, KEY_STORE_PASSWORD, DEFAULT_KEY_STORE_PASSWORD));
     printDebug(KEY_GRPC_ANALYTICS, "gRPC trustStore file : " + <string>getConfigValue(LISTENER_CONF_INSTANCE_ID, TRUST_STORE_PATH, DEFAULT_TRUST_STORE_PATH));
-    printDebug(KEY_GRPC_ANALYTICS, "gRPC tustStore password  : " + <string>getConfigValue(LISTENER_CONF_INSTANCE_ID, TRUST_STORE_PASSWORD, DEFAULT_TRUST_STORE_PASSWORD));
     printDebug(KEY_GRPC_ANALYTICS, "gRPC retry time  : " + gRPCReconnectTime.toString());
 
     if (isGrpcAnalyticsEnabled) {

--- a/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/callhome/Callhome.java
+++ b/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/callhome/Callhome.java
@@ -23,6 +23,8 @@ import org.wso2.callhome.utils.CallHomeInfo;
 import org.wso2.callhome.utils.Util;
 import org.wso2.micro.gateway.core.Constants;
 
+import java.util.regex.Matcher;
+
 /**
  * Invoke call home.
  */
@@ -51,7 +53,7 @@ public class Callhome {
      * @return runtime home location
      */
     private static String getRuntimeHome() {
-        return System.getProperty(Constants.RUNTIME_HOME_PATH);
+        return Matcher.quoteReplacement(System.getProperty(Constants.RUNTIME_HOME_PATH));
     }
 
     /**
@@ -61,8 +63,7 @@ public class Callhome {
      */
     public static String getTrustStoreLocation(String fullpath) {
         String homePathConst = "\\$\\{mgw-runtime.home}";
-        String homePath = System.getProperty(Constants.RUNTIME_HOME_PATH);
-        String correctPath = fullpath.replaceAll(homePathConst, homePath);
-        return correctPath;
+        String homePath = Matcher.quoteReplacement(System.getProperty(Constants.RUNTIME_HOME_PATH));
+        return fullpath.replaceAll(homePathConst, homePath);
     }
 }

--- a/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/jwt/generator/MGWJWTGeneratorInvoker.java
+++ b/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/jwt/generator/MGWJWTGeneratorInvoker.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
 
 /**
  * Class to dynamically invoke the jwt generators defined.
@@ -186,7 +187,7 @@ public class MGWJWTGeneratorInvoker {
      */
     public static String getKeyStorePath(String fullPath) {
         String homePathConst = "\\$\\{mgw-runtime.home}";
-        String homePath = System.getProperty(Constants.RUNTIME_HOME_PATH);
+        String homePath = Matcher.quoteReplacement(System.getProperty(Constants.RUNTIME_HOME_PATH));
         return fullPath.replaceAll(homePathConst, homePath);
     }
 }

--- a/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/mutualssl/LoadKeyStore.java
+++ b/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/mutualssl/LoadKeyStore.java
@@ -26,6 +26,7 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
+import java.util.regex.Matcher;
 
 /**
  * This class is for load the keystore.
@@ -52,7 +53,7 @@ public class LoadKeyStore {
      */
     public static String getKeyStorePath(String fullPath) {
         String homePathConst = "\\$\\{mgw-runtime.home}";
-        String homePath = System.getProperty(Constants.RUNTIME_HOME_PATH);
+        String homePath = Matcher.quoteReplacement(System.getProperty(Constants.RUNTIME_HOME_PATH));
         return fullPath.replaceAll(homePathConst, homePath);
     }
 }


### PR DESCRIPTION
### Purpose
This PR fixes multiple issues.

1. JWT revocation does not work with APIM 3.1.0 due to the below reasons.

- Payload parameters are different
- JMS payloads are different
This PR fixes this issue and enables to use JWT revocation with APIM 3.1.0 and MGW 3.2.0

2. JWT generation fails due to path issues in Windows.


### Issues
Fixes #1364
Fixes #1369

### Automation tests
Unit tests added: Yes/No
Integration tests added: Yes/No

### Tested environments
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
