### PR TITLE
fix java_args not being set during the startup of gateway batch script

### DIFF
--- a/distribution/resources/bin/gateway.bat
+++ b/distribution/resources/bin/gateway.bat
@@ -112,7 +112,7 @@ IF EXIST %CONF_OUT_FILE% DEL /Q /F %CONF_OUT_FILE%
     SET usage_path=%GW_HOME%\api-usage-data
     CALL SET USAGE_DATA_PATH=%%usage_path:\=%separator%%%
 
-    CALL :setJavaArgs %*
+    CALL :setupAndRun %*
 
     GOTO END
 

--- a/distribution/resources/bin/gateway.bat
+++ b/distribution/resources/bin/gateway.bat
@@ -232,7 +232,7 @@ REM add the system variable containing log4j properties file
     SET JAVA_ARGS=-Xms%JAVA_XMS_VALUE% -Xmx%JAVA_XMX_VALUE% -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath='%GW_HOME%\heap-dump.hprof'
     SET LOG4J_CONFIGURATION_FILE_LOCATION=%GW_HOME%\conf\log4j2.properties
     IF EXIST %LOG4J_CONFIGURATION_FILE_LOCATION% (
-        SET JAVA_ARGS=%JAVA_ARGS% -Dlog4j.configurationFile=%LOG4J_CONFIGURATION_FILE_LOCATION%
+        SET JAVA_ARGS=%JAVA_ARGS% '-Dlog4j.configurationFile=%LOG4J_CONFIGURATION_FILE_LOCATION%'
     ) ELSE (
         SET JAVA_ARGS=%JAVA_ARGS% '-Dlog4j.configurationFactory=org.wso2.micro.gateway.core.logging.MgwLog4j2ConfigurationFactory'
     )

--- a/distribution/resources/bin/gateway.bat
+++ b/distribution/resources/bin/gateway.bat
@@ -228,7 +228,7 @@ REM We need to issolate the jar file path and wrap it with quotes
     GOTO :buildBalArgs
 
 REM add the system variable containing log4j properties file
-:setJavaArgs
+:setupAndRun
     SET JAVA_ARGS=-Xms%JAVA_XMS_VALUE% -Xmx%JAVA_XMX_VALUE% -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath='%GW_HOME%\heap-dump.hprof'
     SET LOG4J_CONFIGURATION_FILE_LOCATION=%GW_HOME%\conf\log4j2.properties
     IF EXIST %LOG4J_CONFIGURATION_FILE_LOCATION% (


### PR DESCRIPTION
### Purpose
Addresses the issue where the JAVA_ARGS parameter is not properly set in the batch script. (gateway.bat). The reason is that when some environmental variable is set and executed within parentheses of the if/else block, the execution command does not get the environmental parameter. Hence the setting environmental variable and being called should be separated.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1502

### Automation tests
 - Unit tests added:No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, JDK version, etc... -->
Windows 10

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
