### PR TITLE
Fix #1648 - Enable Access logs for the enforcer

### DIFF
--- a/enforcer/pom.xml
+++ b/enforcer/pom.xml
@@ -135,8 +135,7 @@
                     </filters>
                     <artifactSet>
                         <excludes>
-                            <exclude>org.apache.logging.log4j:log4j-core</exclude>
-                            <exclude>org.apache.logging.log4j:log4j-api</exclude>
+                            <exclude>org.apache.logging:*</exclude>
                         </excludes>
                     </artifactSet>
                 </configuration>

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/api/config/APIConfig.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/api/config/APIConfig.java
@@ -26,7 +26,6 @@ import java.util.List;
  * Holds the metadata related to the API. Common collection to hold data about any API type like REST, gRPC and etc.
  */
 public class APIConfig {
-
     private String name;
     private String version;
     private String basePath;

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/constants/APIConstants.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/constants/APIConstants.java
@@ -67,7 +67,6 @@ public class APIConstants {
     public static final String APPLICATION_JSON = "application/json";
     public static final String API_TRACE_KEY = "X-TRACE-KEY";
 
-
     /**
      * Holds the common set of constants related to the output status codes of the security validations.
      */

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/constants/APIConstants.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/constants/APIConstants.java
@@ -62,6 +62,11 @@ public class APIConstants {
     public static final String NOT_FOUND_MESSAGE = "Not Found";
     public static final String NOT_FOUND_DESCRIPTION = "The requested resource is not available.";
 
+    //headers and values
+    public static final String CONTENT_TYPE_HEADER = "Content-type";
+    public static final String APPLICATION_JSON = "application/json";
+    public static final String API_TRACE_KEY = "X-TRACE-KEY";
+
 
     /**
      * Holds the common set of constants related to the output status codes of the security validations.

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/grpc/interceptors/AccessLogInterceptor.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/grpc/interceptors/AccessLogInterceptor.java
@@ -43,7 +43,8 @@ public class AccessLogInterceptor implements ServerInterceptor {
             EnforcerServerCall enforcerServerCall = new EnforcerServerCall(serverCall);
             ServerCall.Listener listener = serverCallHandler.startCall(enforcerServerCall, metadata);
             return new EnforcerForwardingServerCallListener<ReqT>(serverCall.getMethodDescriptor(), listener) {
-                @Override public void onMessage(ReqT message) {
+                @Override
+                public void onMessage(ReqT message) {
                     if (message instanceof CheckRequest) {
                         CheckRequest checkRequest = (CheckRequest) message;
                         enforcerServerCall.setStartTime(System.currentTimeMillis());

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/grpc/interceptors/AccessLogInterceptor.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/grpc/interceptors/AccessLogInterceptor.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.micro.gateway.enforcer.grpc.interceptors;
+
+import io.envoyproxy.envoy.service.auth.v3.CheckRequest;
+import io.envoyproxy.envoy.service.auth.v3.CheckResponse;
+import io.grpc.ForwardingServerCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Intercepts the gRPC request comes to the enforcer and logs the request access data.
+ */
+public class AccessLogInterceptor implements ServerInterceptor {
+    private static final Logger logger = LogManager.getLogger(AccessLogInterceptor.class);
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> serverCall,
+            Metadata metadata, ServerCallHandler<ReqT, RespT> serverCallHandler) {
+        if (logger.isDebugEnabled()) {
+            EnforcerServerCall enforcerServerCall = new EnforcerServerCall(serverCall);
+            ServerCall.Listener listener = serverCallHandler.startCall(enforcerServerCall, metadata);
+            return new EnforcerForwardingServerCallListener<ReqT>(serverCall.getMethodDescriptor(), listener) {
+                @Override public void onMessage(ReqT message) {
+                    if (message instanceof CheckRequest) {
+                        CheckRequest checkRequest = (CheckRequest) message;
+                        enforcerServerCall.setStartTime(System.currentTimeMillis());
+                        enforcerServerCall.setTraceId(checkRequest.getAttributes().getRequest().getHttp().getId());
+                        super.onMessage(message);
+                    }
+                }
+            };
+        }
+        return serverCallHandler.startCall(serverCall, metadata);
+    }
+
+    private class EnforcerServerCall<ReqT, RespT> extends ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT> {
+
+        ServerCall<ReqT, RespT> serverCall;
+        long startTime;
+        String traceId;
+
+        protected EnforcerServerCall(ServerCall<ReqT, RespT> serverCall) {
+            super(serverCall);
+            this.serverCall = serverCall;
+        }
+
+        @Override
+        public void sendMessage(RespT message) {
+            serverCall.sendMessage(message);
+            if (message instanceof CheckResponse) {
+                long responseTimeMillis = System.currentTimeMillis() - startTime;
+                CheckResponse checkResponse = (CheckResponse) message;
+                // log pattern -> trace ID, gRPC method name, response status code, response time
+                logger.info(String.format("%s %s %d %d", traceId, serverCall.getMethodDescriptor().getFullMethodName(),
+                        checkResponse.getStatus().getCode(), responseTimeMillis));
+            }
+        }
+
+        public void setStartTime(long startTime) {
+            this.startTime = startTime;
+        }
+
+        public void setTraceId(String traceId) {
+            this.traceId = traceId;
+        }
+    }
+
+    private class EnforcerForwardingServerCallListener<M>
+            extends io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener<M> {
+        String methodName;
+
+        protected EnforcerForwardingServerCallListener(MethodDescriptor method, ServerCall.Listener<M> listener) {
+            super(listener);
+            methodName = method.getFullMethodName();
+        }
+    }
+}
+

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/security/AuthFilter.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/security/AuthFilter.java
@@ -59,7 +59,9 @@ public class AuthFilter implements Filter {
         } catch (APISecurityException e) {
             //TODO: (VirajSalaka) provide the error code properly based on exception (401, 403, 429 etc)
             FilterUtils.setErrorToContext(requestContext, e);
+            return false;
         }
+        FilterUtils.setUnauthenticatedErrorToContext(requestContext);
         return false;
     }
 

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/util/FilterUtils.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/util/FilterUtils.java
@@ -204,7 +204,7 @@ public class FilterUtils {
      * retrieve this error details from the request context. Make sure to call this method and set the proper error
      * details when enforcer filters returns an error.
      *
-     * @param requestContext - The context object holds detals about the specific request.
+     * @param requestContext - The context object holds details about the specific request.
      * @param e - APISecurityException thrown when validation failure happens at filter level.
      */
     public static void setErrorToContext(RequestContext requestContext, APISecurityException e) {
@@ -223,6 +223,25 @@ public class FilterUtils {
             requestContext.getProperties().put(APIConstants.MessageFormat.ERROR_DESCRIPTION,
                     APISecurityConstants.getFailureMessageDetailDescription(e.getErrorCode(), e.getMessage()));
         }
+    }
+
+    /**
+     * Set the unauthenticated status code(401), error code(900901), message and description to the request context.
+     * The enforcer response will retrieve this error details from the request context. Make sure to call
+     * this method and set the proper error details when enforcer filters returns an error.
+     *
+     * @param requestContext - The context object holds details about the specific request.
+     */
+    public static void setUnauthenticatedErrorToContext(RequestContext requestContext) {
+        requestContext.getProperties()
+                .put(APIConstants.MessageFormat.STATUS_CODE, APIConstants.StatusCodes.UNAUTHENTICATED.getCode());
+        requestContext.getProperties()
+                .put(APIConstants.MessageFormat.ERROR_CODE, APISecurityConstants.API_AUTH_INVALID_CREDENTIALS);
+        requestContext.getProperties().put(APIConstants.MessageFormat.ERROR_MESSAGE, APISecurityConstants
+                .getAuthenticationFailureMessage(APISecurityConstants.API_AUTH_INVALID_CREDENTIALS));
+        requestContext.getProperties().put(APIConstants.MessageFormat.ERROR_DESCRIPTION,
+                APISecurityConstants.API_AUTH_INVALID_CREDENTIALS_DESCRIPTION);
+
     }
 
 }

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/util/FilterUtils.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/util/FilterUtils.java
@@ -241,7 +241,6 @@ public class FilterUtils {
                 .getAuthenticationFailureMessage(APISecurityConstants.API_AUTH_INVALID_CREDENTIALS));
         requestContext.getProperties().put(APIConstants.MessageFormat.ERROR_DESCRIPTION,
                 APISecurityConstants.API_AUTH_INVALID_CREDENTIALS_DESCRIPTION);
-
     }
 
 }

