### PR TITLE
Version Bump : envoy and go-contol-plane

### DIFF
--- a/docker/with-external-build/docker-compose.yaml
+++ b/docker/with-external-build/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   envoy:
-    image: envoyproxy/envoy:v1.14.1
+    image: envoyproxy/envoy:v1.16.0
     volumes:
       - ./../../envoy.yaml:/etc/envoy/envoy.yaml
 #    expose:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/envoyproxy/go-control-plane v0.9.5
+	github.com/envoyproxy/go-control-plane v0.9.7
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/getkin/kin-openapi v0.8.0
 	github.com/ghodss/yaml v1.0.0

--- a/internal/pkg/mgw/mgw.go
+++ b/internal/pkg/mgw/mgw.go
@@ -138,7 +138,7 @@ func updateEnvoy(location string) {
 
 	atomic.AddInt32(&version, 1)
 	logger.LoggerMgw.Infof(">>>>>>>>>>>>>>>>>>> creating snapshot Version " + fmt.Sprint(version))
-	snap := cachev3.NewSnapshot(fmt.Sprint(version), endpoints, clusters, routes, listeners, nil)
+	snap := cachev3.NewSnapshot(fmt.Sprint(version), endpoints, clusters, routes, listeners, nil, nil)
 	snap.Consistent()
 
 	err := cache.SetSnapshot(nodeId, snap)

--- a/internal/pkg/oasparser/envoyCodegen/httpFilters.go
+++ b/internal/pkg/oasparser/envoyCodegen/httpFilters.go
@@ -21,6 +21,7 @@ import (
 	ext_authv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
 	routerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	hcmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
 	"github.com/golang/protobuf/ptypes"
@@ -58,9 +59,6 @@ func getRouterHttpFilter() hcmv3.HttpFilter {
 		SuppressEnvoyHeaders:     false,
 		StrictCheckHeaders:       nil,
 		RespectExpectedRqTimeout: false,
-		XXX_NoUnkeyedLiteral:     struct{}{},
-		XXX_unrecognized:         nil,
-		XXX_sizecache:            0,
 	}
 
 	routeFilterTypedConf, err := ptypes.MarshalAny(&routeFilterConf)
@@ -69,11 +67,8 @@ func getRouterHttpFilter() hcmv3.HttpFilter {
 	}
 
 	filter := hcmv3.HttpFilter{
-		Name:                 wellknown.Router,
-		ConfigType:           &hcmv3.HttpFilter_TypedConfig{TypedConfig: routeFilterTypedConf},
-		XXX_NoUnkeyedLiteral: struct{}{},
-		XXX_unrecognized:     nil,
-		XXX_sizecache:        0,
+		Name:       wellknown.Router,
+		ConfigType: &hcmv3.HttpFilter_TypedConfig{TypedConfig: routeFilterTypedConf},
 	}
 
 	return filter
@@ -98,6 +93,11 @@ func getExtAauthzHttpFilter() hcmv3.HttpFilter {
 					},
 				},
 			},
+		},
+		//TODO: (VirajSalaka) Provide an error message or log (in envoy) to identify this network failure.
+		// When there is a connection issue or server failure, 500 status code is set.
+		StatusOnError: &typev3.HttpStatus{
+			Code: typev3.StatusCode_InternalServerError,
 		},
 	}
 	ext, err2 := ptypes.MarshalAny(extAuthzConfig)

--- a/internal/pkg/oasparser/envoyCodegen/listener.go
+++ b/internal/pkg/oasparser/envoyCodegen/listener.go
@@ -17,17 +17,17 @@
 package envoyCodegen
 
 import (
+	access_logv3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_filter_accesslog_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
-	access_logv3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	hcmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
-	logger "github.com/wso2/micro-gw/internal/loggers"
-	"github.com/wso2/micro-gw/configs"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/wso2/micro-gw/configs"
+	logger "github.com/wso2/micro-gw/internal/loggers"
 )
 
 /**
@@ -118,7 +118,7 @@ func createConectionManagerFilter(vHost routev3.VirtualHost, routeConfigName str
 			},
 		},
 		HttpFilters: httpFilters,
-		AccessLog: []*access_logv3.AccessLog{&accessLogs},
+		AccessLog:   []*access_logv3.AccessLog{&accessLogs},
 	}
 	return manager
 }
@@ -170,20 +170,20 @@ func createAddress(remoteHost string, port uint32) corev3.Address {
  */
 func getAccessLogConfigs() access_logv3.AccessLog {
 	var logFormat *envoy_config_filter_accesslog_v3.FileAccessLog_Format
-	logpath := "/tmp/envoy.access.log"   //default access log path
+	logpath := "/tmp/envoy.access.log" //default access log path
 
 	logConf, errReadConfig := configs.ReadLogConfigs()
 	if errReadConfig != nil {
 		logger.LoggerOasparser.Error("Error loading configuration. ", errReadConfig)
 	} else {
 		logFormat = &envoy_config_filter_accesslog_v3.FileAccessLog_Format{
-			Format:  logConf.AccessLogs.Format,
+			Format: logConf.AccessLogs.Format,
 		}
 		logpath = logConf.AccessLogs.LogFile
 	}
 
 	accessLogConf := &envoy_config_filter_accesslog_v3.FileAccessLog{
-		Path:   logpath,
+		Path:            logpath,
 		AccessLogFormat: logFormat,
 	}
 
@@ -193,14 +193,11 @@ func getAccessLogConfigs() access_logv3.AccessLog {
 	}
 
 	access_logs := access_logv3.AccessLog{
-		Name:                 "envoy.access_loggers.file",
-		Filter:               nil,
-		ConfigType:           &access_logv3.AccessLog_TypedConfig{
+		Name:   "envoy.access_loggers.file",
+		Filter: nil,
+		ConfigType: &access_logv3.AccessLog_TypedConfig{
 			TypedConfig: accessLogTypedConf,
 		},
-		XXX_NoUnkeyedLiteral: struct{}{},
-		XXX_unrecognized:     nil,
-		XXX_sizecache:        0,
 	}
 
 	return access_logs


### PR DESCRIPTION
 # Purpose
- Upgrade envoy version 1.14.1 -> 1.6.0
- Upgrade go-control-plane version 0.9.5 -> 0.9.7
- When the external auth service connection fails, return the error code 500 (instead of 403)

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Docker 

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
