### PR TITLE
Fix checkstyle and javadoc issues

### DIFF
--- a/enforcer/pom.xml
+++ b/enforcer/pom.xml
@@ -73,7 +73,7 @@
                                 https://raw.githubusercontent.com/wso2/code-quality-tools/v1.3/checkstyle/checkstyle.xml
                             </configLocation>
                             <suppressionsLocation>
-                                https://raw.githubusercontent.com/wso2/code-quality-tools/v1.3/checkstyle/suppressions.xml
+                                suppressions.xml
                             </suppressionsLocation>
                             <consoleOutput>true</consoleOutput>
                             <failsOnError>true</failsOnError>

--- a/enforcer/suppressions.xml
+++ b/enforcer/suppressions.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    # Copyright 2021 WSO2 Inc. (http://wso2.org)
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+@@ -14,34 +14,12 @@
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+-->
+<!--This file is copied from https://raw.githubusercontent.com/wso2/code-quality-tools/v1.3/checkstyle/suppressions.xml-->
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+
+    <suppress checks="Javadoc.*" files=".*/src/test/java/.*" />
+
+    <suppress checks="JavadocPackage" files=".*/src/(main|integration)/java/.*"/>
+    <suppress checks="JavadocPackage" files=".*/src/.*/internal/.*"/>
+
+    <suppress checks="JavadocStyle" files=".*/src/(main|integration)/java/.*"/>
+    <suppress checks="JavadocStyle" files=".*/src/.*/internal/.*"/>
+
+    <suppress checks="MethodNameCheck" files=".*/*CommandProvider.java"/>
+    <suppress checks="Regexp" files=".*/*CommandProvider.java"/>
+
+
+    <!-- copied from apache hadoop, won't fix style to keep diff minimal -->
+    <suppress checks=".*" files=".*/LocalJobRunnerWithFix.java"/>
+
+    <!-- do not check thrift generated files -->
+    <suppress checks=".*" files=".*/transaction/distributed/thrift/.*"/>
+
+    <!-- do not check swagger generated files -->
+    <suppress checks=".*" files=".*/src/gen/java/.*"/>
+
+    <!--  Following is added to exclude gen files in enforcer-->
+    <suppress checks=".*" files=".*/src/main/gen/.*"/>
+
+</suppressions>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -36,4 +36,8 @@
         <module>test-integration</module>
     </modules>
 
+    <properties>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
+
 </project>


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
task

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Encountered following errors when building the project.
1. org.wso2.micro.gateway.enforcer: Failed during checkstyle execution: There are 2704 errors reported. 
sol: exclude gen folder from checkstyle check.
2. javadoc: error - No source files for package org.wso2am.micro.gw.mockbackend
sol: exclude test package from javadoc

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, JDK version, etc... -->
catalina

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
