### PR TITLE
[Envoy-MGW]  Change failsafe plugin to surefire to run test cases in integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,5 +55,6 @@
         <io.netty.version>4.1.54.Final</io.netty.version>
         <org.testcontainers.version>1.15.0</org.testcontainers.version>
         <com.google.code.gson.version>2.3.1</com.google.code.gson.version>
+        <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
     </properties>
 </project>

--- a/test/test-integration/pom.xml
+++ b/test/test-integration/pom.xml
@@ -33,8 +33,9 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.0</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
                 <configuration>
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>

--- a/test/test-integration/src/test/java/org/wso2am/micro/gw/tests/apiDeploy/APiDeployTestCase.java
+++ b/test/test-integration/src/test/java/org/wso2am/micro/gw/tests/apiDeploy/APiDeployTestCase.java
@@ -46,7 +46,7 @@ public class APiDeployTestCase extends BaseTestCase {
     }
 
     @Test(description = "Test to check the api deployment is working")
-    public void invokeJWTHeaderSuccessTest() throws Exception {
+    public void apiDeployTest() throws Exception {
 
         //api yaml file should put to the resources/apis/openApis folder
         String apiZipfile = ApiProjectGenerator.createApictlProjZip("mockApi.yaml");

--- a/test/test-integration/src/test/java/org/wso2am/micro/gw/tests/util/ApiDeployment.java
+++ b/test/test-integration/src/test/java/org/wso2am/micro/gw/tests/util/ApiDeployment.java
@@ -38,7 +38,7 @@ public class ApiDeployment {
     private static final Logger log = LoggerFactory.getLogger(ApiDeployment.class);
 
     /**
-     * Get Mock backend server module root path.
+     * Deploy api to adapter via adapter REST APIs.
      *
      * @param apiZipFilePath  path for the apictl project zip file
      *


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
As $subject, this will change the failsafe plugin to the surefire plugin and from this, we can define the preserved order for the test classes.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1522

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