--- a/enforcer/src/main/resources/Dockerfile
+++ b/enforcer/src/main/resources/Dockerfile
@@ -59,4 +59,4 @@ USER ${MG_USER}
 COPY maven/ lib/
 COPY maven/conf conf
 COPY maven/security security
-CMD java $JAVA_OPTS -Dlog4j.configurationFile="/home/wso2/conf/log4j2.properties" -cp "lib/*" org.wso2.micro.gateway.enforcer.server.AuthServer
+CMD java $JAVA_OPTS -Dlog4j.configurationFile="${ENFORCER_HOME}/conf/log4j2.properties" -cp "lib/*" org.wso2.micro.gateway.enforcer.server.AuthServer

--- a/enforcer/src/main/resources/Dockerfile
+++ b/enforcer/src/main/resources/Dockerfile
@@ -49,7 +49,7 @@ ARG MOTD="\n\
 RUN \
     addgroup -S -g ${MG_USER_GROUP_ID} ${MG_USER_GROUP} \
     && adduser -S -u ${MG_USER_ID} -h ${MG_USER_HOME} -G ${MG_USER_GROUP} ${MG_USER} \
-    && mkdir ${MG_USER_HOME}/lib && mkdir -p ${MG_USER_HOME}/mg/security \
+    && mkdir ${MG_USER_HOME}/lib && mkdir -p ${MG_USER_HOME}/mg/security && mkdir -p ${MG_USER_HOME}/mg/logs  \
     && echo '[ ! -z "${TERM}" -a -r /etc/motd ] && cat /etc/motd' >> /etc/bash.bashrc; echo "${MOTD}" > /etc/motd
 
 WORKDIR ${MG_USER_HOME}
