### PR TITLE
Support Multiple Users to deploy APICTL projects

### DIFF
--- a/adapter/config/mgwtypes.go
+++ b/adapter/config/mgwtypes.go
@@ -73,10 +73,8 @@ type Config struct {
 		PublicKeyPath string
 		// Private Key Path (For the https connection between adapter and apictl)
 		PrivateKeyPath string
-		// Username credential
-		Username string
-		// Password credential
-		Password string
+		// APICTL Users
+		Users []APICtlUser `toml:"users"`
 	}
 
 	// Envoy Listener Component related configurations.
@@ -103,4 +101,10 @@ type Config struct {
 			}
 		}
 	}
+}
+
+// APICtlUser represents registered APICtl Users
+type APICtlUser struct {
+	Username string
+	Password string
 }

--- a/adapter/config/mgwtypes.go
+++ b/adapter/config/mgwtypes.go
@@ -62,19 +62,21 @@ func NewReceiver() chan string {
 // Config represents the adapter configuration.
 // It is created directly from the configuration toml file.
 type Config struct {
-
-	// Server represents the configuration related to rest API (to which the apictl requests)
-	Server struct {
-		// Host name of the server
-		Host string
-		// Port of the server
-		Port string
-		// Public Certificate Path (For the https connection between adapter and apictl)
-		PublicKeyPath string
-		// Private Key Path (For the https connection between adapter and apictl)
-		PrivateKeyPath string
-		// APICTL Users
-		Users []APICtlUser `toml:"users"`
+	//Adapter related Configurations
+	Adapter struct {
+		// Server represents the configuration related to rest API (to which the apictl requests)
+		Server struct {
+			// Host name of the server
+			Host string
+			// Port of the server
+			Port string
+			// Public Certificate Path (For the https connection between adapter and apictl)
+			PublicKeyPath string
+			// Private Key Path (For the https connection between adapter and apictl)
+			PrivateKeyPath string
+			// APICTL Users
+			Users []APICtlUser `toml:"users"`
+		}
 	}
 
 	// Envoy Listener Component related configurations.

--- a/adapter/pkg/api/restserver/config_restapi.go
+++ b/adapter/pkg/api/restserver/config_restapi.go
@@ -60,9 +60,14 @@ func configureAPI(api *operations.RestapiAPI) http.Handler {
 
 	// Applies when the Authorization header is set with the Basic scheme
 	api.BasicAuthAuth = func(user string, pass string) (*models.Principal, error) {
-		if user != mgwConfig.Server.Username || pass != mgwConfig.Server.Password {
-			// TODO: (VirajSalaka) Introduce Constants
-			logger.LoggerAPI.Info("Credentials are invalid")
+		authenticated := false
+		for _, regUser := range mgwConfig.Server.Users {
+			if user == regUser.Username && pass == regUser.Password {
+				authenticated = true
+			}
+		}
+		if !authenticated {
+			logger.LoggerAPI.Info("Credentials provided for deploy command are invalid")
 			return nil, errors.New(401, "Credentials are invalid")
 		}
 		// TODO: implement authentication principal

--- a/adapter/pkg/api/restserver/config_restapi.go
+++ b/adapter/pkg/api/restserver/config_restapi.go
@@ -61,7 +61,7 @@ func configureAPI(api *operations.RestapiAPI) http.Handler {
 	// Applies when the Authorization header is set with the Basic scheme
 	api.BasicAuthAuth = func(user string, pass string) (*models.Principal, error) {
 		authenticated := false
-		for _, regUser := range mgwConfig.Server.Users {
+		for _, regUser := range mgwConfig.Adapter.Server.Users {
 			if user == regUser.Username && pass == regUser.Password {
 				authenticated = true
 			}
@@ -102,7 +102,7 @@ func configureAPI(api *operations.RestapiAPI) http.Handler {
 func configureTLS(tlsConfig *tls.Config) {
 	// Make all necessary changes to the TLS configuration here.
 	// TODO: (VirajSalaka) Introduce PKCS12
-	tlsConfig.Certificates, _ = getCertificates(mgwConfig.Server.PublicKeyPath, mgwConfig.Server.PrivateKeyPath)
+	tlsConfig.Certificates, _ = getCertificates(mgwConfig.Adapter.Server.PublicKeyPath, mgwConfig.Adapter.Server.PrivateKeyPath)
 }
 
 func getCertificates(publicKeyPath, privateKeyPath string) ([]tls.Certificate, error) {
@@ -162,10 +162,10 @@ func StartRestServer(config *config.Config) {
 	defer server.Shutdown()
 
 	server.ConfigureAPI()
-	server.TLSHost = mgwConfig.Server.Host
-	port, err := strconv.Atoi(mgwConfig.Server.Port)
+	server.TLSHost = mgwConfig.Adapter.Server.Host
+	port, err := strconv.Atoi(mgwConfig.Adapter.Server.Port)
 	if err != nil {
-		logger.LoggerAPI.Fatalf("The provided port value for the REST Api Server :%v is not an integer. %v", mgwConfig.Server.Port, err)
+		logger.LoggerAPI.Fatalf("The provided port value for the REST Api Server :%v is not an integer. %v", mgwConfig.Adapter.Server.Port, err)
 		return
 	}
 	server.TLSPort = port

--- a/resources/conf/config.toml
+++ b/resources/conf/config.toml
@@ -4,6 +4,7 @@ host = "0.0.0.0"
 port = "9843"
 publicKeyPath = "/home/wso2/security/localhost.pem"
 privateKeyPath = "/home/wso2/security/localhost.key"
+[[server.users]]
 username = "admin"
 password = "admin"
 

--- a/resources/conf/config.toml
+++ b/resources/conf/config.toml
@@ -1,10 +1,11 @@
+[adapter]
 # The configuration file for mgw
-[server]
+[adapter.server]
 host = "0.0.0.0"
 port = "9843"
 publicKeyPath = "/home/wso2/security/localhost.pem"
 privateKeyPath = "/home/wso2/security/localhost.key"
-[[server.users]]
+[[adapter.server.users]]
 username = "admin"
 password = "admin"
 


### PR DESCRIPTION
### Purpose
Refactor the adapter related configuration such that REST Server configuration is moved into a separate tag called `adapter`.
Support Multiple Users to deploy APICTL projects. (earlier it was single user). 

Hence the configuration would be changed as follows.

```
[adapter]
[adapter.server]
host = "0.0.0.0"
port = "9843"
publicKeyPath = "/home/wso2/security/localhost.pem"
privateKeyPath = "/home/wso2/security/localhost.key"
[[adapter.server.users]]
username = "admin"
password = "admin"
```

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1548 

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, JDK version, etc... -->
MacOS Mojave

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
