### PR TITLE
Configure max inbound msg size for xds

### DIFF
--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/config/ConfigHolder.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/config/ConfigHolder.java
@@ -79,12 +79,6 @@ public class ConfigHolder {
     private void init() {
         //Load Client Trust Store
         loadTrustStore();
-        try {
-            TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-            tmf.init(trustStore);
-        } catch (NoSuchAlgorithmException | KeyStoreException e) {
-            logger.error("Error while initiating trustManagerFactory.", e);
-        }
         ConfigDiscoveryClient cds = new ConfigDiscoveryClient(envVarConfig, trustManagerFactory);
 
         try {
@@ -92,6 +86,7 @@ public class ConfigHolder {
             parseConfigs(cdsConfig);
         } catch (DiscoveryException e) {
             logger.error("Error in loading configurations from Adapter", e);
+            System.exit(1);
         }
     }
 

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/config/EnvVarConfig.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/config/EnvVarConfig.java
@@ -31,6 +31,7 @@ public class EnvVarConfig {
     private static final String ADAPTER_HOST = "ADAPTER_HOST";
     private static final String ADAPTER_XDS_PORT = "ADAPTER_XDS_PORT";
     private static final String ENFORCER_LABEL = "ENFORCER_LABEL";
+    public static final String XDS_MAX_MSG_SIZE = "XDS_MAX_MSG_SIZE";
 
     // Since the container is running in linux container, path separator is not needed.
     private static final String DEFAULT_TRUSTED_CA_CERTS_PATH = "/home/wso2/security";
@@ -40,6 +41,7 @@ public class EnvVarConfig {
     private static final String DEFAULT_ADAPTER_HOST = "adapter";
     private static final String DEFAULT_ADAPTER_XDS_PORT = "18000";
     private static final String DEFAULT_ENFORCER_LABEL = "enforcer";
+    public static final String DEFAULT_XDS_MAX_MSG_SIZE = "4194304";
 
     private String trustedAdapterCertsPath;
     private String enforcerPrivateKeyPath;
@@ -48,6 +50,7 @@ public class EnvVarConfig {
     private String enforcerLabel;
     private String adapterXdsPort;
     private String adapterHostName;
+    private final String xdsMaxMsgSize;
 
     public EnvVarConfig() {
         trustedAdapterCertsPath = retrieveEnvVarOrDefault(TRUSTED_CA_CERTS_PATH,
@@ -60,6 +63,7 @@ public class EnvVarConfig {
         adapterHost = retrieveEnvVarOrDefault(ADAPTER_HOST, DEFAULT_ADAPTER_HOST);
         adapterHostName = retrieveEnvVarOrDefault(ADAPTER_HOST_NAME, DEFAULT_ADAPTER_HOST_NAME);
         adapterXdsPort = retrieveEnvVarOrDefault(ADAPTER_XDS_PORT, DEFAULT_ADAPTER_XDS_PORT);
+        xdsMaxMsgSize = retrieveEnvVarOrDefault(XDS_MAX_MSG_SIZE, DEFAULT_XDS_MAX_MSG_SIZE);
     }
 
     private String retrieveEnvVarOrDefault(String variable, String defaultValue) {
@@ -95,5 +99,9 @@ public class EnvVarConfig {
 
     public String getAdapterHostName() {
         return adapterHostName;
+    }
+
+    public String getXdsMaxMsgSize() {
+        return xdsMaxMsgSize;
     }
 }

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/constants/Constants.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/constants/Constants.java
@@ -22,7 +22,6 @@ package org.wso2.micro.gateway.enforcer.constants;
  * This class holds the constant keys related to the Microgateway.
  */
 public class Constants {
-
     public static final String CONFIG_TYPE_URL = "type.googleapis.com/wso2.discovery.config.enforcer.Config";
     public static final String API_TYPE_URL = "type.googleapis.com/wso2.discovery.api.Api";
     public static final String SUBSCRIPTION_LIST_TYPE_URL =

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/discovery/ApiDiscoveryClient.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/discovery/ApiDiscoveryClient.java
@@ -111,7 +111,8 @@ public class ApiDiscoveryClient {
 
     public void watchApis() {
         // TODO: (Praminda) implement a deadline with retries
-        reqObserver = stub.streamApis(new StreamObserver<DiscoveryResponse>() {
+        int maxSize = Integer.parseInt(ConfigHolder.getInstance().getEnvVarConfig().getXdsMaxMsgSize());
+        reqObserver = stub.withMaxInboundMessageSize(maxSize).streamApis(new StreamObserver<DiscoveryResponse>() {
                     @Override
                     public void onNext(DiscoveryResponse response) {
                         logger.debug("Received API discovery response " + response);

--- a/resources/docker-compose.yaml
+++ b/resources/docker-compose.yaml
@@ -58,5 +58,6 @@ services:
       - ADAPTER_HOST=adapter
       - ADAPTER_XDS_PORT=18000
       - ENFORCER_LABEL=enforcer
+      - XDS_MAX_MSG_SIZE=4194304
     ports:
       - "8081:8081"   


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
If xds message is larger than the default 4MB. Enforcer will be killed during larger stream messages such as API discoveryresponse.
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1632

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, JDK version, etc... -->
Tested on Mac with default docker compose

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