@@ -59,4 +59,4 @@ USER ${MG_USER}
 COPY maven/ lib/
 COPY maven/conf conf
 COPY maven/security security
-CMD java $JAVA_OPTS -Dlog4j.configurationFile="${ENFORCER_HOME}/conf/log4j2.properties" -cp "lib/*" org.wso2.micro.gateway.enforcer.server.AuthServer
+CMD java $JAVA_OPTS -Dlog4j.configurationFile="/home/wso2/conf/log4j2.properties" -cp "lib/*" org.wso2.micro.gateway.enforcer.server.AuthServer

--- a/resources/conf/log4j2.properties
+++ b/resources/conf/log4j2.properties
@@ -1,4 +1,6 @@
-appenders = MGW_CONSOLE, MGW_LOGFILE
+monitorInterval=20
+
+appenders = MGW_CONSOLE, MGW_LOGFILE, MGW_ACCESS_LOG
 
 appender.MGW_CONSOLE.type = Console
 appender.MGW_CONSOLE.name = MGW_CONSOLE
@@ -10,7 +12,7 @@ appender.MGW_CONSOLE.filter.threshold.level = DEBUG
 appender.MGW_LOGFILE.type = RollingFile
 appender.MGW_LOGFILE.name = MGW_LOGFILE
 appender.MGW_LOGFILE.fileName = logs/enforcer.log
-appender.MGW_LOGFILE.filePattern = /logs/wso2MGW-%d{MM-dd-yyyy}.log
+appender.MGW_LOGFILE.filePattern = /logs/enforcer-%d{MM-dd-yyyy}.log
 appender.MGW_LOGFILE.layout.type = PatternLayout
 appender.MGW_LOGFILE.layout.pattern = [%d] %5p {%c} - [%m%ex%n]
 appender.MGW_LOGFILE.policies.type = Policies
@@ -24,8 +26,33 @@ appender.MGW_LOGFILE.strategy.max = 20
 appender.MGW_LOGFILE.filter.threshold.type = ThresholdFilter
 appender.MGW_LOGFILE.filter.threshold.level = DEBUG
 
