### PR TITLE
Add configurations to preserve headers

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
@@ -608,6 +608,7 @@ public const string SERVER_HEADER = "header";
 //server preserve headers configurations
 public const string SERVER_PRESERVE_HEADERS_ID = "server.preserveHeaders";
 public const string SERVER_PRESERVE_HEADERS_USER_AGENT = "userAgent";
+public const string SERVER_PRESERVE_HEADERS_SERVER = "server";
 
 public const string APIM_CREDENTIALS_INSTANCE_ID = "apim.credentials";
 public const string APIM_CREDENTIALS_USERNAME = "username";

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
@@ -26,6 +26,7 @@ public const string API_KEY_IN = "in";
 public const string API_KEY_NAME = "name";
 public const string AUTH_HEADER = "Authorization";
 public const string SERVER_HEADER_NAME = "server";
+public const string USER_AGENT_HEADER_NAME = "User-Agent";
 public const string AUTH_SCHEME_BASIC = "Basic";
 public const string AUTH_SCHEME_BEARER = "Bearer";
 public const string AUTH_SCHEME_BASIC_LOWERCASE = "basic";
@@ -605,10 +606,11 @@ public const string SERVER_CONF_ID = "server";
 public const string SERVER_TIMESTAMP_SKEW = "timestampSkew";
 public const string SERVER_HEADER = "header";
 
-//server preserve headers configurations
-public const string SERVER_PRESERVE_HEADERS_ID = "server.preserveHeaders";
-public const string SERVER_PRESERVE_HEADERS_USER_AGENT = "userAgent";
-public const string SERVER_PRESERVE_HEADERS_SERVER = "server";
+// server preserved header configurations
+public const string SERVER_HEADER_ID = "server.header";
+public const string SERVER_HEADER_HEADER_NAME = "headerName";
+public const string SERVER_HEADER_PRESERVE_HEADER = "preserveHeader";
+public const string SERVER_HEADER_OVERRIDE_VALUE = "overrideValue";
 
 public const string APIM_CREDENTIALS_INSTANCE_ID = "apim.credentials";
 public const string APIM_CREDENTIALS_USERNAME = "username";

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
@@ -605,6 +605,10 @@ public const string SERVER_CONF_ID = "server";
 public const string SERVER_TIMESTAMP_SKEW = "timestampSkew";
 public const string SERVER_HEADER = "header";
 
+//server preserve headers configurations
+public const string SERVER_PRESERVE_HEADERS_ID = "server.preserveHeaders";
+public const string SERVER_PRESERVE_HEADERS_USER_AGENT = "userAgent";
+
 public const string APIM_CREDENTIALS_INSTANCE_ID = "apim.credentials";
 public const string APIM_CREDENTIALS_USERNAME = "username";
 public const string APIM_CREDENTIALS_PASSWORD = "password";

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
@@ -607,7 +607,7 @@ public const string SERVER_TIMESTAMP_SKEW = "timestampSkew";
 public const string SERVER_HEADER = "header";
 
 // server preserved header configurations
-public const string SERVER_HEADER_ID = "server.header";
+public const string SERVER_HEADER_ID = "server.headerConf";
 public const string SERVER_HEADER_HEADER_NAME = "headerName";
 public const string SERVER_HEADER_PRESERVE_HEADER = "preserveHeader";
 public const string SERVER_HEADER_OVERRIDE_VALUE = "overrideValue";

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/micro_gw_conf_defaults.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/micro_gw_conf_defaults.bal
@@ -205,6 +205,4 @@ public const string DEFAULT_APIM_CREDENTIALS_PASSWORD = "admin";
 
 public const int DEFAULT_SERVER_TIMESTAMP_SKEW = -1;
 public const string DEFAULT_SERVER_HEADER = "ballerina";
-
-public const boolean DEFAULT_SERVER_PRESERVE_HEADERS_USER_AGENT = false;
-public const boolean DEFAULT_SERVER_PRESERVE_HEADERS_SERVER = true;
+public const boolean DEFAULT_SERVER_HEADER_PRESERVE_HEADER = false;

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/micro_gw_conf_defaults.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/micro_gw_conf_defaults.bal
@@ -205,4 +205,6 @@ public const string DEFAULT_APIM_CREDENTIALS_PASSWORD = "admin";
 
 public const int DEFAULT_SERVER_TIMESTAMP_SKEW = -1;
 public const string DEFAULT_SERVER_HEADER = "ballerina";
