### PR TITLE
[envoy-gw] Refactor update API

### DIFF
--- a/adapter/pkg/oasparser/configGenerator.go
+++ b/adapter/pkg/oasparser/configGenerator.go
@@ -23,35 +23,24 @@ import (
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
-	"github.com/wso2/micro-gw/loggers"
 
 	wso2 "github.com/envoyproxy/go-control-plane/wso2/discovery/api"
 	envoy "github.com/wso2/micro-gw/pkg/oasparser/envoyconf"
 	"github.com/wso2/micro-gw/pkg/oasparser/model"
 	mgw "github.com/wso2/micro-gw/pkg/oasparser/model"
-	"github.com/wso2/micro-gw/pkg/oasparser/operator"
 )
 
 // GetProductionRoutesClustersEndpoints generates the routes, clusters and endpoints (envoy)
 // when the openAPI Json is provided. For websockets apiJsn created from api.yaml file is considerd.
-func GetProductionRoutesClustersEndpoints(byteArr []byte, upstreamCerts []byte, apiType string) ([]*routev3.Route, []*clusterv3.Cluster, []*corev3.Address, mgw.MgwSwagger) {
-	var mgwSwagger mgw.MgwSwagger
+func GetProductionRoutesClustersEndpoints(mgwSwagger mgw.MgwSwagger, upstreamCerts []byte) ([]*routev3.Route, []*clusterv3.Cluster, []*corev3.Address) {
 	var routes []*routev3.Route
 	var clusters []*clusterv3.Cluster
 	var endpoints []*corev3.Address
 
-	if apiType == mgw.HTTP {
-		mgwSwagger = operator.GetMgwSwagger(byteArr)
-	} else if apiType == mgw.WS {
-		mgwSwagger = operator.GetMgwSwaggerWebSocket(byteArr)
-	} else {
-		// Unreachable else condition. Added in case previous apiType check fails due to any modifications.
-		loggers.LoggerOasparser.Errorf("API type not currently supported with WSO2 Micro-gateway")
-	}
 	routes, clusters, endpoints = envoy.CreateRoutesWithClusters(mgwSwagger, upstreamCerts)
 	//TODO: (VirajSalaka) Decide if this needs to be added to the MgwSwagger
 
-	return routes, clusters, endpoints, mgwSwagger
+	return routes, clusters, endpoints
 }
 
 // GetProductionListenerAndRouteConfig generates the listener and routesconfiguration configurations.

--- a/adapter/pkg/oasparser/model/mgwResource.go
+++ b/adapter/pkg/oasparser/model/mgwResource.go
@@ -39,7 +39,7 @@ type Resource struct {
 	productionUrls   []Endpoint
 	sandboxUrls      []Endpoint
 	security         []map[string][]string
-	vendorExtensible map[string]interface{}
+	vendorExtensions map[string]interface{}
 }
 
 // GetProdEndpoints returns the production endpoints array of a given resource.
@@ -77,7 +77,7 @@ func (resource *Resource) GetMethod() []string {
 // CreateDummyResourceForTests create an resource object which could be used for unit tests.
 func CreateDummyResourceForTests(path, method, description string, consumes, schemes,
 	tags []string, summary, id string, productionUrls, sandboxUrls []Endpoint,
-	security []map[string][]string, vendorExtensible map[string]interface{}) Resource {
+	security []map[string][]string, vendorExtensions map[string]interface{}) Resource {
 	return Resource{
 		path:             path,
 		methods:          []string{method},
@@ -90,7 +90,7 @@ func CreateDummyResourceForTests(path, method, description string, consumes, sch
 		productionUrls:   productionUrls,
 		sandboxUrls:      sandboxUrls,
 		security:         security,
-		vendorExtensible: vendorExtensible,
+		vendorExtensions: vendorExtensions,
 	}
 }
 

--- a/adapter/pkg/oasparser/model/mgwSwagger.go
+++ b/adapter/pkg/oasparser/model/mgwSwagger.go
@@ -27,13 +27,12 @@ import (
 // the root level of the openAPI definition. The pathItem level information is represented
 // by the resources array which contains the MgwResource entries.
 type MgwSwagger struct {
-	id          string
-	apiType     string
-	description string
-	title       string
-	version     string
-	// TODO - (VirajSalaka) rename to vendorExtensions
-	vendorExtensible map[string]interface{}
+	id               string
+	apiType          string
+	description      string
+	title            string
+	version          string
+	vendorExtensions map[string]interface{}
 	productionUrls   []Endpoint //
 	sandboxUrls      []Endpoint
 	resources        []Resource
@@ -96,10 +95,10 @@ func (swagger *MgwSwagger) GetXWso2Basepath() string {
 	return swagger.xWso2Basepath
 }
 
-// GetVendorExtensible returns the map of vendor extensions which are defined
+// GetVendorExtensions returns the map of vendor extensions which are defined
 // at openAPI's root level.
-func (swagger *MgwSwagger) GetVendorExtensible() map[string]interface{} {
-	return swagger.vendorExtensible
+func (swagger *MgwSwagger) GetVendorExtensions() map[string]interface{} {
+	return swagger.vendorExtensions
 }
 
 // GetProdEndpoints returns the array of production endpoints.
@@ -142,14 +141,14 @@ func (swagger *MgwSwagger) SetXWso2Extenstions() {
 }
 
 func (swagger *MgwSwagger) setXWso2PrdoductionEndpoint() {
-	xWso2APIEndpoints := getXWso2Endpoints(swagger.vendorExtensible, productionEndpoints)
+	xWso2APIEndpoints := getXWso2Endpoints(swagger.vendorExtensions, productionEndpoints)
 	if xWso2APIEndpoints != nil && len(xWso2APIEndpoints) > 0 {
 		swagger.productionUrls = xWso2APIEndpoints
 	}
 
 	//resources
 	for i, resource := range swagger.resources {
-		xwso2ResourceEndpoints := getXWso2Endpoints(resource.vendorExtensible, productionEndpoints)
+		xwso2ResourceEndpoints := getXWso2Endpoints(resource.vendorExtensions, productionEndpoints)
 		if xwso2ResourceEndpoints != nil {
 			swagger.resources[i].productionUrls = xwso2ResourceEndpoints
 		}
@@ -157,14 +156,14 @@ func (swagger *MgwSwagger) setXWso2PrdoductionEndpoint() {
 }
 
 func (swagger *MgwSwagger) setXWso2SandboxEndpoint() {
-	xWso2APIEndpoints := getXWso2Endpoints(swagger.vendorExtensible, sandboxEndpoints)
+	xWso2APIEndpoints := getXWso2Endpoints(swagger.vendorExtensions, sandboxEndpoints)
 	if xWso2APIEndpoints != nil && len(xWso2APIEndpoints) > 0 {
 		swagger.sandboxUrls = xWso2APIEndpoints
 	}
 
 	// resources
 	for i, resource := range swagger.resources {
-		xwso2ResourceEndpoints := getXWso2Endpoints(resource.vendorExtensible, sandboxEndpoints)
+		xwso2ResourceEndpoints := getXWso2Endpoints(resource.vendorExtensions, sandboxEndpoints)
 		if xwso2ResourceEndpoints != nil {
 			swagger.resources[i].sandboxUrls = xwso2ResourceEndpoints
 		}
@@ -172,11 +171,11 @@ func (swagger *MgwSwagger) setXWso2SandboxEndpoint() {
 }
 
 // getXWso2Endpoints extracts and generate the Endpoint Objects from the vendor extension map.
-func getXWso2Endpoints(vendorExtensible map[string]interface{}, endpointType string) []Endpoint {
+func getXWso2Endpoints(vendorExtensions map[string]interface{}, endpointType string) []Endpoint {
 	var endpoints []Endpoint
 
 	// TODO: (VirajSalaka) x-wso2-production-endpoint 's type does not represent http/https, instead it indicates loadbalance and failover
-	if y, found := vendorExtensible[endpointType]; found {
+	if y, found := vendorExtensions[endpointType]; found {
 		if val, ok := y.(map[string]interface{}); ok {
 			urlsProperty, ok := val[urls]
 			if !ok {
@@ -224,9 +223,9 @@ func getXWso2Endpoints(vendorExtensible map[string]interface{}, endpointType str
 
 // getXWso2Basepath extracts the value of xWso2BasePath extension.
 // if the property is not available, an empty string is returned.
-func getXWso2Basepath(vendorExtensible map[string]interface{}) string {
+func getXWso2Basepath(vendorExtensions map[string]interface{}) string {
 	xWso2basepath := ""
-	if y, found := vendorExtensible[xWso2BasePath]; found {
+	if y, found := vendorExtensions[xWso2BasePath]; found {
 		if val, ok := y.(string); ok {
 			xWso2basepath = val
 		}
@@ -235,14 +234,14 @@ func getXWso2Basepath(vendorExtensible map[string]interface{}) string {
 }
 
 func (swagger *MgwSwagger) setXWso2Basepath() {
-	extBasepath := getXWso2Basepath(swagger.vendorExtensible)
+	extBasepath := getXWso2Basepath(swagger.vendorExtensions)
 	if extBasepath != "" {
 		swagger.xWso2Basepath = extBasepath
 	}
 }
 
 func (swagger *MgwSwagger) setXWso2Cors() {
-	if cors, corsFound := swagger.vendorExtensible[xWso2Cors]; corsFound {
+	if cors, corsFound := swagger.vendorExtensions[xWso2Cors]; corsFound {
 		logger.LoggerOasparser.Debugf("%v configuration is available", xWso2Cors)
 		if parsedCors, parsedCorsOk := cors.(map[string]interface{}); parsedCorsOk {
 			//Default CorsConfiguration

--- a/adapter/pkg/oasparser/model/mgwSwagger_internal_test.go
+++ b/adapter/pkg/oasparser/model/mgwSwagger_internal_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestGetXWso2Endpoints(t *testing.T) {
 	type getXWso2EndpointsTestItem struct {
-		inputVendorExtensible map[string]interface{}
+		inputVendorExtensions map[string]interface{}
 		inputEndpointType     string
 		result                []Endpoint
 		message               string
@@ -33,7 +33,7 @@ func TestGetXWso2Endpoints(t *testing.T) {
 	dataItems := []getXWso2EndpointsTestItem{
 		{
 			inputEndpointType: "x-wso2-production-endpoints",
-			inputVendorExtensible: map[string]interface{}{"x-wso2-production-endpoints": map[string]interface{}{
+			inputVendorExtensions: map[string]interface{}{"x-wso2-production-endpoints": map[string]interface{}{
 				"type": "https", "urls": []interface{}{"https://www.facebook.com:80"}}},
 			result: []Endpoint{
 				{
@@ -46,38 +46,38 @@ func TestGetXWso2Endpoints(t *testing.T) {
 		},
 		{
 			inputEndpointType: "x-wso2-production-endpoints",
-			inputVendorExtensible: map[string]interface{}{"x-wso2-production-endpoints+++": map[string]interface{}{
+			inputVendorExtensions: map[string]interface{}{"x-wso2-production-endpoints+++": map[string]interface{}{
 				"type": "https", "urls": []interface{}{"https://www.facebook.com:80/base"}}},
 			result:  nil,
 			message: "when having incorrect extenstion name",
 		},
 	}
 	for _, item := range dataItems {
-		resultResources := getXWso2Endpoints(item.inputVendorExtensible, item.inputEndpointType)
+		resultResources := getXWso2Endpoints(item.inputVendorExtensions, item.inputEndpointType)
 		assert.Equal(t, item.result, resultResources, item.message)
 	}
 }
 
 func TestGetXWso2Basepath(t *testing.T) {
 	type getXWso2BasepathTestItem struct {
-		inputVendorExtensible map[string]interface{}
+		inputVendorExtensions map[string]interface{}
 		result                string
 		message               string
 	}
 	dataItems := []getXWso2BasepathTestItem{
 		{
-			inputVendorExtensible: map[string]interface{}{"x-wso2-basePath": "/base"},
+			inputVendorExtensions: map[string]interface{}{"x-wso2-basePath": "/base"},
 			result:                "/base",
 			message:               "usual case",
 		},
 		{
-			inputVendorExtensible: map[string]interface{}{"x-wso2-basepath+++": "/base"},
+			inputVendorExtensions: map[string]interface{}{"x-wso2-basepath+++": "/base"},
 			result:                "",
 			message:               "when having incorrect structure",
 		},
 	}
 	for _, item := range dataItems {
-		resultResources := getXWso2Basepath(item.inputVendorExtensible)
+		resultResources := getXWso2Basepath(item.inputVendorExtensions)
 		assert.Equal(t, item.result, resultResources, item.message)
 	}
 }
@@ -91,11 +91,11 @@ func TestSetXWso2PrdoductionEndpoint(t *testing.T) {
 	dataItems := []setXWso2PrdoductionEndpointTestItem{
 		{
 			input: MgwSwagger{
-				vendorExtensible: map[string]interface{}{"x-wso2-production-endpoints": map[string]interface{}{
+				vendorExtensions: map[string]interface{}{"x-wso2-production-endpoints": map[string]interface{}{
 					"type": "https", "urls": []interface{}{"https://www.facebook.com:80/base"}}},
 				resources: []Resource{
 					{
-						vendorExtensible: nil,
+						vendorExtensions: nil,
 					},
 				},
 			},
@@ -118,11 +118,11 @@ func TestSetXWso2PrdoductionEndpoint(t *testing.T) {
 		},
 		{
 			input: MgwSwagger{
-				vendorExtensible: map[string]interface{}{"x-wso2-production-endpoints": map[string]interface{}{
+				vendorExtensions: map[string]interface{}{"x-wso2-production-endpoints": map[string]interface{}{
 					"type": "https", "urls": []interface{}{"https://www.facebook.com:80/base"}}},
 				resources: []Resource{
 					{
-						vendorExtensible: map[string]interface{}{"x-wso2-production-endpoints": map[string]interface{}{
+						vendorExtensions: map[string]interface{}{"x-wso2-production-endpoints": map[string]interface{}{
 							"type": "https", "urls": []interface{}{"https://resource.endpoint:80/base"}}},
 					},
 				},

--- a/adapter/pkg/oasparser/model/openApi.go
+++ b/adapter/pkg/oasparser/model/openApi.go
@@ -44,7 +44,7 @@ func (swagger *MgwSwagger) SetInfoOpenAPI(swagger3 openapi3.Swagger) {
 		swagger.version = swagger3.Info.Version
 	}
 
-	swagger.vendorExtensible = convertExtensibletoReadableFormat(swagger3.ExtensionProps)
+	swagger.vendorExtensions = convertExtensibletoReadableFormat(swagger3.ExtensionProps)
 	swagger.resources = setResourcesOpenAPI(swagger3)
 	swagger.apiType = HTTP
 
@@ -69,7 +69,7 @@ func setPathInfoOpenAPI(path string, methods []string, pathItem *openapi3.PathIt
 			//Schemes: operation.,
 			//tags: operation.Tags,
 			//Security: operation.Security.,
-			vendorExtensible: convertExtensibletoReadableFormat(pathItem.ExtensionProps),
+			vendorExtensions: convertExtensibletoReadableFormat(pathItem.ExtensionProps),
 		}
 	}
 	return resource
@@ -179,8 +179,8 @@ func isServerURLIsAvailable(servers openapi3.Servers) bool {
 }
 
 // convertExtensibletoReadableFormat unmarshalls the vendor extensible in open api3.
-func convertExtensibletoReadableFormat(vendorExtensible openapi3.ExtensionProps) map[string]interface{} {
-	jsnRawExtensible := vendorExtensible.Extensions
+func convertExtensibletoReadableFormat(vendorExtensions openapi3.ExtensionProps) map[string]interface{} {
+	jsnRawExtensible := vendorExtensions.Extensions
 	b, err := json.Marshal(jsnRawExtensible)
 	if err != nil {
 		logger.LoggerOasparser.Error("Error marsheling vendor extenstions: ", err)

--- a/adapter/pkg/oasparser/model/swagger.go
+++ b/adapter/pkg/oasparser/model/swagger.go
@@ -40,7 +40,7 @@ func (swagger *MgwSwagger) SetInfoSwagger(swagger2 spec.Swagger) {
 		swagger.title = swagger2.Info.Title
 		swagger.version = swagger2.Info.Version
 	}
-	swagger.vendorExtensible = swagger2.VendorExtensible.Extensions
+	swagger.vendorExtensions = swagger2.VendorExtensible.Extensions
 	swagger.resources = setResourcesSwagger(swagger2)
 	swagger.apiType = HTTP
 	swagger.xWso2Basepath = swagger2.BasePath
@@ -125,7 +125,7 @@ func setOperationSwagger(path string, methods []string, pathItem spec.PathItem) 
 		//schemes:          operation.Schemes,
 		//tags:             operation.Tags,
 		//security:         operation.Security,
-		vendorExtensible: pathItem.VendorExtensible.Extensions,
+		vendorExtensions: pathItem.VendorExtensible.Extensions,
 	}
 	return resource
 }

--- a/adapter/pkg/xds/xds_server.go
+++ b/adapter/pkg/xds/xds_server.go
@@ -192,7 +192,7 @@ func UpdateAPI(byteArr []byte, upstreamCerts []byte, apiType string, environment
 	var apiMapKey string
 	var newLabels []string
 	var mgwSwagger mgw.MgwSwagger
-	vhost := "default" //TODO: update once vhost feature added
+	vhost := "default" //TODO: (SuKSW) update once vhost feature added
 
 	//TODO: (VirajSalaka) Optimize locking
 	var l sync.Mutex


### PR DESCRIPTION
### Purpose
1. Fixes #1621 - Replace multiple API maps (swagger2, swagger3, websocket) with one API map (existing mgwSwagger)
2. Rename vendorExtensible to vendorExtensions
3. Update apiMapKey to vhost:name:version

### Automation tests
 - Unit tests updated: Yes
 - Integration tests added: No

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
