### PR TITLE
Rename get endpoint method

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/revocation/revoked_jwt_retriever_task.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/revocation/revoked_jwt_retriever_task.bal
@@ -20,7 +20,7 @@ import ballerina/task;
 boolean enabledPersistentMessage = getConfigBooleanValue(PERSISTENT_MESSAGE_INSTANCE_ID,
         PERSISTENT_MESSAGE_ENABLED, DEFAULT_TOKEN_REVOCATION_ENABLED);
 const int revokedJWTRetrievalRetries = 15;
-string revokedJwtServiceURL = getRerokedJwtPersistantEndpoint();
+string revokedJwtServiceURL = getRevokedJwtPersistantEndpoint();
 int jwtRetrievalRetriesCount = 0;
 const int retryIntervalInMillis = 15000;
 
@@ -44,7 +44,7 @@ task:Scheduler revokedJwtRetievalTimer = new ({
     initialDelayInMillis: 2000
 });
 
-function getRerokedJwtPersistantEndpoint() returns string {
+function getRevokedJwtPersistantEndpoint() returns string {
     string revokedJwtServiceURL = getConfigValue(PERSISTENT_MESSAGE_INSTANCE_ID, PERSISTENT_MESSAGE_HOSTNAME, "");
     if (revokedJwtServiceURL == "") {
         revokedJwtServiceURL = getConfigValue(PERSISTENT_MESSAGE_INSTANCE_ID, PERSISTENT_MESSAGE_ENDPOINT,


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
renamed incorrectly named `getRevokedJwtPersistantEndpoint` method
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Task

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
