### PR TITLE
Fix #1800 - Enforcer reconnect after adapter restart

### DIFF
--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/config/ConfigHolder.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/config/ConfigHolder.java
@@ -83,7 +83,7 @@ public class ConfigHolder {
     private static final Logger logger = LogManager.getLogger(ConfigHolder.class);
 
     private static ConfigHolder configHolder;
-    private EnvVarConfig envVarConfig = new EnvVarConfig();
+    private EnvVarConfig envVarConfig = EnvVarConfig.getInstance();
     EnforcerConfig config = new EnforcerConfig();
     private KeyStore trustStore = null;
     private KeyStore trustStoreForJWT = null;

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/config/EnvVarConfig.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/config/EnvVarConfig.java
@@ -34,6 +34,7 @@ public class EnvVarConfig {
     private static final String ENFORCER_LABEL = "ENFORCER_LABEL";
     public static final String XDS_MAX_MSG_SIZE = "XDS_MAX_MSG_SIZE";
     public static final String XDS_MAX_RETRIES = "XDS_MAX_RETRIES";
+    public static final String XDS_RETRY_PERIOD = "XDS_RETRY_PERIOD";
 
     // Since the container is running in linux container, path separator is not needed.
     private static final String DEFAULT_TRUSTED_CA_CERTS_PATH = "/home/wso2/security/truststore";
@@ -45,7 +46,9 @@ public class EnvVarConfig {
     private static final String DEFAULT_ENFORCER_LABEL = "enforcer";
     public static final String DEFAULT_XDS_MAX_MSG_SIZE = "4194304";
     public static final String DEFAULT_XDS_MAX_RETRIES = Integer.toString(Constants.MAX_XDS_RETRIES);
+    public static final String DEFAULT_XDS_RETRY_PERIOD = Integer.toString(Constants.XDS_DEFAULT_RETRY);
 
+    private static EnvVarConfig instance;
     private final String trustedAdapterCertsPath;
     private final String enforcerPrivateKeyPath;
     private final String enforcerPublicKeyPath;
@@ -55,8 +58,9 @@ public class EnvVarConfig {
     private final String adapterHostName;
     private final String xdsMaxMsgSize;
     private final String xdsMaxRetries;
+    private final String xdsRetryPeriod;
 
-    public EnvVarConfig() {
+    private EnvVarConfig() {
         trustedAdapterCertsPath = retrieveEnvVarOrDefault(TRUSTED_CA_CERTS_PATH,
                 DEFAULT_TRUSTED_CA_CERTS_PATH);
         enforcerPrivateKeyPath = retrieveEnvVarOrDefault(ENFORCER_PRIVATE_KEY_PATH,
@@ -69,7 +73,20 @@ public class EnvVarConfig {
         adapterXdsPort = retrieveEnvVarOrDefault(ADAPTER_XDS_PORT, DEFAULT_ADAPTER_XDS_PORT);
         xdsMaxMsgSize = retrieveEnvVarOrDefault(XDS_MAX_MSG_SIZE, DEFAULT_XDS_MAX_MSG_SIZE);
         xdsMaxRetries = retrieveEnvVarOrDefault(XDS_MAX_RETRIES, DEFAULT_XDS_MAX_RETRIES);
+        xdsRetryPeriod = retrieveEnvVarOrDefault(XDS_RETRY_PERIOD, DEFAULT_XDS_MAX_RETRIES);
     }
+
+    public static EnvVarConfig getInstance() {
+        if (instance == null) {
+            synchronized (EnvVarConfig.class) {
+                if (instance == null) {
+                    instance = new EnvVarConfig();
+                }
+            }
+        }
+        return instance;
+    }
+
 
     private String retrieveEnvVarOrDefault(String variable, String defaultValue) {
         if (StringUtils.isEmpty(System.getenv(variable))) {
@@ -112,5 +129,9 @@ public class EnvVarConfig {
 
     public String getXdsMaxRetries() {
         return xdsMaxRetries;
+    }
+
+    public String getXdsRetryPeriod() {
+        return xdsRetryPeriod;
     }
 }

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/constants/Constants.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/constants/Constants.java
@@ -44,6 +44,7 @@ public class Constants {
 
     // xDS constants
     public static final int MAX_XDS_RETRIES = 3;
+    public static final int XDS_DEFAULT_RETRY = 15;
 
     // Config constants
     public static final String EVENT_HUB_EVENT_LISTENING_ENDPOINT = "eventListeningEndpoints";

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/discovery/ApplicationDiscoveryClient.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/discovery/ApplicationDiscoveryClient.java
@@ -23,6 +23,7 @@ import com.google.rpc.Status;
 import io.envoyproxy.envoy.config.core.v3.Node;
 import io.envoyproxy.envoy.service.discovery.v3.DiscoveryRequest;
 import io.envoyproxy.envoy.service.discovery.v3.DiscoveryResponse;
+import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
 import io.grpc.stub.StreamObserver;
 import org.apache.logging.log4j.LogManager;
@@ -33,22 +34,26 @@ import org.wso2.gateway.discovery.subscription.ApplicationList;
 import org.wso2.micro.gateway.enforcer.config.ConfigHolder;
 import org.wso2.micro.gateway.enforcer.constants.AdapterConstants;
 import org.wso2.micro.gateway.enforcer.constants.Constants;
+import org.wso2.micro.gateway.enforcer.discovery.scheduler.XdsSchedulerManager;
 import org.wso2.micro.gateway.enforcer.subscription.SubscriptionDataStoreImpl;
 import org.wso2.micro.gateway.enforcer.util.GRPCUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Client to communicate with Application discovery service at the adapter.
  */
-public class ApplicationDiscoveryClient {
+public class ApplicationDiscoveryClient implements Runnable {
     private static final Logger logger = LogManager.getLogger(ApplicationDiscoveryClient.class);
     private static ApplicationDiscoveryClient instance;
-    private final ManagedChannel channel;
-    private final ApplicationDiscoveryServiceGrpc.ApplicationDiscoveryServiceStub stub;
+    private ManagedChannel channel;
+    private ApplicationDiscoveryServiceGrpc.ApplicationDiscoveryServiceStub stub;
     private StreamObserver<DiscoveryRequest> reqObserver;
     private SubscriptionDataStoreImpl subscriptionDataStore;
+    private String host;
+    private int port;
 
     /**
      * This is a reference to the latest received response from the ADS.
@@ -74,11 +79,31 @@ public class ApplicationDiscoveryClient {
     private final String nodeId;
 
     private ApplicationDiscoveryClient(String host, int port) {
+        this.host = host;
+        this.port = port;
         this.subscriptionDataStore = SubscriptionDataStoreImpl.getInstance();
-        this.channel = GRPCUtils.createSecuredChannel(logger, host, port);
-        this.stub = ApplicationDiscoveryServiceGrpc.newStub(channel);
+        initConnection();
         this.nodeId = AdapterConstants.COMMON_ENFORCER_LABEL;
         this.latestACKed = DiscoveryResponse.getDefaultInstance();
+    }
+
+    private void initConnection() {
+        if (GRPCUtils.isReInitRequired(channel)) {
+            if (channel != null && !channel.isShutdown()) {
+                channel.shutdownNow();
+                do {
+                    try {
+                        channel.awaitTermination(100, TimeUnit.MILLISECONDS);
+                    } catch (InterruptedException e) {
+                        logger.error("Application discovery channel shutdown wait was interrupted", e);
+                    }
+                } while (!channel.isShutdown());
+            }
+            this.channel = GRPCUtils.createSecuredChannel(logger, host, port);
+            this.stub = ApplicationDiscoveryServiceGrpc.newStub(channel);
+        } else if (channel.getState(true) == ConnectivityState.READY) {
+            XdsSchedulerManager.getInstance().stopApplicationDiscoveryScheduling();
+        }
     }
 
     public static ApplicationDiscoveryClient getInstance() {
@@ -90,12 +115,18 @@ public class ApplicationDiscoveryClient {
         return instance;
     }
 
+    public void run() {
+        initConnection();
+        watchApplications();
+    }
+
     public void watchApplications() {
         // TODO: (Praminda) implement a deadline with retries
         reqObserver = stub.streamApplications(new StreamObserver<DiscoveryResponse>() {
             @Override
             public void onNext(DiscoveryResponse response) {
                 logger.debug("Received Application discovery response " + response);
+                XdsSchedulerManager.getInstance().stopApplicationDiscoveryScheduling();
                 latestReceived = response;
                 try {
                     List<Application> applicationList = new ArrayList<>();
@@ -113,7 +144,7 @@ public class ApplicationDiscoveryClient {
             @Override
             public void onError(Throwable throwable) {
                 logger.error("Error occurred during Application discovery", throwable);
-                // TODO: (Praminda) if adapter is unavailable keep retrying
+                XdsSchedulerManager.getInstance().startApplicationDiscoveryScheduling();
                 nack(throwable);
             }
 

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/discovery/scheduler/XdsSchedulerManager.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/discovery/scheduler/XdsSchedulerManager.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.micro.gateway.enforcer.discovery.scheduler;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.wso2.micro.gateway.enforcer.config.EnvVarConfig;
+import org.wso2.micro.gateway.enforcer.discovery.ApiDiscoveryClient;
+import org.wso2.micro.gateway.enforcer.discovery.ApiListDiscoveryClient;
+import org.wso2.micro.gateway.enforcer.discovery.ApplicationDiscoveryClient;
+import org.wso2.micro.gateway.enforcer.discovery.ApplicationKeyMappingDiscoveryClient;
+import org.wso2.micro.gateway.enforcer.discovery.KeyManagerDiscoveryClient;
+import org.wso2.micro.gateway.enforcer.discovery.RevokedTokenDiscoveryClient;
+import org.wso2.micro.gateway.enforcer.discovery.SubscriptionDiscoveryClient;
+import org.wso2.micro.gateway.enforcer.discovery.ThrottleDataDiscoveryClient;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Manages all the scheduling tasks that runs for retrying discovery requests.
+ */
+public class XdsSchedulerManager {
+
+    private static final Logger log = LogManager.getLogger(XdsSchedulerManager.class);
+    private static int retryPeriod;
+    private static volatile XdsSchedulerManager instance;
+
+    private static ScheduledExecutorService discoveryClientScheduler;
+    private ScheduledFuture<?> apiDiscoveryScheduledFuture;
+    private ScheduledFuture<?> apiDiscoveryListScheduledFuture;
+    private ScheduledFuture<?> applicationDiscoveryScheduledFuture;
+    private ScheduledFuture<?> applicationKeyMappingDiscoveryScheduledFuture;
+    private ScheduledFuture<?> keyManagerDiscoveryScheduledFuture;
+    private ScheduledFuture<?> revokedTokenDiscoveryScheduledFuture;
+    private ScheduledFuture<?> subscriptionDiscoveryScheduledFuture;
+    private ScheduledFuture<?> throttleDataDiscoveryScheduledFuture;
+
+    public static XdsSchedulerManager getInstance() {
+        if (instance == null) {
+            synchronized (XdsSchedulerManager.class) {
+                if (instance == null) {
+                    instance = new XdsSchedulerManager();
+                    discoveryClientScheduler = Executors.newSingleThreadScheduledExecutor();
+                    retryPeriod = Integer.parseInt(EnvVarConfig.getInstance().getXdsRetryPeriod());
+                }
+            }
+        }
+        return instance;
+    }
+
+    public synchronized void startAPIDiscoveryScheduling() {
+        if (apiDiscoveryScheduledFuture == null || apiDiscoveryScheduledFuture.isDone()) {
+            apiDiscoveryScheduledFuture = discoveryClientScheduler
+                    .scheduleWithFixedDelay(ApiDiscoveryClient.getInstance(), 1, retryPeriod, TimeUnit.SECONDS);
+        }
+    }
+
+    public synchronized void stopAPIDiscoveryScheduling() {
+        if (apiDiscoveryScheduledFuture != null && !apiDiscoveryScheduledFuture.isDone()) {
+            apiDiscoveryScheduledFuture.cancel(false);
+        }
+    }
+
+    public synchronized void startAPIListDiscoveryScheduling() {
+        if (apiDiscoveryListScheduledFuture == null || apiDiscoveryListScheduledFuture.isDone()) {
+            apiDiscoveryListScheduledFuture = discoveryClientScheduler
+                    .scheduleWithFixedDelay(ApiListDiscoveryClient.getInstance(), 1, retryPeriod, TimeUnit.SECONDS);
+        }
+    }
+
+    public synchronized void stopAPIListDiscoveryScheduling() {
+        if (apiDiscoveryListScheduledFuture != null && !apiDiscoveryListScheduledFuture.isDone()) {
+            apiDiscoveryListScheduledFuture.cancel(false);
+        }
+    }
+
+    public synchronized void startApplicationDiscoveryScheduling() {
+        if (applicationDiscoveryScheduledFuture == null || applicationDiscoveryScheduledFuture.isDone()) {
+            applicationDiscoveryScheduledFuture = discoveryClientScheduler
+                    .scheduleWithFixedDelay(ApplicationDiscoveryClient.getInstance(), 1, retryPeriod, TimeUnit.SECONDS);
+        }
+    }
+
+    public synchronized void stopApplicationDiscoveryScheduling() {
+        if (applicationDiscoveryScheduledFuture != null && !applicationDiscoveryScheduledFuture.isDone()) {
+            applicationDiscoveryScheduledFuture.cancel(false);
+        }
+    }
+
+    public synchronized void startApplicationKeyMappingDiscoveryScheduling() {
+        if (applicationKeyMappingDiscoveryScheduledFuture == null || applicationKeyMappingDiscoveryScheduledFuture
+                .isDone()) {
+            applicationKeyMappingDiscoveryScheduledFuture = discoveryClientScheduler
+                    .scheduleWithFixedDelay(ApplicationKeyMappingDiscoveryClient.getInstance(), 1, retryPeriod,
+                            TimeUnit.SECONDS);
+        }
+    }
+
+    public synchronized void stopApplicationKeyMappingDiscoveryScheduling() {
+        if (applicationKeyMappingDiscoveryScheduledFuture != null && !applicationKeyMappingDiscoveryScheduledFuture
+                .isDone()) {
+            applicationKeyMappingDiscoveryScheduledFuture.cancel(false);
+        }
+    }
+
+    public synchronized void startKeyManagerDiscoveryScheduling() {
+        if (keyManagerDiscoveryScheduledFuture == null || keyManagerDiscoveryScheduledFuture.isDone()) {
+            keyManagerDiscoveryScheduledFuture = discoveryClientScheduler
+                    .scheduleWithFixedDelay(KeyManagerDiscoveryClient.getInstance(), 1, retryPeriod, TimeUnit.SECONDS);
+        }
+    }
+
+    public synchronized void stopKeyManagerDiscoveryScheduling() {
+        if (keyManagerDiscoveryScheduledFuture != null && !keyManagerDiscoveryScheduledFuture.isDone()) {
+            keyManagerDiscoveryScheduledFuture.cancel(false);
+        }
+    }
+
+    public synchronized void startRevokedTokenDiscoveryScheduling() {
+        if (revokedTokenDiscoveryScheduledFuture == null || revokedTokenDiscoveryScheduledFuture.isDone()) {
+            revokedTokenDiscoveryScheduledFuture = discoveryClientScheduler
+                    .scheduleWithFixedDelay(RevokedTokenDiscoveryClient.getInstance(), 1, retryPeriod,
+                            TimeUnit.SECONDS);
+        }
+    }
+
+    public synchronized void stopRevokedTokenDiscoveryScheduling() {
+        if (revokedTokenDiscoveryScheduledFuture != null && !revokedTokenDiscoveryScheduledFuture.isDone()) {
+            revokedTokenDiscoveryScheduledFuture.cancel(false);
+        }
+    }
+
+    public synchronized void startSubscriptionDiscoveryScheduling() {
+        if (subscriptionDiscoveryScheduledFuture == null || subscriptionDiscoveryScheduledFuture.isDone()) {
+            subscriptionDiscoveryScheduledFuture = discoveryClientScheduler
+                    .scheduleWithFixedDelay(SubscriptionDiscoveryClient.getInstance(), 1, retryPeriod,
+                            TimeUnit.SECONDS);
+        }
+    }
+
+    public synchronized void stopSubscriptionDiscoveryScheduling() {
+        if (subscriptionDiscoveryScheduledFuture != null && !subscriptionDiscoveryScheduledFuture.isDone()) {
+            subscriptionDiscoveryScheduledFuture.cancel(false);
+        }
+    }
+
+    public synchronized void startThrottleDataDiscoveryScheduling() {
+        if (throttleDataDiscoveryScheduledFuture == null || throttleDataDiscoveryScheduledFuture.isDone()) {
+            throttleDataDiscoveryScheduledFuture = discoveryClientScheduler
+                    .scheduleWithFixedDelay(ThrottleDataDiscoveryClient.getInstance(), 1, retryPeriod,
+                            TimeUnit.SECONDS);
+        }
+    }
+
+    public synchronized void stopThrottleDataDiscoveryScheduling() {
+        if (throttleDataDiscoveryScheduledFuture != null && !throttleDataDiscoveryScheduledFuture.isDone()) {
+            throttleDataDiscoveryScheduledFuture.cancel(false);
+        }
+    }
+}

--- a/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/util/GRPCUtils.java
+++ b/enforcer/src/main/java/org/wso2/micro/gateway/enforcer/util/GRPCUtils.java
@@ -18,6 +18,7 @@
 
 package org.wso2.micro.gateway.enforcer.util;
 
+import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
@@ -53,5 +54,13 @@ public class GRPCUtils {
                 .sslContext(sslContext)
                 .overrideAuthority(ConfigHolder.getInstance().getEnvVarConfig().getAdapterHostName())
                 .build();
+    }
+
+    public static boolean isReInitRequired(ManagedChannel channel) {
+        if (channel != null && (channel.getState(true) == ConnectivityState.CONNECTING
+                || channel.getState(true) == ConnectivityState.READY)) {
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
### Purpose
Fix issue of enforcer does not reconnect after adapter restart.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1800 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
