### PR TITLE
Update K8s configs for MG 4.0.0-m7

### DIFF
--- a/resources/k8s-artifacts/mg-adapter/config-toml-configmap.yaml
+++ b/resources/k8s-artifacts/mg-adapter/config-toml-configmap.yaml
@@ -30,7 +30,7 @@ data:
 
     [[adapter.server.users]]
     username = "admin"
-    password = "admin"
+    password = "$env{adapter_admin_pwd}"
 
     [adapter.keystore]
     certPath = "/home/wso2/security/keystore/mg.pem"
@@ -98,10 +98,19 @@ data:
         consumerKeyClaim = "azp"
         # Certificate Filepath within enforcer
         certificateFilePath = "/home/wso2/security/truststore/wso2carbon.pem"
+        [[enforcer.jwtTokenConfig.claimMapping]]
+            remoteClaim = "sub"
+            localClaim = "CUSTOM-CLAIM"
+
 
     [enforcer.apimCredentials]
         username="admin"
-        password="admin"
+        password="$env{apim_admin_pwd}"
+
+    [enforcer.cache]
+      enabled = true
+      maximumSize = 10000
+      expiryTime = 15
 
     [enforcer.jwtGenerator]
         enable = false
@@ -122,10 +131,10 @@ data:
     enabled = false
     serviceUrl = "https://localhost:9443/"
     username="admin"
-    password="admin"
+    password="$env{cp_admin_pwd}"
     environmentLabels = ["Production and Sandbox"]
     retryInterval = 5
     skipSSLVerification=true
     # Message broker connection URL of the control plane
     [controlPlane.eventHub.jmsConnectionParameters]
-    eventListeningEndpoints = "amqp://admin:admin@localhost:5672/"
+    eventListeningEndpoints = ["amqp://admin:admin@localhost:5672?retries='5'&connectdelay='30000'"]

--- a/resources/k8s-artifacts/mg-adapter/deployment.yaml
+++ b/resources/k8s-artifacts/mg-adapter/deployment.yaml
@@ -48,8 +48,13 @@ spec:
             - mountPath: /home/wso2/conf/log_config.toml
               subPath: log_config.toml
               name: logconfig-toml-vol
-          image: wso2/mg-adapter:4.0.0-m6
+          image: wso2/mg-adapter:4.0.0-m7
           imagePullPolicy: Always
+          env:
+            - name: cp_admin_pwd
+              value: "admin"
+            - name: adapter_admin_pwd
+              value: "admin"
           resources:
             requests:
               memory: "250Mi"

--- a/resources/k8s-artifacts/mg-enforcer/deployment.yaml
+++ b/resources/k8s-artifacts/mg-enforcer/deployment.yaml
@@ -50,7 +50,9 @@ spec:
             - mountPath: /home/wso2/conf/log_config.toml
               subPath: log_config.toml
               name: logconfig-toml-vol
-          image: wso2/mg-enforcer:4.0.0-m6
+            - mountPath: /home/wso2/lib/dropins
+              name: dropins-vol
+          image: wso2/mg-enforcer:4.0.0-m7
           imagePullPolicy: Always
           env:
             - name: ENFORCER_PRIVATE_KEY_PATH
@@ -71,6 +73,8 @@ spec:
               value: "4194304"
             - name: JAVA_OPTS
               value: ""
+            - name: apim_admin_pwd
+              value: "admin"
           resources:
             requests:
               memory: "250Mi"
@@ -106,4 +110,6 @@ spec:
         - name: logconfig-toml-vol
           configMap:
             name: logconfig-toml
+        - name: dropins-vol
+          emptyDir: {}
       restartPolicy: Always

--- a/resources/k8s-artifacts/mg-router/deployment.yaml
+++ b/resources/k8s-artifacts/mg-router/deployment.yaml
@@ -37,7 +37,7 @@ spec:
               name: router-keystore-vol
             - mountPath: /home/wso2/security/truststore
               name: router-truststore-vol
-          image: wso2/mg-router:4.0.0-m6
+          image: wso2/mg-router:4.0.0-m7
           imagePullPolicy: Always
           env:
             - name: ROUTER_ADMIN_HOST


### PR DESCRIPTION
### Purpose
$subject

```
$ apictl init petstore --oas https://petstore.swagger.io/v2/swagger.json
Initializing a new WSO2 API Manager project in /Users/renuka/git/product-microgateway/distribution/target/wso2am-micro-gw-4.0.0-m7/resources/k8s-artifacts/petstore
Project initialized
Open README file to learn more

$ apictl mg deploy --host https://localhost:30200 --file petstore  -u admin -p admin -k
Successfully imported API.

$ curl -X GET "https://localhost:30201/v2/pet/1" -H "accept: application/json" -H "Authorization:Bearer $TOKEN" -k
{"id":1,"category":{"id":1,"name":"Dog"},"name":"Butch","photoUrls":[],"tags":[],"status":"available"}

$ k get po
NAME                           READY   STATUS    RESTARTS   AGE
mg-adapter-8564898c65-x55hn    1/1     Running   0          78s
mg-enforcer-67488f667d-zwdc4   1/1     Running   0          78s
mg-router-6bfb654fff-f99jc     1/1     Running   0          78s
```

### Issues
Fixes https://github.com/wso2/product-microgateway/issues/1689

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
K8s - Docker Desktop

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
