### PR TITLE
Set the ballerina thread pool size to 100

### DIFF
--- a/distribution/resources/bin/gateway
+++ b/distribution/resources/bin/gateway
@@ -167,6 +167,13 @@ if [ -e "$GW_HOME/bin/gateway.pid" ]; then
   PID=`cat "$GW_HOME"/bin/gateway.pid`
 fi
 
+# set the ballerina thread pool size
+if [ -z "${BALLERINA_MAX_POOL_SIZE+set}" ]; then
+  export BALLERINA_MAX_POOL_SIZE=100
+else
+  echo "Info: Ballerina thread pool size is set to ${BALLERINA_MAX_POOL_SIZE}"
+fi
+
 #To run the Java classes required for the identification of observability
 java_cmd_tools () {
   METRIC_CLASSPATH=""

--- a/distribution/resources/bin/gateway
+++ b/distribution/resources/bin/gateway
@@ -168,7 +168,7 @@ if [ -e "$GW_HOME/bin/gateway.pid" ]; then
 fi
 
 # set the ballerina thread pool size
-if [ -z "${BALLERINA_MAX_POOL_SIZE+set}" ]; then
+if [ -z "$BALLERINA_MAX_POOL_SIZE" ]; then
   export BALLERINA_MAX_POOL_SIZE=100
 else
   echo "Info: Ballerina thread pool size is set to ${BALLERINA_MAX_POOL_SIZE}"

--- a/distribution/resources/bin/gateway.bat
+++ b/distribution/resources/bin/gateway.bat
@@ -74,6 +74,8 @@ IF %ERRORLEVEL% NEQ 0 GOTO END
 CALL :validateExecutable %*
 IF %ERRORLEVEL% NEQ 0 GOTO END
 
+CALL :setBallerinaWorkerPoolSize
+
 SET EXEC_FILE=%~1
 CALL :buildBalArgs %*
 
@@ -202,6 +204,15 @@ REM Check JAVA availability
     IF NOT EXIST "%JAVA_HOME%\bin\java.exe" (
         ECHO ERROR: JAVA_HOME is invalid.
         EXIT /B 1
+    )
+    EXIT /B 0
+
+REM set the ballerina thread pool size
+:setBallerinaWorkerPoolSize
+    IF "%BALLERINA_MAX_POOL_SIZE%"=="" (
+        SET BALLERINA_MAX_POOL_SIZE=100
+    ) else (
+        ECHO Info: Ballerina thread pool size is set to %BALLERINA_MAX_POOL_SIZE%
     )
     EXIT /B 0
 


### PR DESCRIPTION
### Purpose
Set the ballerina thread pool size to 100 in order to enhance performance. In addition, users can override this configuration by providing the environmental variable.
`export BALLERINA_MAX_POOL_SIZE=50`

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
MacOS Mojave

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