-public const boolean DEFAULT_SERVER_HEADER_PRESERVE_HEADER = false;
+public const boolean DEFAULT_SERVER_HEADERCONF_USER_AGENT_PRESERVE_HEADER = false;
+public const boolean DEFAULT_SERVER_HEADERCONF_SERVER_PRESERVE_HEADER = true;
+public const boolean DEFAULT_SERVER_HEADERCONF_PRESERVE_HEADER = false;

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/micro_gw_conf_defaults.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/micro_gw_conf_defaults.bal
@@ -207,3 +207,4 @@ public const int DEFAULT_SERVER_TIMESTAMP_SKEW = -1;
 public const string DEFAULT_SERVER_HEADER = "ballerina";
 
 public const boolean DEFAULT_SERVER_PRESERVE_HEADERS_USER_AGENT = false;
+public const boolean DEFAULT_SERVER_PRESERVE_HEADERS_SERVER = true;

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/micro_gw_conf_defaults.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/micro_gw_conf_defaults.bal
@@ -205,3 +205,5 @@ public const string DEFAULT_APIM_CREDENTIALS_PASSWORD = "admin";
 
 public const int DEFAULT_SERVER_TIMESTAMP_SKEW = -1;
 public const string DEFAULT_SERVER_HEADER = "ballerina";
