### PR TITLE
Fix inconsistency when updating APIM custom throttling policies

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/dtos/throttle_dtos.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/dtos/throttle_dtos.bal
@@ -149,3 +149,8 @@ type ConditionalThrottleInfo record {|
     boolean isJwtConditionsEnabled = false;
     http:Request request;
 |};
+
+public type KeyTemplate record {|
+    string value;
+    int timestamp = 0;
+|};

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/throttle_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/throttle_filter.bal
@@ -545,8 +545,8 @@ function checkCustomThrottlePolicies(http:Caller caller, http:Request request, h
     string apiTenant = tenantDomain;
     string appId = keyValidationDto.applicationId;
 
-    foreach string key in keyTemplateMap.keys() {
-        string modifiedKey = replaceAll(key, "\\$resourceKey", resourceLevelThrottleKey);
+    foreach KeyTemplate key in keyTemplateMap {
+        string modifiedKey = replaceAll(key.value, "\\$resourceKey", resourceLevelThrottleKey);
         modifiedKey = replaceAll(modifiedKey, "\\$userId", userId);
         modifiedKey = replaceAll(modifiedKey, "\\$apiContext", apiContext);
         if(apiVersion is string) {

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/services/throttle_event_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/services/throttle_event_listener.bal
@@ -170,7 +170,7 @@ function handleKeyTemplateMessage(jms:MapMessage message, string keyTemplateValu
         if (msgTime is int) {
             timestamp = <@untainted>msgTime;
         } else {
-            // This is an edge case where timestamp is not avail in the jms message. This can cause inconsistancies
+            // This is an edge case where timestamp is not available in the jms message. This can cause inconsistencies
             // when a policy is redeployed/updated from the APIM side. Re-adding policy from APIM is the workaround.
             timestamp = time:currentTime().time;
         }
@@ -249,14 +249,12 @@ function removeKeyTemplate(string template, int timestamp) returns KeyTemplate |
     if (!keyTemplateMap.hasKey(template)) {
         return ();
     }
-    int earlierTimestamp = keyTemplateMap.get(template).timestamp;
-
-    // When policy is redeployed add and remove jms messages can be received in outof order fashion.
-    // Validating the timestamp to avoid if the recieved msg order is `add -> remove`
-    if (earlierTimestamp >= timestamp) {
-        return ();
-    }
     lock {
+        // When policy is redeployed add and remove jms messages can be received in outof order fashion.
+        // Validating the timestamp to avoid if the recieved msg order is `add -> remove`
+        if (keyTemplateMap.get(template).timestamp >= timestamp) {
+            return ();
+        }
         return keyTemplateMap.remove(template);
     }
 }

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/throttler/key_template_retriever_task.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/throttler/key_template_retriever_task.bal
@@ -16,6 +16,7 @@
 
 import ballerina/http;
 import ballerina/task;
+import ballerina/time;
 
 const int keyTemplateRetrievalRetries = 15;
 string keyTemplateSrerviceURL = getConfigValue(THROTTLE_CONF_KEY_TEMPLATE_INSTANCE_ID, KM_SERVER_URL,
@@ -75,7 +76,8 @@ service keyTemplateRetrievalService = service {
                 if (keyTemplates is json[]) {
                     foreach var key in keyTemplates {
                         string keyTempalteValue = key.toString();
-                        addKeyTemplate(<@untainted>keyTempalteValue, 0);
+                        time:Time time = time:currentTime();
+                        addKeyTemplate(<@untainted>keyTempalteValue, time.time);
                     }
                 }
                 printDebug(KEY_TEMPLATE_RETIEVAL_TASK, "Key template map : " + keyTemplateMap.toString());

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/throttler/key_template_retriever_task.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/throttler/key_template_retriever_task.bal
@@ -75,7 +75,7 @@ service keyTemplateRetrievalService = service {
                 if (keyTemplates is json[]) {
                     foreach var key in keyTemplates {
                         string keyTempalteValue = key.toString();
-                        keyTemplateMap[keyTempalteValue] = <@untainted>keyTempalteValue;
+                        addKeyTemplate(<@untainted>keyTempalteValue, 0);
                     }
                 }
                 printDebug(KEY_TEMPLATE_RETIEVAL_TASK, "Key template map : " + keyTemplateMap.toString());


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
When keytemplate is updated (redeployed) in APIM order of the jms messages received by mgw is not guaranteed. If first msg is a 'add' and the next one is a 'remove', updated keyemplate is lost in mgw side. To resolve this we sync the msg order by looking at the jms msg timestamp.
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1433

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
