### PR TITLE
Make server header configurable and issues in 3rd party jwts

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
@@ -25,6 +25,7 @@ public const string QUERY = "query";
 public const string API_KEY_IN = "in";
 public const string API_KEY_NAME = "name";
 public const string AUTH_HEADER = "Authorization";
+public const string SERVER_HEADER_NAME = "server";
 public const string AUTH_SCHEME_BASIC = "Basic";
 public const string AUTH_SCHEME_BEARER = "Bearer";
 public const string AUTH_SCHEME_BASIC_LOWERCASE = "basic";
@@ -597,6 +598,7 @@ public const string JWT_GENERATOR_TOKEN_CACHE_EVICTION_FACTOR = "tokenCacheEvict
 // server configurations
 public const string SERVER_CONF_ID = "server";
 public const string SERVER_TIMESTAMP_SKEW = "timestampSkew";
+public const string SERVER_HEADER = "header";
 
 public const string APIM_CREDENTIALS_INSTANCE_ID = "apim.credentials";
 public const string APIM_CREDENTIALS_USERNAME = "username";

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/micro_gw_conf_defaults.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/micro_gw_conf_defaults.bal
@@ -201,3 +201,4 @@ public const string DEFAULT_APIM_CREDENTIALS_USERNAME = "admin";
 public const string DEFAULT_APIM_CREDENTIALS_PASSWORD = "admin";
 
 public const int DEFAULT_SERVER_TIMESTAMP_SKEW = -1;
+public const string DEFAULT_SERVER_HEADER = "ballerina";

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/listeners/api_gateway_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/listeners/api_gateway_listener.bal
@@ -51,6 +51,7 @@ public type APIGatewayListener object {
             self.listenerPort = getConfigIntValue(LISTENER_CONF_INSTANCE_ID, LISTENER_CONF_HTTPS_PORT, port);
             self.listenerType = "HTTPS";
         }
+        config.server = getConfigValue(SERVER_CONF_ID, SERVER_HEADER, DEFAULT_SERVER_HEADER);
         printDebug(KEY_GW_LISTNER, "Initialized gateway configurations for port:" + self.listenerPort.toString());
         self.httpListener = new (self.listenerPort, config = config);
         printDebug(KEY_GW_LISTNER, "Successfully initialized APIGatewayListener for port:" + self.listenerPort.toString());

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/jwt_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/jwt_util.bal
@@ -55,6 +55,13 @@ public function isAllowedKey(string token, jwt:JwtPayload payload, boolean isVal
         consumerKey = audiencePayload[0];
     }
     printDebug(JWT_UTIL,"Consumer key resolved : " + consumerKey);
+
+    //set key type
+    if (customClaims is map<json> && customClaims.hasKey(KEY_TYPE)) {
+        json keyType = customClaims.get(KEY_TYPE);
+        authenticationContext.keyType = keyType.toString();
+    }
+    invocationContext.attributes[KEY_TYPE_ATTR] = authenticationContext.keyType;
     if (apiConfig is APIConfiguration && consumerKey != "") {
         string apiName = apiConfig.name;
         string apiVersion = apiConfig.apiVersion;

--- a/distribution/resources/conf/default-micro-gw.conf.template
+++ b/distribution/resources/conf/default-micro-gw.conf.template
@@ -480,6 +480,8 @@
 [server]
   # timestamp skew in milliseconds which added when checking the token validity period
   timestampSkew = 5000
+  # The value of the server header sent in the response by microgateway
+  header="ballerina"
 
 # Configurations for retrieving API and subscription data from API Manager.
 [apim.eventHub]


### PR DESCRIPTION
### Purpose
> Makes microgateway server header in the response configurable. But still the server header can not be removed.
> Fix issue of key type is not setting when third party jwts are used. When 3rd party jwts are used default key type should be `PRODUCTION`

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1415 
Fixes #1435 

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
