### PR TITLE
Change enforcer imgae to alpine base image

### DIFF
--- a/enforcer/src/main/resources/Dockerfile
+++ b/enforcer/src/main/resources/Dockerfile
@@ -15,7 +15,7 @@
 # -----------------------------------------------------------------------
 
 # TODO: (VirajSalaka) finalize jdk 11 image
-FROM adoptopenjdk:11.0.8_10-jre-hotspot-bionic
+FROM adoptopenjdk/openjdk11:jre-11.0.9_11.1-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" 
 
 ENV LANG=C.UTF-8
@@ -24,7 +24,7 @@ ARG MG_USER=wso2
 ARG MG_USER_ID=802
 ARG MG_USER_GROUP=wso2
 ARG MG_USER_GROUP_ID=802
-ARG MG_USER_HOME=/home/${MGW_USER}
+ARG MG_USER_HOME=/home/${MG_USER}
 ARG MG_VERSION=1.0-SNAPSHOT
 
 ENV VERSION=${MG_VERSION}
@@ -38,9 +38,9 @@ ARG MOTD="\n\
  Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
 
 RUN \
-    groupadd --system -g ${MG_USER_GROUP_ID} ${MG_USER_GROUP} \
-    && useradd --system --create-home --home-dir ${MG_USER_HOME} --no-log-init -g ${MG_USER_GROUP_ID} -u ${MG_USER_ID} ${MG_USER} \
-    && mkdir ${MG_USER_HOME}/lib && mkdir ${MG_USER_HOME}/mg/security \
+    addgroup -S -g ${MG_USER_GROUP_ID} ${MG_USER_GROUP} \
+    && adduser -S -u ${MG_USER_ID} -h ${MG_USER_HOME} -G ${MG_USER_GROUP} ${MG_USER} \
+    && mkdir ${MG_USER_HOME}/lib && mkdir -p ${MG_USER_HOME}/mg/security \
     && echo '[ ! -z "${TERM}" -a -r /etc/motd ] && cat /etc/motd' >> /etc/bash.bashrc; echo "${MOTD}" > /etc/motd
 
 WORKDIR ${MG_USER_HOME}


### PR DESCRIPTION
### Purpose
Change the enforce base image to alpine based open jre 11 image.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes Task

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
