### PR TITLE
Fix Open APIv2 struct issue

### DIFF
--- a/adapter/pkg/xds/xds_server.go
+++ b/adapter/pkg/xds/xds_server.go
@@ -159,7 +159,7 @@ func UpdateAPI(byteArr []byte, upstreamCerts []byte, apiType string) {
 		} else {
 			openAPIV2Struct, err := operator.GetOpenAPIV2Struct(jsonContent)
 			if err != nil {
-				logger.LoggerXds.Error("Error while parsing to a OpenAPIv3 struct. ", err)
+				logger.LoggerXds.Error("Error while parsing to a OpenAPIv2 struct. ", err)
 			}
 			apiMapKey = openAPIV2Struct.Info.Title + ":" + openAPIV2Struct.Info.Version
 			existingOpenAPI, ok := openAPIV2Map[apiMapKey]
@@ -170,6 +170,7 @@ func UpdateAPI(byteArr []byte, upstreamCerts []byte, apiType string) {
 					return
 				}
 			}
+			openAPIV2Map[apiMapKey] = openAPIV2Struct
 			newLabels = operator.GetXWso2Labels(openAPIV2Struct.Extensions)
 		}
 


### PR DESCRIPTION
### Purpose
Add the openapi v2 struct to map assignment. Fixes #1580 
---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