+
+public const boolean DEFAULT_SERVER_PRESERVE_HEADERS_USER_AGENT = false;

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/dtos/config_dtos/server_config.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/dtos/config_dtos/server_config.bal
@@ -37,8 +37,13 @@ public function getserverHeaders() returns (serverHeaderDTO[]) {
             anydata preserveHeader = serverHeader[SERVER_HEADER_PRESERVE_HEADER];
             anydata overrideValue = serverHeader[SERVER_HEADER_OVERRIDE_VALUE];
             if (headerName is string) {
-                boolean preserveHeaderVal = DEFAULT_SERVER_HEADER_PRESERVE_HEADER;
-                string overridValueStr = DEFAULT_SERVER_HEADER;
+                boolean preserveHeaderVal = DEFAULT_SERVER_HEADERCONF_PRESERVE_HEADER;
+                if (headerName.toLowerAscii() == USER_AGENT_HEADER_NAME.toLowerAscii()) {
+                    preserveHeaderVal = DEFAULT_SERVER_HEADERCONF_USER_AGENT_PRESERVE_HEADER;
+                } else if (headerName.toLowerAscii() == SERVER_HEADER_NAME.toLowerAscii()) {
+                    preserveHeaderVal = DEFAULT_SERVER_HEADERCONF_SERVER_PRESERVE_HEADER;
+                }
+                string overrideValueStr = DEFAULT_SERVER_HEADER;
                 if (preserveHeader is boolean) {
                     preserveHeaderVal = preserveHeader;
                 } else if (preserveHeader.toString() != "") {
@@ -46,13 +51,13 @@ public function getserverHeaders() returns (serverHeaderDTO[]) {
                     panic err;
                 }
                 if (overrideValue is string) {
-                    overridValueStr = overrideValue;
+                    overrideValueStr = overrideValue;
                 } else if (overrideValue.toString() != "") {
                     error err = error("'overrideValue' config value is not 'string'");
                     panic err;
                 }
                 serverHeaderDTO serverHeaderDto = {headerName: headerName, preserveHeader: preserveHeaderVal,
-                                                    overrideValue: overridValueStr};
+                                                    overrideValue: overrideValueStr};
                 serverHeaders.push(serverHeaderDto);
             } else if (headerName.toString() != "") {
                 error err = error("'headerName' config value is not 'string'");

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/dtos/config_dtos/server_config.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/dtos/config_dtos/server_config.bal
@@ -1,0 +1,57 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/config;
+
+public type ServerConfigDTO record {
+    int timestampSkew = getConfigIntValue(SERVER_CONF_ID, SERVER_TIMESTAMP_SKEW, DEFAULT_SERVER_TIMESTAMP_SKEW);
+    string header = getConfigValue(SERVER_CONF_ID, SERVER_HEADER, DEFAULT_SERVER_HEADER);
+    serverHeaderDTO[] serverHeaders = getserverHeaders();
+    //PreservedHeaderDTO[] preservedRequestHeaders = getPreservedRequestHeaders();
+    //PreservedHeaderDTO[] preservedResponseHeaders = getPreservedResponseHeaders();
+};
+
+public type serverHeaderDTO record {
+    string headerName;
+    boolean preserveHeader;
+    string overrideValue;
+};
+
+public function getserverHeaders() returns (serverHeaderDTO[]) {
+    map<anydata>[] | error serverHeaderMap = map<anydata>[].constructFrom(config:getAsArray(SERVER_HEADER_ID));
+    serverHeaderDTO[] serverHeaders = [];
+    if (serverHeaderMap is map<anydata>[] && serverHeaderMap.length() > 0) {
+        foreach map<anydata> serverHeader in serverHeaderMap {
+            anydata headerName = serverHeader[SERVER_HEADER_HEADER_NAME];
+            anydata preserveHeader = serverHeader[SERVER_HEADER_PRESERVE_HEADER];
+            anydata overrideValue = serverHeader[SERVER_HEADER_OVERRIDE_VALUE];
+            if (headerName is string) {
+                boolean preserveHeaderVal = DEFAULT_SERVER_HEADER_PRESERVE_HEADER;
+                string overridValueStr = DEFAULT_SERVER_HEADER;
+                if (preserveHeader is boolean) {
+                    preserveHeaderVal = preserveHeader;
+                }
+                if (overrideValue is string) {
+                    overridValueStr = overrideValue;
+                }
+                serverHeaderDTO serverHeaderDto = {headerName: headerName, preserveHeader: preserveHeaderVal,
+                                                    overrideValue: overridValueStr};
+                serverHeaders.push(serverHeaderDto);
+            }
+        }
+    }
+    return serverHeaders;
+}

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/dtos/config_dtos/server_config.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/dtos/config_dtos/server_config.bal
@@ -18,7 +18,7 @@ import ballerina/config;
 
 public type ServerConfigDTO record {
     int timestampSkew = getConfigIntValue(SERVER_CONF_ID, SERVER_TIMESTAMP_SKEW, DEFAULT_SERVER_TIMESTAMP_SKEW);
-    string header = getConfigValue(SERVER_CONF_ID, SERVER_HEADER, DEFAULT_SERVER_HEADER);
+    string header = getConfigValue(SERVER_CONF_ID, SERVER_HEADER, "");
     serverHeaderDTO[] serverHeaders = getserverHeaders();
 };
 

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/dtos/config_dtos/server_config.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/dtos/config_dtos/server_config.bal
@@ -20,8 +20,6 @@ public type ServerConfigDTO record {
     int timestampSkew = getConfigIntValue(SERVER_CONF_ID, SERVER_TIMESTAMP_SKEW, DEFAULT_SERVER_TIMESTAMP_SKEW);
     string header = getConfigValue(SERVER_CONF_ID, SERVER_HEADER, DEFAULT_SERVER_HEADER);
     serverHeaderDTO[] serverHeaders = getserverHeaders();
-    //PreservedHeaderDTO[] preservedRequestHeaders = getPreservedRequestHeaders();
-    //PreservedHeaderDTO[] preservedResponseHeaders = getPreservedResponseHeaders();
 };
 
 public type serverHeaderDTO record {
@@ -43,13 +41,22 @@ public function getserverHeaders() returns (serverHeaderDTO[]) {
                 string overridValueStr = DEFAULT_SERVER_HEADER;
                 if (preserveHeader is boolean) {
                     preserveHeaderVal = preserveHeader;
+                } else if (preserveHeader.toString() != "") {
+                    error err = error("'preservedHeader' config value is not 'boolean'");
+                    panic err;
                 }
                 if (overrideValue is string) {
                     overridValueStr = overrideValue;
+                } else if (overrideValue.toString() != "") {
+                    error err = error("'overrideValue' config value is not 'string'");
+                    panic err;
                 }
                 serverHeaderDTO serverHeaderDto = {headerName: headerName, preserveHeader: preserveHeaderVal,
                                                     overrideValue: overridValueStr};
                 serverHeaders.push(serverHeaderDto);
+            } else if (headerName.toString() != "") {
+                error err = error("'headerName' config value is not 'string'");
+                panic err;
             }
         }
     }

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/pre_authn_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/pre_authn_filter.bal
@@ -24,6 +24,13 @@ public type PreAuthnFilter object {
 
     public function filterRequest(http:Caller caller, http:Request request,@tainted http:FilterContext context) returns boolean {
         setFilterSkipToFilterContext(context);
+        boolean preserveUserAgentHeader = getConfigBooleanValue(SERVER_PRESERVE_HEADERS_ID,
+                                                                SERVER_PRESERVE_HEADERS_USER_AGENT,
+                                                                DEFAULT_SERVER_PRESERVE_HEADERS_USER_AGENT);
+        if (preserveUserAgentHeader) {
+            request.setHeader("User-Agent", request.userAgent);
+        }
+
         if (context.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>context.attributes[SKIP_ALL_FILTERS]) {
             printDebug(KEY_PRE_AUTHN_FILTER, "Skip all filter annotation set in the service. Skip the filter");
             return true;

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/pre_authn_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/pre_authn_filter.bal
@@ -24,13 +24,7 @@ public type PreAuthnFilter object {
 
     public function filterRequest(http:Caller caller, http:Request request,@tainted http:FilterContext context) returns boolean {
         setFilterSkipToFilterContext(context);
-        boolean preserveUserAgentHeader = getConfigBooleanValue(SERVER_PRESERVE_HEADERS_ID,
-                                                                SERVER_PRESERVE_HEADERS_USER_AGENT,
-                                                                DEFAULT_SERVER_PRESERVE_HEADERS_USER_AGENT);
-        if (preserveUserAgentHeader) {
-            request.setHeader("User-Agent", request.userAgent);
-        }
-
+        preserveRequestHeaders(request);
         if (context.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>context.attributes[SKIP_ALL_FILTERS]) {
             printDebug(KEY_PRE_AUTHN_FILTER, "Skip all filter annotation set in the service. Skip the filter");
             return true;
@@ -48,13 +42,7 @@ public type PreAuthnFilter object {
     }
 
     public function filterResponse(http:Response response, http:FilterContext context) returns boolean {
-        boolean preserveServerHeader = getConfigBooleanValue(SERVER_PRESERVE_HEADERS_ID,
-                                                                SERVER_PRESERVE_HEADERS_SERVER,
-                                                                DEFAULT_SERVER_PRESERVE_HEADERS_SERVER);
-        if (!preserveServerHeader) {
-            string serverHeaderConfig = getConfigValue(SERVER_CONF_ID, SERVER_HEADER, DEFAULT_SERVER_HEADER);
-            response.setHeader("server", serverHeaderConfig);
-        }
+        preserveResponseHeaders(response);
         if (context.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>context.attributes[SKIP_ALL_FILTERS]) {
             printDebug(KEY_PRE_AUTHN_FILTER, "Skip all filter annotation set in the service. Skip the filter");
             return true;
@@ -185,5 +173,24 @@ function getAuthenticationProviderType(string authHeader) returns (string) {
         return AUTH_SCHEME_JWT;
     } else {
         return AUTH_SCHEME_OAUTH2;
+    }
+}
+
+function preserveRequestHeaders(http:Request request) {
+    boolean preserveUserAgentHeader = getConfigBooleanValue(SERVER_PRESERVE_HEADERS_ID,
+                                                            SERVER_PRESERVE_HEADERS_USER_AGENT,
+                                                            DEFAULT_SERVER_PRESERVE_HEADERS_USER_AGENT);
+    if (preserveUserAgentHeader) {
+        request.setHeader("User-Agent", request.userAgent);
+    }
+}
+
+function preserveResponseHeaders(http:Response response) {
+    boolean preserveServerHeader = getConfigBooleanValue(SERVER_PRESERVE_HEADERS_ID,
+                                                            SERVER_PRESERVE_HEADERS_SERVER,
+                                                            DEFAULT_SERVER_PRESERVE_HEADERS_SERVER);
+    if (!preserveServerHeader) {
+        string serverHeaderConfig = getConfigValue(SERVER_CONF_ID, SERVER_HEADER, DEFAULT_SERVER_HEADER);
+        response.setHeader("server", serverHeaderConfig);
     }
 }

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/pre_authn_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/pre_authn_filter.bal
@@ -206,10 +206,12 @@ function preserveResponseHeaders(@tainted http:Response response) {
         string[] responseHeaders = response.getHeaderNames();
         foreach string responseHeader in responseHeaders {
             if (serverHeader.headerName.toLowerAscii() == SERVER_HEADER_NAME.toLowerAscii()) {
-                if (serverHeader.preserveHeader) {
-                    response.setHeader(serverHeader.headerName, response.server);
-                } else {
-                    response.setHeader(serverHeader.headerName, serverHeader.overrideValue);
+                if (!serverHeader.preserveHeader) {
+                    if (response.server != "") {
+                        response.setHeader(serverHeader.headerName, serverHeader.overrideValue);
+                    } else if (gatewayConf.getServerConfig().header == "") {
+                        response.setHeader(serverHeader.headerName, serverHeader.overrideValue);
+                    }
                 }
                 break;
             } else if (responseHeader.toLowerAscii() == serverHeader.headerName.toLowerAscii()) {

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/pre_authn_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/pre_authn_filter.bal
@@ -48,6 +48,13 @@ public type PreAuthnFilter object {
     }
 
     public function filterResponse(http:Response response, http:FilterContext context) returns boolean {
+        boolean preserveServerHeader = getConfigBooleanValue(SERVER_PRESERVE_HEADERS_ID,
+                                                                SERVER_PRESERVE_HEADERS_SERVER,
+                                                                DEFAULT_SERVER_PRESERVE_HEADERS_SERVER);
+        if (!preserveServerHeader) {
+            string serverHeaderConfig = getConfigValue(SERVER_CONF_ID, SERVER_HEADER, DEFAULT_SERVER_HEADER);
+            response.setHeader("server", serverHeaderConfig);
+        }
         if (context.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>context.attributes[SKIP_ALL_FILTERS]) {
             printDebug(KEY_PRE_AUTHN_FILTER, "Skip all filter annotation set in the service. Skip the filter");
             return true;

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/pre_authn_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/pre_authn_filter.bal
@@ -23,8 +23,8 @@ import ballerina/stringutils;
 public type PreAuthnFilter object {
 
     public function filterRequest(http:Caller caller, http:Request request,@tainted http:FilterContext context) returns boolean {
-        setFilterSkipToFilterContext(context);
         preserveRequestHeaders(request);
+        setFilterSkipToFilterContext(context);
         if (context.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>context.attributes[SKIP_ALL_FILTERS]) {
             printDebug(KEY_PRE_AUTHN_FILTER, "Skip all filter annotation set in the service. Skip the filter");
             return true;
@@ -41,7 +41,7 @@ public type PreAuthnFilter object {
         return result;
     }
 
-    public function filterResponse(http:Response response, http:FilterContext context) returns boolean {
+    public function filterResponse(@tainted http:Response response, http:FilterContext context) returns boolean {
         preserveResponseHeaders(response);
         if (context.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>context.attributes[SKIP_ALL_FILTERS]) {
             printDebug(KEY_PRE_AUTHN_FILTER, "Skip all filter annotation set in the service. Skip the filter");
@@ -177,20 +177,50 @@ function getAuthenticationProviderType(string authHeader) returns (string) {
 }
 
 function preserveRequestHeaders(http:Request request) {
-    boolean preserveUserAgentHeader = getConfigBooleanValue(SERVER_PRESERVE_HEADERS_ID,
-                                                            SERVER_PRESERVE_HEADERS_USER_AGENT,
-                                                            DEFAULT_SERVER_PRESERVE_HEADERS_USER_AGENT);
-    if (preserveUserAgentHeader) {
-        request.setHeader("User-Agent", request.userAgent);
+    serverHeaderDTO[] serverHeaders = gatewayConf.getServerConfig().serverHeaders;
+    foreach serverHeaderDTO serverHeader in serverHeaders {
+        string[] requestHeaders = request.getHeaderNames();
+        foreach string requestHeader in requestHeaders {
+            if (serverHeader.headerName.toLowerAscii() == USER_AGENT_HEADER_NAME.toLowerAscii()) {
+                if (serverHeader.preserveHeader) {
+                    request.setHeader(serverHeader.headerName, request.userAgent);
+                } else {
+                    request.setHeader(serverHeader.headerName, serverHeader.overrideValue);
+                }
+                break;
+            } else if (requestHeader.toLowerAscii() == serverHeader.headerName.toLowerAscii()) {
+                if (serverHeader.preserveHeader) {
+                    request.setHeader(serverHeader.headerName, request.getHeader(<@untainted> requestHeader));
+                } else {
+                    request.setHeader(serverHeader.headerName, serverHeader.overrideValue);
+                }
+                break;
+            }
+        }
     }
 }
 
-function preserveResponseHeaders(http:Response response) {
-    boolean preserveServerHeader = getConfigBooleanValue(SERVER_PRESERVE_HEADERS_ID,
-                                                            SERVER_PRESERVE_HEADERS_SERVER,
-                                                            DEFAULT_SERVER_PRESERVE_HEADERS_SERVER);
-    if (!preserveServerHeader) {
-        string serverHeaderConfig = getConfigValue(SERVER_CONF_ID, SERVER_HEADER, DEFAULT_SERVER_HEADER);
-        response.setHeader("server", serverHeaderConfig);
+function preserveResponseHeaders(@tainted http:Response response) {
+    serverHeaderDTO[] serverHeaders = gatewayConf.getServerConfig().serverHeaders;
+    foreach serverHeaderDTO serverHeader in serverHeaders {
+        string[] responseHeaders = response.getHeaderNames();
+        foreach string responseHeader in responseHeaders {
+            if (serverHeader.headerName.toLowerAscii() == SERVER_HEADER_NAME.toLowerAscii()) {
+                if (serverHeader.preserveHeader) {
+                    response.setHeader(serverHeader.headerName, response.server);
+                } else {
+                    response.setHeader(serverHeader.headerName, serverHeader.overrideValue);
+                }
+                break;
+            } else if (responseHeader.toLowerAscii() == serverHeader.headerName.toLowerAscii()) {
+                if (serverHeader.preserveHeader) {
+                    response.setHeader(serverHeader.headerName, response.getHeader(<@untainted> responseHeader));
+                } else {
+                    response.setHeader(serverHeader.headerName, serverHeader.overrideValue);
+                }
+                break;
+            }
+        }
     }
 }
+

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/gateway_conf.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/gateway_conf.bal
@@ -20,6 +20,7 @@ public type GatewayConf object {
     public JWTGeneratorConfigDTO jwtGeneratorConfig = {};
     public ListenerConfigDTO listenerConfig = {};
     public ApimCredentialsDTO apimCredentials = {};
+    public ServerConfigDTO serverConfig = {};
 
     public function getGatewayConf() returns (GatewayConf) {
         return gatewayConf;
@@ -31,6 +32,14 @@ public type GatewayConf object {
 
     public function getKeyManagerConf() returns (KeyManagerConf) {
         return gatewayConf.keyManagerConf;
+    }
+
+    public function setServerConfig(ServerConfigDTO serverConfig) {
+        gatewayConf.serverConfig = serverConfig;
+    }
+
+    public function getServerConfig() returns (ServerConfigDTO) {
+        return gatewayConf.serverConfig;
     }
 };
 

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/listeners/api_gateway_listener.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/listeners/api_gateway_listener.bal
@@ -51,7 +51,22 @@ public type APIGatewayListener object {
             self.listenerPort = getConfigIntValue(LISTENER_CONF_INSTANCE_ID, LISTENER_CONF_HTTPS_PORT, port);
             self.listenerType = "HTTPS";
         }
-        config.server = getConfigValue(SERVER_CONF_ID, SERVER_HEADER, DEFAULT_SERVER_HEADER);
+        string serverHeaderConf = gatewayConf.getServerConfig().header;
+        if (serverHeaderConf == "") {
+            serverHeaderDTO[] serverHeaders = gatewayConf.getServerConfig().serverHeaders;
+            boolean headerFound = false;
+            foreach serverHeaderDTO serverHeader in serverHeaders {
+                if (serverHeader.headerName.toLowerAscii() == SERVER_HEADER_NAME.toLowerAscii()) {
+                    serverHeaderConf = serverHeader.overrideValue;
+                    headerFound = true;
+                    break;
+                }
+            }
+            if (!headerFound) {
+                serverHeaderConf = DEFAULT_SERVER_HEADER;
+            }
+        }
+        config.server = serverHeaderConf;
         printDebug(KEY_GW_LISTNER, "Initialized gateway configurations for port:" + self.listenerPort.toString());
         self.httpListener = new (self.listenerPort, config = config);
         printDebug(KEY_GW_LISTNER, "Successfully initialized APIGatewayListener for port:" + self.listenerPort.toString());

--- a/distribution/resources/conf/default-micro-gw.conf.template
+++ b/distribution/resources/conf/default-micro-gw.conf.template
@@ -504,7 +504,7 @@
   timestampSkew = 5000
   # The value of the server header sent in the response by microgateway
   header="ballerina"
-  # The headers will be preserved in the request and the response without any intermediate change
+  # Preserve or override header values intercepted by the gateway
   [[server.header]]
       headerName = "User-Agent"
       preserveHeader = true

--- a/distribution/resources/conf/default-micro-gw.conf.template
+++ b/distribution/resources/conf/default-micro-gw.conf.template
@@ -504,6 +504,9 @@
   timestampSkew = 5000
   # The value of the server header sent in the response by microgateway
   header="ballerina"
+  # The headers will be prserved in the request forwarded to the backend without any intermediate change
+  [server.preserveHeaders]
+    userAgent = false
 
 # Configurations for retrieving API and subscription data from API Manager.
 [apim.eventHub]

--- a/distribution/resources/conf/default-micro-gw.conf.template
+++ b/distribution/resources/conf/default-micro-gw.conf.template
@@ -511,7 +511,7 @@
       overrideValue = "ballerina"
   [[server.headerConf]]
       headerName = "Server"
-      preserveHeader = false
+      preserveHeader = true
       overrideValue = "ballerina"
 
 # Configurations for retrieving API and subscription data from API Manager.

--- a/distribution/resources/conf/default-micro-gw.conf.template
+++ b/distribution/resources/conf/default-micro-gw.conf.template
@@ -507,6 +507,7 @@
   # The headers will be prserved in the request forwarded to the backend without any intermediate change
   [server.preserveHeaders]
     userAgent = false
+    server = true
 
 # Configurations for retrieving API and subscription data from API Manager.
 [apim.eventHub]

--- a/distribution/resources/conf/default-micro-gw.conf.template
+++ b/distribution/resources/conf/default-micro-gw.conf.template
@@ -502,6 +502,8 @@
 [server]
   # timestamp skew in milliseconds which added when checking the token validity period
   timestampSkew = 5000
+  # The value of the server header sent in the response by microgateway
+  header="ballerina"
   # The headers will be preserved in the request and the response without any intermediate change
   [[server.header]]
       headerName = "User-Agent"

--- a/distribution/resources/conf/default-micro-gw.conf.template
+++ b/distribution/resources/conf/default-micro-gw.conf.template
@@ -505,13 +505,13 @@
   # The value of the server header sent in the response by microgateway
   header="ballerina"
   # Preserve or override header values intercepted by the gateway
-  [[server.header]]
+  [[server.headerConf]]
       headerName = "User-Agent"
-      preserveHeader = true
+      preserveHeader = false
       overrideValue = "ballerina"
-  [[server.header]]
+  [[server.headerConf]]
       headerName = "Server"
-      preserveHeader = true
+      preserveHeader = false
       overrideValue = "ballerina"
 
 # Configurations for retrieving API and subscription data from API Manager.

--- a/distribution/resources/conf/default-micro-gw.conf.template
+++ b/distribution/resources/conf/default-micro-gw.conf.template
@@ -502,12 +502,15 @@
 [server]
   # timestamp skew in milliseconds which added when checking the token validity period
   timestampSkew = 5000
-  # The value of the server header sent in the response by microgateway
-  header="ballerina"
-  # The headers will be prserved in the request forwarded to the backend without any intermediate change
-  [server.preserveHeaders]
-    userAgent = false
-    server = true
+  # The headers will be preserved in the request and the response without any intermediate change
+  [[server.header]]
+      headerName = "User-Agent"
+      preserveHeader = true
+      overrideValue = "ballerina"
+  [[server.header]]
+      headerName = "Server"
+      preserveHeader = true
+      overrideValue = "ballerina"
 
 # Configurations for retrieving API and subscription data from API Manager.
 [apim.eventHub]


### PR DESCRIPTION
### Purpose
This PR adds the configurations to preserve headers in the request/responses without any intermediate change in microgateway.
By adding the header properties under `server.headerConf` config, you have the ability to preserve headers by setting the config `preserveHeader` to true. Furthermore, by setting `preserveHeader` to false and adding the desired value to `overrideValue` config, you have the capability to override a header in request/response.
```
# server configuration
[server]
  # Preserve or override header values intercepted by the gateway
  [[server.headerConf]]
      headerName = "User-Agent"
      preserveHeader = true
      overrideValue = "ballerina"
  [[server.headerConf]]
      headerName = "Server"
      preserveHeader = true
      overrideValue = "ballerina"
```

### Issues
Fixes https://github.com/wso2/product-microgateway/issues/1558

### Tested environments
Ubuntu 20.04 LTS, OpenJDK 1.8.0_275