+appender.MGW_ACCESS_LOG.type = RollingFile
+appender.MGW_ACCESS_LOG.name = MGW_ACCESS_LOG
+appender.MGW_ACCESS_LOG.fileName = logs/enforcer_access.log
+appender.MGW_ACCESS_LOG.filePattern = /logs/enforcer_access-%d{MM-dd-yyyy}.log
+appender.MGW_ACCESS_LOG.layout.type = PatternLayout
+appender.MGW_ACCESS_LOG.layout.pattern = [%d] - %m%ex%n
+appender.MGW_ACCESS_LOG.policies.type = Policies
+appender.MGW_ACCESS_LOG.policies.time.type = TimeBasedTriggeringPolicy
+appender.MGW_ACCESS_LOG.policies.time.interval = 1
+appender.MGW_ACCESS_LOG.policies.time.modulate = true
+appender.MGW_ACCESS_LOG.policies.size.type = SizeBasedTriggeringPolicy
+appender.MGW_ACCESS_LOG.policies.size.size=10MB
+appender.MGW_ACCESS_LOG.strategy.type = DefaultRolloverStrategy
+appender.MGW_ACCESS_LOG.strategy.max = 20
+appender.MGW_ACCESS_LOG.filter.threshold.type = ThresholdFilter
+appender.MGW_ACCESS_LOG.filter.threshold.level = DEBUG
 
-loggers = mgw-enforcer, io-swagger-v3
+
+loggers = mgw-enforcer, io-swagger-v3, mgw-enforcer-interceptors
+
+# Log to access log file
+logger.mgw-enforcer-interceptors.name = org.wso2.micro.gateway.enforcer.grpc.interceptors
+# Change the log level into DEBUG to view the access logs.
+logger.mgw-enforcer-interceptors.level = INFO
+logger.mgw-enforcer-interceptors.additivity = false
+logger.mgw-enforcer-interceptors.appenderRef.rolling.ref = MGW_ACCESS_LOG
+
 # Log to console and rolling file
 logger.mgw-enforcer.name = org.wso2.micro.gateway.enforcer
 logger.mgw-enforcer.level = INFO
@@ -42,3 +69,4 @@ logger.io-swagger-v3.appenderRef.console.ref = MGW_CONSOLE
 rootLogger.level = ERROR
 rootLogger.appenderRef.MGW_CONSOLE.ref = MGW_CONSOLE
 rootLogger.appenderRef.MGW_LOGFILE.ref = MGW_LOGFILE
+rootLogger.appenderRef.MGW_ACCESS_LOG.ref = MGW_ACCESS_LOG

--- a/resources/conf/log4j2.properties
+++ b/resources/conf/log4j2.properties
@@ -43,7 +43,6 @@ appender.MGW_ACCESS_LOG.strategy.max = 20
 appender.MGW_ACCESS_LOG.filter.threshold.type = ThresholdFilter
 appender.MGW_ACCESS_LOG.filter.threshold.level = DEBUG
 
-
 loggers = mgw-enforcer, io-swagger-v3, mgw-enforcer-interceptors
 
 # Log to access log file


### PR DESCRIPTION
### Purpose
In the log4j2.properties file following logger is added.
```
# Log to access log file
logger.mgw-enforcer-interceptors.name = org.wso2.micro.gateway.enforcer.grpc.interceptors
# Change the log level into DEBUG to view the access logs.
logger.mgw-enforcer-interceptors.level = INFO
logger.mgw-enforcer-interceptors.additivity = false
logger.mgw-enforcer-interceptors.appenderRef.rolling.ref = MGW_ACCESS_LOG
```

By default access logs will not prints. By making the value `logger.mgw-enforcer-interceptors.level` to `DEBUG` in the above config will enable access logs without restarting the enforcer.

The access log format will be as follow. It will print the `server time`, `trace Id from envoy`, `gRPC service method`, `gRPC status code`, `response time`
```
[2021-02-19 07:48:49,505] - 5920896249661898188 envoy.service.auth.v3.Authorization/Check 16 34
[2021-02-19 07:48:52,592] - 17895662172888229144 envoy.service.auth.v3.Authorization/Check 16 7
[2021-02-19 07:49:53,789] - 5900610984790867879 envoy.service.auth.v3.Authorization/Check 16 2
[2021-02-19 07:52:41,886] - 15440112743963585656 envoy.service.auth.v3.Authorization/Check 16 4
```

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1648 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
