### PR TITLE
Add Retry-After header to throttle response

### DIFF
--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/api/RequestContext.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/api/RequestContext.java
@@ -137,6 +137,7 @@ public class RequestContext {
             requestContext.authenticationContext = this.authenticationContext;
             requestContext.requestID = this.requestID;
             requestContext.clientIp = this.clientIp;
+            requestContext.responseHeaders = new HashMap<>();
             String[] queryParts = this.requestPath.split("\\?");
             String queryPrams = queryParts.length > 1 ? queryParts[1] : "";
 

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/api/RestAPI.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/api/RestAPI.java
@@ -74,7 +74,7 @@ public class RestAPI implements API {
         ResponseObject responseObject = new ResponseObject();
         if (executeFilterChain(requestContext)) {
             responseObject.setStatusCode(APIConstants.StatusCodes.OK.getCode());
-            if (requestContext.getResponseHeaders() != null) {
+            if (requestContext.getResponseHeaders() != null && requestContext.getResponseHeaders().size() > 0) {
                 responseObject.setHeaderMap(requestContext.getResponseHeaders());
             }
         } else {

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/grpc/ExtAuthService.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/grpc/ExtAuthService.java
@@ -46,8 +46,8 @@ public class ExtAuthService extends AuthorizationGrpc.AuthorizationImplBase {
     @Override
     public void check(CheckRequest request, StreamObserver<CheckResponse> responseObserver) {
         ResponseObject responseObject = requestHandler.process(request, responseObserver);
-        CheckResponse response1 = buildResponse(request, responseObject);
-        responseObserver.onNext(response1);
+        CheckResponse response = buildResponse(request, responseObject);
+        responseObserver.onNext(response);
         // When you are done, you must call onCompleted.
         responseObserver.onCompleted();
     }
@@ -57,8 +57,7 @@ public class ExtAuthService extends AuthorizationGrpc.AuthorizationImplBase {
         HttpStatus status = HttpStatus.newBuilder().setCodeValue(responseObject.getStatusCode()).build();
         String traceKey = request.getAttributes().getRequest().getHttp().getId();
         if (responseObject.isDirectResponse()) {
-            // To handle pre flight options request
-            if (responseObject.getStatusCode() == HttpConstants.NO_CONTENT_STATUS_CODE) {
+            if (responseObject.getHeaderMap() != null) {
                 responseObject.getHeaderMap().forEach((key, value) -> {
                             HeaderValueOption headerValueOption = HeaderValueOption.newBuilder()
                                     .setHeader(HeaderValue.newBuilder().setKey(key).setValue(value).build())
@@ -66,6 +65,9 @@ public class ExtAuthService extends AuthorizationGrpc.AuthorizationImplBase {
                             responseBuilder.addHeaders(headerValueOption);
                         }
                 );
+            }
+            // To handle pre flight options request
+            if (responseObject.getStatusCode() == HttpConstants.NO_CONTENT_STATUS_CODE) {
                 return CheckResponse.newBuilder()
                         .setStatus(Status.newBuilder().setCode(getCode(responseObject.getStatusCode())))
                         .setDeniedResponse(responseBuilder.setStatus(status).build())
@@ -101,7 +103,7 @@ public class ExtAuthService extends AuthorizationGrpc.AuthorizationImplBase {
             HeaderValueOption headerValueOption = HeaderValueOption.newBuilder()
                     .setHeader(HeaderValue.newBuilder().setKey(APIConstants.API_TRACE_KEY).setValue(traceKey).build())
                     .build();
-            responseBuilder.addHeaders(headerValueOption);
+            okResponseBuilder.addHeaders(headerValueOption);
             return CheckResponse.newBuilder().setStatus(Status.newBuilder().setCode(Code.OK_VALUE).build())
                     .setOkResponse(okResponseBuilder.build()).build();
         }

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/throttle/ThrottleConstants.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/throttle/ThrottleConstants.java
@@ -57,4 +57,6 @@ public class ThrottleConstants {
     public static final String EVALUATED_CONDITIONS = "evaluatedConditions";
     public static final String TRUE = "true";
     public static final String DEFAULT_THROTTLE_CONDITION = "default";
+    public static final String HEADER_RETRY_AFTER = "Retry-After";
+    public static final String GMT = "GMT";
 }

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/throttle/ThrottleDataHolder.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/throttle/ThrottleDataHolder.java
@@ -18,12 +18,21 @@
 
 package org.wso2.micro.gateway.enforcer.throttle;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.wso2.micro.gateway.enforcer.api.RequestContext;
+import org.wso2.micro.gateway.enforcer.config.ConfigHolder;
+import org.wso2.micro.gateway.enforcer.config.dto.ThrottleConfigDto;
+import org.wso2.micro.gateway.enforcer.throttle.dto.Decision;
+import org.wso2.micro.gateway.enforcer.util.FilterUtils;
 
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * This class holds throttle data per given node. In addition to holding throttle data if provides
@@ -112,21 +121,251 @@ public class ThrottleDataHolder {
      * </ol>
      *
      * @param key throttle key
-     * @return {@code true} if event is throttled {@code false} if event is not throttled.
+     * @return throttle {@link Decision} defining the whether request is throttled or not
      */
-    public boolean isThrottled(String key) {
-        boolean isThrottled = this.throttleDataMap.containsKey(key);
+    public Decision isThrottled(String key) {
+        Decision decision = new Decision();
+        Long timestamp = this.throttleDataMap.get(key);
 
-        if (isThrottled) {
+        if (timestamp != null) {
             long currentTime = System.currentTimeMillis();
-            long timestamp = this.throttleDataMap.get(key);
+            decision.setThrottled(true);
+            decision.setResetAt(timestamp);
+
             if (timestamp < currentTime) {
                 this.throttleDataMap.remove(key);
-                isThrottled = false;
+                decision.setThrottled(false);
+            }
+        }
+
+        return decision;
+    }
+
+    /**
+     * Decide whether {@code key} is throttled or not by the traffic manager.
+     * This function is defined to evaluate only API and Resource level throttling
+     * decisions received from the traffic manager.
+     *
+     * @param key     throttle key to evaluate the throttle decision
+     * @param context RequestContext of the evaluated request
+     * @return throttle {@link Decision}
+     */
+    public Decision isAdvancedThrottled(String key, RequestContext context) {
+        String conditionKey = null;
+        Decision decision = new Decision();
+        Map<String, List<ThrottleCondition>> conditionGrps = conditionDtoMap.get(key);
+        List<ThrottleCondition> defaultGrp = null;
+
+        if (conditionGrps == null) {
+            return decision;
+        }
+
+        log.debug("Found throttle condition in condition map");
+        // iterate through all available conditions and find if the current request
+        // attributes are eligible to be throttled by the available throttled conditions
+        for (String name : conditionGrps.keySet()) {
+            if (!ThrottleConstants.DEFAULT_THROTTLE_CONDITION.equals(name)) {
+                boolean isPipelineThrottled = isThrottledByCondition(conditionGrps.get(name), context);
+                if (isPipelineThrottled) {
+                    conditionKey = name;
+                    break;
+                }
+            } else {
+                defaultGrp = conditionGrps.get(name);
+            }
+        }
+
+        if (conditionKey == null && defaultGrp != null) {
+            boolean isPipelineThrottled = isThrottledByCondition(defaultGrp, context);
+            if (!isPipelineThrottled) {
+                conditionKey = ThrottleConstants.DEFAULT_THROTTLE_CONDITION;
+            }
+        }
+
+        // if we detect the request is throttled by a condition. Then check the validity of throttle
+        // decision from the throttle event data available in the throttleDataMap
+        if (conditionKey != null) {
+            log.debug("Found throttled pipeline with condition: {}", conditionKey);
+            String combinedThrottleKey = key + '_' + conditionKey;
+
+            // if throttle data is not available for the combined key, conditional throttle decision
+            // is no longer valid
+            Long timestamp = throttleDataMap.get(combinedThrottleKey);
+            if (timestamp == null) {
+                return decision;
+            }
+
+            long currentTime = System.currentTimeMillis();
+            if (timestamp < currentTime) {
+                this.throttleDataMap.remove(key);
+                this.conditionDtoMap.remove(key);
+                return decision;
+            }
+
+            decision.setThrottled(true);
+            decision.setResetAt(timestamp);
+            return decision;
+        }
+
+        return decision;
+    }
+
+    /**
+     * Check if the request is throttled by an advanced throttle condition.
+     * Such as IP, header, query param based conditions.
+     *
+     * @param conditions throttled conditions received from global throttle engine
+     * @param req        RequestContext containing all required information about the evaluated request.
+     * @return {@code true} if throttled by a condition, {@code false} otherwise
+     */
+    private boolean isThrottledByCondition(List<ThrottleCondition> conditions, RequestContext req) {
+        boolean isThrottled = false;
+        ThrottleConfigDto conf = ConfigHolder.getInstance().getConfig().getThrottleConfig();
+
+        for (ThrottleCondition condition : conditions) {
+            // We initially set throttled flag to true. Then we move onto evaluating all conditions and
+            // set the flag to false accordingly. This is done in this way to implement the `AND` logic
+            // between each condition inside a condition group.
+            isThrottled = true;
+            ThrottleCondition.HeaderConditions headerConditions = condition.getHeaderConditions();
+            ThrottleCondition.IPCondition ipCondition = condition.getIpCondition();
+            ThrottleCondition.IPCondition ipRangeCondition = condition.getIpRangeCondition();
+            ThrottleCondition.QueryParamConditions queryConditions = condition.getQueryParameterConditions();
+            ThrottleCondition.JWTClaimConditions claimConditions = condition.getJwtClaimConditions();
+
+            if (ipCondition != null) {
+                if (!isMatchingIp(req.getClientIp(), ipCondition)) {
+                    isThrottled = false;
+                }
+            } else if (ipRangeCondition != null) {
+                if (!isWithinIpRange(req.getClientIp(), ipRangeCondition)) {
+                    isThrottled = false;
+                }
+            }
+            if (conf.isHeaderConditionsEnabled()
+                    && headerConditions != null && !headerConditions.getValues().isEmpty()) {
+                if (!isHeaderPresent(req, headerConditions)) {
+                    isThrottled = false;
+                }
+            }
+            if (conf.isQueryConditionsEnabled()
+                    && queryConditions != null && !queryConditions.getValues().isEmpty()) {
+                if (!isQueryParamPresent(req, queryConditions)) {
+                    isThrottled = false;
+                }
+            }
+            if (conf.isJwtClaimConditionsEnabled()
+                    && (claimConditions != null && !claimConditions.getValues().isEmpty())) {
+                if (!isJwtClaimPresent(req, claimConditions)) {
+                    isThrottled = false;
+                }
+            }
+
+            if (isThrottled) {
+                break;
             }
         }
 
         return isThrottled;
     }
 
+    private boolean isMatchingIp(String clientIp, ThrottleCondition.IPCondition ipCondition) {
+        BigInteger longIp = FilterUtils.ipToBigInteger(clientIp);
+        boolean isMatched = (longIp.equals(ipCondition.getSpecificIp()));
+
+        if (ipCondition.isInvert()) {
+            return !isMatched;
+        }
+
+        return isMatched;
+    }
+
+    private boolean isWithinIpRange(String clientIp, ThrottleCondition.IPCondition ipCondition) {
+        boolean status;
+
+        if (StringUtils.isEmpty(clientIp)) {
+            return false;
+        }
+
+        BigInteger currentIp = FilterUtils.ipToBigInteger(clientIp);
+        status = ipCondition.getStartingIp().compareTo(currentIp) <= 0
+                && ipCondition.getEndingIp().compareTo(currentIp) >= 0;
+
+        if (ipCondition.isInvert()) {
+            return !status;
+        }
+
+        return status;
+    }
+
+    private boolean isHeaderPresent(RequestContext req, ThrottleCondition.HeaderConditions conditions) {
+        boolean status = true;
+        Map<String, String> headers = req.getHeaders();
+
+        for (Map.Entry<String, String> entry : conditions.getValues().entrySet()) {
+            if (headers != null) {
+                String value = headers.get(entry.getKey());
+
+                if (StringUtils.isEmpty(value)) {
+                    status = false;
+                    break;
+                }
+                Pattern pattern = Pattern.compile(entry.getValue());
+                Matcher matcher = pattern.matcher(value);
+                status = status && matcher.find();
+            }
+        }
+
+        if (conditions.isInvert()) {
+            return !status;
+        }
+
+        return status;
+    }
+
+    private boolean isJwtClaimPresent(RequestContext req, ThrottleCondition.JWTClaimConditions conditions) {
+        Map<String, String> assertions = ThrottleUtils.getJWTClaims(req.getAuthenticationContext().getCallerToken());
+        boolean status = true;
+
+        for (Map.Entry<String, String> jwtClaim : conditions.getValues().entrySet()) {
+            String value = assertions.get(jwtClaim.getKey());
+            if (value == null) {
+                status = false;
+                break;
+            }
+
+            Pattern pattern = Pattern.compile(jwtClaim.getValue());
+            Matcher matcher = pattern.matcher(value);
+            status = status && matcher.find();
+        }
+
+        if (conditions.isInvert()) {
+            return !status;
+        }
+
+        return status;
+    }
+
+    private boolean isQueryParamPresent(RequestContext req, ThrottleCondition.QueryParamConditions condition) {
+        Map<String, String> queryParamMap = req.getQueryParameters();
+        boolean status = true;
+
+        for (Map.Entry<String, String> queryParam : condition.getValues().entrySet()) {
+            String value = queryParamMap.get(queryParam.getKey());
+            if (value == null) {
+                status = false;
+                break;
+            }
+
+            Pattern pattern = Pattern.compile(queryParam.getValue());
+            Matcher matcher = pattern.matcher(value);
+            status = status && matcher.find();
+        }
+
+        if (condition.isInvert()) {
+            return !status;
+        }
+
+        return status;
+    }
 }

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/throttle/ThrottleFilter.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/throttle/ThrottleFilter.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.micro.gateway.enforcer.throttle;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
@@ -29,6 +30,7 @@ import org.wso2.micro.gateway.enforcer.config.dto.ThrottleConfigDto;
 import org.wso2.micro.gateway.enforcer.constants.APIConstants;
 import org.wso2.micro.gateway.enforcer.security.AuthenticationContext;
 import org.wso2.micro.gateway.enforcer.throttle.databridge.agent.util.ThrottleEventConstants;
+import org.wso2.micro.gateway.enforcer.throttle.dto.Decision;
 import org.wso2.micro.gateway.enforcer.util.FilterUtils;
 
 import java.net.Inet4Address;
@@ -85,36 +87,44 @@ public class ThrottleFilter implements Filter {
         if (reqContext.getAuthenticationContext() != null) {
             log.debug("Found AuthenticationContext for the request");
             APIConfig api = reqContext.getMathedAPI().getAPIConfig();
-            String apiContext = api.getBasePath() + '/' + api.getVersion();
+            String apiContext = api.getBasePath();
             String apiVersion = api.getVersion();
             String appId = authContext.getApplicationId();
-            String apiTier = getApiTier(api, authContext.getTier());
+            String apiTier = getApiTier(api);
             String apiThrottleKey = getApiThrottleKey(apiContext, apiVersion);
             String resourceTier = getResourceTier(reqContext.getMatchedResourcePath());
             String resourceThrottleKey = getResourceThrottleKey(reqContext, apiContext, apiVersion);
             String subTier = authContext.getTier();
             String appTier = authContext.getApplicationTier();
+            boolean isApiLevelTriggered = false;
 
-            if (isAPILevelThrottled(apiThrottleKey, apiTier)) {
-                FilterUtils.setThrottleErrorToContext(reqContext,
-                        ThrottleConstants.API_THROTTLE_OUT_ERROR_CODE,
-                        ThrottleConstants.THROTTLE_OUT_MESSAGE,
+            if (!StringUtils.isEmpty(apiTier) && !ThrottleConstants.UNLIMITED_TIER.equalsIgnoreCase(apiTier)) {
+                resourceThrottleKey = apiThrottleKey;
+                resourceTier = apiTier;
+                isApiLevelTriggered = true;
+            }
+
+            // Checking API and Resource level throttling. If API tier is defined,
+            // we ignore the resource level tier definition.
+            Decision apiDecision = checkResourceThrottled(resourceThrottleKey, resourceTier, reqContext);
+            if (apiDecision.isThrottled()) {
+                int errorCode;
+                if (isApiLevelTriggered) {
+                    errorCode = ThrottleConstants.API_THROTTLE_OUT_ERROR_CODE;
+                } else {
+                    errorCode = ThrottleConstants.RESOURCE_THROTTLE_OUT_ERROR_CODE;
+                }
+                FilterUtils.setThrottleErrorToContext(reqContext, errorCode, ThrottleConstants.THROTTLE_OUT_MESSAGE,
                         ThrottleConstants.THROTTLE_OUT_DESCRIPTION);
                 reqContext.getProperties().put(ThrottleConstants.THROTTLE_OUT_REASON,
                         ThrottleConstants.THROTTLE_OUT_REASON_API_LIMIT_EXCEEDED);
-                return true;
-            } else if (isResourceLevelThrottled(resourceThrottleKey, resourceTier)) {
-                FilterUtils.setThrottleErrorToContext(reqContext,
-                        ThrottleConstants.RESOURCE_THROTTLE_OUT_ERROR_CODE,
-                        ThrottleConstants.THROTTLE_OUT_MESSAGE,
-                        ThrottleConstants.THROTTLE_OUT_DESCRIPTION);
-                reqContext.getProperties().put(ThrottleConstants.THROTTLE_OUT_REASON,
-                        ThrottleConstants.THROTTLE_OUT_REASON_RESOURCE_LIMIT_EXCEEDED);
+                ThrottleUtils.setRetryAfterHeader(reqContext, apiDecision.getResetAt());
                 return true;
             }
+
             String subThrottleKey = getSubscriptionThrottleKey(appId, apiContext, apiVersion);
-            boolean isSubscriptionThrottled = isSubscriptionLevelThrottled(subThrottleKey, subTier);
-            if (isSubscriptionThrottled) {
+            Decision subDecision = checkSubscriptionLevelThrottled(subThrottleKey, subTier);
+            if (subDecision.isThrottled()) {
                 if (authContext.isStopOnQuotaReach()) {
                     log.debug("Setting subscription throttle out response");
                     FilterUtils.setThrottleErrorToContext(reqContext,
@@ -123,14 +133,15 @@ public class ThrottleFilter implements Filter {
                             ThrottleConstants.THROTTLE_OUT_DESCRIPTION);
                     reqContext.getProperties().put(ThrottleConstants.THROTTLE_OUT_REASON,
                             ThrottleConstants.THROTTLE_OUT_REASON_SUBSCRIPTION_LIMIT_EXCEEDED);
+                    ThrottleUtils.setRetryAfterHeader(reqContext, subDecision.getResetAt());
                     return true;
                 }
                 log.debug("Proceeding since stopOnQuotaReach is false");
             }
 
             String appThrottleKey = appId + ':' + authContext.getUsername();
-            boolean isAppThrottled = isAppLevelThrottled(appThrottleKey, appTier);
-            if (isAppThrottled) {
+            Decision appDecision = checkAppLevelThrottled(appThrottleKey, appTier);
+            if (appDecision.isThrottled()) {
                 log.debug("Setting application throttle out response");
                 FilterUtils.setThrottleErrorToContext(reqContext,
                         ThrottleConstants.APPLICATION_THROTTLE_OUT_ERROR_CODE,
@@ -138,65 +149,42 @@ public class ThrottleFilter implements Filter {
                         ThrottleConstants.THROTTLE_OUT_DESCRIPTION);
                 reqContext.getProperties().put(ThrottleConstants.THROTTLE_OUT_REASON,
                         ThrottleConstants.THROTTLE_OUT_REASON_APPLICATION_LIMIT_EXCEEDED);
+                ThrottleUtils.setRetryAfterHeader(reqContext, appDecision.getResetAt());
                 return true;
             }
         }
         return false;
     }
 
-    private boolean isSubscriptionLevelThrottled(String throttleKey, String tier) {
-        boolean isThrottled = dataHolder.isThrottled(throttleKey);
-        log.debug("Subscription Level throttle decision is {} for key:tier {}:{}", isThrottled, throttleKey, tier);
-        return isThrottled;
+    private Decision checkSubscriptionLevelThrottled(String throttleKey, String tier) {
+        Decision decision = dataHolder.isThrottled(throttleKey);
+        log.debug("Subscription Level throttle decision is {} for key:tier {}:{}", decision.isThrottled(),
+                throttleKey, tier);
+        return decision;
     }
 
-    private boolean isAppLevelThrottled(String throttleKey, String tier) {
-        boolean isThrottled = dataHolder.isThrottled(throttleKey);
-        log.debug("Application Level throttle decision is {} for key:tier {}:{}", isThrottled, throttleKey, tier);
-        return isThrottled;
+    private Decision checkAppLevelThrottled(String throttleKey, String tier) {
+        Decision decision = dataHolder.isThrottled(throttleKey);
+        log.debug("Application Level throttle decision is {} for key:tier {}:{}", decision.isThrottled(),
+                throttleKey, tier);
+        return decision;
     }
 
-    private boolean isAPILevelThrottled(String throttleKey, String tier) {
-        log.debug("Checking if request is throttled at API level for tier: {}", tier);
+    private Decision checkResourceThrottled(String throttleKey, String tier, RequestContext context) {
+        log.debug("Checking if request is throttled at API/Resource level for tier: {}, key: {}", tier, throttleKey);
+        Decision decision = new Decision();
 
         if (ThrottleConstants.UNLIMITED_TIER.equals(tier)) {
-            return false;
+            return decision;
         }
 
         if (isGlobalThrottlingEnabled) {
-            // TODO: (Praminda) Check conditional throttling decisions
-            boolean isThrottled;
-            throttleKey += "_default";
-
-            isThrottled = dataHolder.isThrottled(throttleKey);
-            log.debug("API Level throttle decision: {}", isThrottled);
-            return isThrottled;
+            decision = dataHolder.isAdvancedThrottled(throttleKey, context);
+            log.debug("API/Resource Level throttle decision: {}", decision.isThrottled());
+            return decision;
         }
-        return false;
+        return decision;
     }
-
-    private boolean isResourceLevelThrottled(String throttleKey, String tier) {
-        log.debug("Checking if request is throttled at resource level for tier: " + tier);
-
-        if (ThrottleConstants.UNLIMITED_TIER.equals(tier)) {
-            return false;
-        }
-
-        if (isGlobalThrottlingEnabled) {
-            boolean isThrottled;
-            throttleKey += "_default";
-
-            isThrottled = dataHolder.isThrottled(throttleKey);
-            log.debug("Resource Level throttle decision: {}", isThrottled);
-            return isThrottled;
-        }
-        return false;
-    }
-
-    //TODO (amaliMatharaarachchi) Add default values to keys.
-    // Handle fault invocations.
-    // Test all flows.
-    // Add unit tests.
 
     /**
      * This will generate the throttling event map to be publish to the traffic manager.
@@ -211,9 +199,9 @@ public class ThrottleFilter implements Filter {
 
         String basePath = api.getBasePath();
         String apiVersion = api.getVersion();
-        String apiContext = basePath + '/' + apiVersion;
+        String apiContext = basePath + ':' + apiVersion;
         String apiName = api.getName();
-        String apiTier = getApiTier(api, authenticationContext.getApiTier());
+        String apiTier = getApiTier(api);
         String tenantDomain = FilterUtils.getTenantDomainFromRequestURL(apiContext);
         if (tenantDomain == null) {
             tenantDomain = APIConstants.SUPER_TENANT_DOMAIN_NAME;
@@ -226,7 +214,7 @@ public class ThrottleFilter implements Filter {
             resourceKey = apiContext;
         } else {
             resourceTier = getResourceTier(requestContext.getMatchedResourcePath());
-            resourceKey = getResourceThrottleKey(requestContext, apiContext, apiVersion);
+            resourceKey = getResourceThrottleKey(requestContext, basePath, apiVersion);
         }
 
         throttleEvent.put(ThrottleEventConstants.MESSAGE_ID, requestContext.getRequestID());
@@ -264,7 +252,7 @@ public class ThrottleFilter implements Filter {
     private String getApiThrottleKey(String apiContext, String apiVersion) {
         String apiThrottleKey = apiContext;
         if (!apiVersion.isBlank()) {
-            apiThrottleKey += '/' + apiVersion;
+            apiThrottleKey += ':' + apiVersion;
         }
         return apiThrottleKey;
     }
@@ -284,11 +272,11 @@ public class ThrottleFilter implements Filter {
         return ThrottleConstants.UNLIMITED_TIER;
     }
 
-    private String getApiTier(APIConfig apiConfig, String tier) {
+    private String getApiTier(APIConfig apiConfig) {
         if (!apiConfig.getTier().isBlank()) {
             return apiConfig.getTier();
         }
-        return tier;
+        return ThrottleConstants.UNLIMITED_TIER;
     }
 
     private JSONObject getProperties(RequestContext requestContext) {

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/throttle/ThrottleUtils.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/throttle/ThrottleUtils.java
@@ -24,12 +24,16 @@ import org.apache.commons.codec.binary.Base64;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONTokener;
+import org.wso2.micro.gateway.enforcer.api.RequestContext;
 
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.regex.Pattern;
 
 /**
@@ -145,6 +149,26 @@ public class ThrottleUtils {
         }.getType();
 
         return new Gson().fromJson(jwtAssertion, mapType);
+    }
+
+    /**
+     * When sent with a 429 (Too Many Requests) response, this indicates how long to wait before making a new request.
+     * {@code Retry-After: <http-date>} format header will be set.
+     * <p>
+     *     Ex: Retry-After: Fri, 31 Dec 1999 23:59:59 GMT
+     * </p>
+     *
+     * @param context the request context to set the header
+     * @param retryTimestamp value of the Retry-After header
+     */
+    public static void setRetryAfterHeader(RequestContext context, Long retryTimestamp) {
+        if (retryTimestamp != null) {
+            SimpleDateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
+            dateFormat.setTimeZone(TimeZone.getTimeZone(ThrottleConstants.GMT));
+            Date date = new Date(retryTimestamp);
+            String retryAfterValue = dateFormat.format(date);
+            context.getResponseHeaders().put(ThrottleConstants.HEADER_RETRY_AFTER, retryAfterValue);
+        }
     }
 
 }

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/throttle/dto/Decision.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/throttle/dto/Decision.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.micro.gateway.enforcer.throttle.dto;
+
+/**
+ * Detailed information about the throttle decision.
+ */
+public class Decision {
+    /**
+     * Is request throttled or not
+     */
+    boolean isThrottled;
+
+    /**
+     * When will this decision reset. This is a timestamp in {@link Long} format,
+     * deciding when the user can access the blocked resource again.
+     */
+    long resetAt;
+
+    public Decision() {
+        this.isThrottled = false;
+        this.resetAt = 0;
+    }
+
+    public boolean isThrottled() {
+        return isThrottled;
+    }
+
+    public void setThrottled(boolean throttled) {
+        isThrottled = throttled;
+    }
+
+    public long getResetAt() {
+        return resetAt;
+    }
+
+    public void setResetAt(long resetAt) {
+        this.resetAt = resetAt;
+    }
+}

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/util/FilterUtils.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/util/FilterUtils.java
@@ -44,6 +44,7 @@ import org.wso2.micro.gateway.enforcer.dto.APIKeyValidationInfoDTO;
 import org.wso2.micro.gateway.enforcer.exception.APISecurityException;
 import org.wso2.micro.gateway.enforcer.exception.MGWException;
 import org.wso2.micro.gateway.enforcer.security.AuthenticationContext;
+import org.wso2.micro.gateway.enforcer.throttle.ThrottleConstants;
 
 import java.math.BigInteger;
 import java.net.InetAddress;
@@ -375,8 +376,13 @@ public class FilterUtils {
      */
     public static void setThrottleErrorToContext(RequestContext context, int errorCode, String msg, String desc) {
         context.getProperties().put(APIConstants.MessageFormat.ERROR_CODE, errorCode);
-        context.getProperties().put(APIConstants.MessageFormat.STATUS_CODE,
-                APIConstants.StatusCodes.THROTTLED.getCode());
+        if (ThrottleConstants.BLOCKED_ERROR_CODE == errorCode) {
+            context.getProperties().put(APIConstants.MessageFormat.STATUS_CODE,
+                    APIConstants.StatusCodes.UNAUTHORIZED.getCode());
+        } else {
+            context.getProperties().put(APIConstants.MessageFormat.STATUS_CODE,
+                    APIConstants.StatusCodes.THROTTLED.getCode());
+        }
         context.getProperties().put(APIConstants.MessageFormat.ERROR_MESSAGE, msg);
         context.getProperties().put(APIConstants.MessageFormat.ERROR_DESCRIPTION, desc);
     }

--- a/integration/test-integration/src/test/resources/jwtGenerator/config.toml
+++ b/integration/test-integration/src/test/resources/jwtGenerator/config.toml
@@ -75,6 +75,9 @@
     consumerKeyClaim = "azp"
     # Certificate Filepath within enforcer
     certificateFilePath = "/home/wso2/security/truststore/wso2carbon.pem"
+    [[enforcer.jwtTokenConfig.claimMapping]]
+    remoteClaim = "sub"
+    localClaim = "CUSTOM-CLAIM"
 
 # Issuer 2
 [[enforcer.jwtTokenConfig]]


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
Retry-After header in a throttled response defines when the resource is available again for accepting requests. Also this commit updates the tier/level selection logic for API & Res levels. If API level tier is defined we don't do resource level throttling and only perform API level throttling.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1534 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
