### PR TITLE
Resolve throttle publisher pwd from env vars

### DIFF
--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/config/ConfigHolder.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/config/ConfigHolder.java
@@ -46,13 +46,13 @@ import org.wso2.micro.gateway.enforcer.config.dto.ExtendedTokenIssuerDto;
 import org.wso2.micro.gateway.enforcer.config.dto.JWTIssuerConfigurationDto;
 import org.wso2.micro.gateway.enforcer.config.dto.ThrottleAgentConfigDto;
 import org.wso2.micro.gateway.enforcer.config.dto.ThrottleConfigDto;
+import org.wso2.micro.gateway.enforcer.config.dto.ThrottlePublisherConfigDto;
 import org.wso2.micro.gateway.enforcer.constants.Constants;
 import org.wso2.micro.gateway.enforcer.discovery.ConfigDiscoveryClient;
 import org.wso2.micro.gateway.enforcer.exception.DiscoveryException;
 import org.wso2.micro.gateway.enforcer.exception.MGWException;
 import org.wso2.micro.gateway.enforcer.security.jwt.JWTUtil;
 import org.wso2.micro.gateway.enforcer.throttle.databridge.agent.conf.AgentConfiguration;
-import org.wso2.micro.gateway.enforcer.throttle.databridge.publisher.PublisherConfiguration;
 import org.wso2.micro.gateway.enforcer.util.TLSUtils;
 
 import java.io.IOException;
