### PR TITLE
Bump ballerina version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -570,7 +570,7 @@
     </build>
 
     <properties>
-        <ballerina.platform.version>1.2.12</ballerina.platform.version>
+        <ballerina.platform.version>1.2.13</ballerina.platform.version>
         <broker.version>0.970.5</broker.version>
         <assembly.plugin.version>3.1.1</assembly.plugin.version>
         <compiler.plugin.version>3.7.0</compiler.plugin.version>


### PR DESCRIPTION
## Purpose
This PR fixes processing headers as trailer headers when an HTTP/2 upstream responds with an empty body by bumping the ballerina version.

Fixes https://github.com/wso2/product-microgateway/issues/1528