### PR TITLE
Add missing ssl protocol configuration to the api gateway listener configuration.

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/listeners/api_gateway_secure_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/listeners/api_gateway_secure_listener.bal
@@ -67,6 +67,7 @@ function initiateGatewaySecureConfigurations(http:ListenerConfiguration config) 
     http:ListenerSecureSocket secureSocket = {
         trustStore: trustStore,
         keyStore: keyStore,
+        protocol: protocol,
         sslVerifyClient: sslVerifyClient,
         ciphers: ciphers
     };

--- a/distribution/resources/conf/micro-gw.conf
+++ b/distribution/resources/conf/micro-gw.conf
@@ -61,3 +61,7 @@
 
 [security]
   validateSubscriptions = false
+
+# Enable http2 for the microgateway listeners.
+[http2]
+  enable = true


### PR DESCRIPTION
### Purpose
Add missing ssl protocol configuration (which includes the specific tls version) to the api gateway listener.

### Issues
Partially provide fix for #1302 . In addition to this fix, it is required to upgrade the ballerina version to 1.2.7 as well.

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
MacOS Mojave 
Browser : Chrome
---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