@@ -257,7 +257,7 @@ public class ConfigHolder {
         agentConf.setTrustStore(trustStore);
 
         PublisherPool pool = binary.getPool();
-        PublisherConfiguration pubConf = PublisherConfiguration.getInstance();
+        ThrottlePublisherConfigDto pubConf = new ThrottlePublisherConfigDto();
         pubConf.setUserName(binary.getUsername());
         pubConf.setPassword(binary.getPassword());
         pubConf.setInitIdleObjectDataPublishingAgents(pool.getInitIdleObjectDataPublishingAgents());
@@ -301,7 +301,7 @@ public class ConfigHolder {
      * such that to make them compatible with the binary agent.
      */
     private void processTMPublisherURLGroup(List<TMURLGroup> urlGroups,
-                                            PublisherConfiguration pubConfiguration) {
+                                            ThrottlePublisherConfigDto pubConfiguration) {
         StringBuilder restructuredReceiverURL = new StringBuilder();
         StringBuilder restructuredAuthURL = new StringBuilder();
 

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/config/dto/ThrottleAgentConfigDto.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/config/dto/ThrottleAgentConfigDto.java
@@ -19,7 +19,6 @@
 package org.wso2.micro.gateway.enforcer.config.dto;
 
 import org.wso2.micro.gateway.enforcer.throttle.databridge.agent.conf.AgentConfiguration;
-import org.wso2.micro.gateway.enforcer.throttle.databridge.publisher.PublisherConfiguration;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,7 +30,7 @@ public class ThrottleAgentConfigDto {
     String username;
     String password;
     List<ThrottleURLGroupDto> urlGroup = new ArrayList<>();
-    PublisherConfiguration publisher;
+    ThrottlePublisherConfigDto publisher;
     AgentConfiguration agent;
 
     public String getUsername() {
@@ -58,11 +57,11 @@ public class ThrottleAgentConfigDto {
         this.urlGroup = urlGroup;
     }
 
-    public PublisherConfiguration getPublisher() {
+    public ThrottlePublisherConfigDto getPublisher() {
         return publisher;
     }
 
-    public void setPublisher(PublisherConfiguration publisher) {
+    public void setPublisher(ThrottlePublisherConfigDto publisher) {
         this.publisher = publisher;
     }
 

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/config/dto/ThrottlePublisherConfigDto.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/config/dto/ThrottlePublisherConfigDto.java
@@ -16,18 +16,19 @@
  * under the License.
  */
 
-package org.wso2.micro.gateway.enforcer.throttle.databridge.publisher;
+package org.wso2.micro.gateway.enforcer.config.dto;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.wso2.micro.gateway.enforcer.throttle.databridge.publisher.DataPublisherConstants;
 
 import java.util.Map;
 
 /**
  * This class holds the configurations related to binary data publisher.
  */
-public class PublisherConfiguration {
-    private static final Logger log = LogManager.getLogger(PublisherConfiguration.class);
+public class ThrottlePublisherConfigDto {
+    private static final Logger log = LogManager.getLogger(ThrottlePublisherConfigDto.class);
 
     private int maxIdleDataPublishingAgents;
     private int initIdleObjectDataPublishingAgents;
@@ -39,11 +40,6 @@ public class PublisherConfiguration {
     private String authUrlGroup;
     private String userName;
     private char[] password;
-
-    private static PublisherConfiguration instance = new PublisherConfiguration();
-
-    private PublisherConfiguration() {
-    }
 
     public void setMaxIdleDataPublishingAgents(int maxIdleDataPublishingAgents) {
         this.maxIdleDataPublishingAgents = maxIdleDataPublishingAgents;
@@ -115,14 +111,6 @@ public class PublisherConfiguration {
 
     public String getPassword() {
         return String.valueOf(password);
-    }
-
-    public static PublisherConfiguration getInstance() {
-        return instance;
-    }
-
-    public static synchronized void setInstance(PublisherConfiguration publisherConfiguration) {
-        instance = publisherConfiguration;
     }
 
     public void setConfiguration(Map<String, Object> publisherConfiguration) {

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/throttle/databridge/publisher/ThrottleDataPublisher.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/throttle/databridge/publisher/ThrottleDataPublisher.java
@@ -21,6 +21,8 @@ package org.wso2.micro.gateway.enforcer.throttle.databridge.publisher;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.databridge.commons.exception.TransportException;
+import org.wso2.micro.gateway.enforcer.config.ConfigHolder;
+import org.wso2.micro.gateway.enforcer.config.dto.ThrottlePublisherConfigDto;
 import org.wso2.micro.gateway.enforcer.throttle.databridge.agent.DataPublisher;
 import org.wso2.micro.gateway.enforcer.throttle.databridge.agent.exception.DataEndpointAuthenticationException;
 import org.wso2.micro.gateway.enforcer.throttle.databridge.agent.exception.DataEndpointConfigurationException;
@@ -57,19 +59,20 @@ public class ThrottleDataPublisher {
      */
     public ThrottleDataPublisher() {
         dataPublisherPool = ThrottleDataPublisherPool.getInstance();
-        PublisherConfiguration publisherConfiguration = PublisherConfiguration.getInstance();
+        ThrottlePublisherConfigDto throttlePublisherConfigDto = ConfigHolder.getInstance().getConfig().
+                getThrottleConfig().getThrottleAgent().getPublisher();
 
         try {
             executor = new DataPublisherThreadPoolExecutor(
-                    publisherConfiguration.getPublisherThreadPoolCoreSize(),
-                    publisherConfiguration.getPublisherThreadPoolMaximumSize(),
-                    publisherConfiguration.getPublisherThreadPoolKeepAliveTime(),
+                    throttlePublisherConfigDto.getPublisherThreadPoolCoreSize(),
+                    throttlePublisherConfigDto.getPublisherThreadPoolMaximumSize(),
+                    throttlePublisherConfigDto.getPublisherThreadPoolKeepAliveTime(),
                     TimeUnit.SECONDS,
                     new LinkedBlockingDeque<Runnable>() {
                     });
-            dataPublisher = new DataPublisher(publisherConfiguration.getReceiverUrlGroup(),
-                    publisherConfiguration.getAuthUrlGroup(), publisherConfiguration.getUserName(),
-                    publisherConfiguration.getPassword());
+            dataPublisher = new DataPublisher(throttlePublisherConfigDto.getReceiverUrlGroup(),
+                    throttlePublisherConfigDto.getAuthUrlGroup(), throttlePublisherConfigDto.getUserName(),
+                    throttlePublisherConfigDto.getPassword());
 
         } catch (DataEndpointException | DataEndpointConfigurationException | DataEndpointAuthenticationException
                 | TransportException e) {

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/throttle/databridge/publisher/ThrottleDataPublisherPool.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/throttle/databridge/publisher/ThrottleDataPublisherPool.java
@@ -23,6 +23,8 @@ import org.apache.commons.pool.ObjectPool;
 import org.apache.commons.pool.impl.StackObjectPool;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.wso2.micro.gateway.enforcer.config.ConfigHolder;
+import org.wso2.micro.gateway.enforcer.config.dto.ThrottlePublisherConfigDto;
 
 /**
  * This class implemented to hold throttle data publishing agent pool. Reason for implement this is to
@@ -43,7 +45,8 @@ public class ThrottleDataPublisherPool {
         // active" instance created by the pool, but is quite useful for re-using Objects without introducing
         // artificial limits.
         //Proper tuning is mandatory for good performance according to system load.
-        PublisherConfiguration configuration = PublisherConfiguration.getInstance();
+        ThrottlePublisherConfigDto configuration = ConfigHolder.getInstance().getConfig().getThrottleConfig()
+                .getThrottleAgent().getPublisher();
         clientPool = new StackObjectPool(new BasePoolableObjectFactory() {
             @Override
             public Object makeObject() throws Exception {


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
`[enforcer.throttling.publisher].password` was not resolved from env variables due to invalid pkg structure of a config dto. This was fixed by moving the config dto to correct pkg.
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1767

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
