### PR TITLE
Fix IndexOutofBound Exception in the first api call with JWT generation

### DIFF
--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
@@ -48,6 +48,7 @@ import org.wso2.choreo.connect.enforcer.exception.MGWException;
 import org.wso2.choreo.connect.enforcer.security.AuthenticationContext;
 import org.wso2.choreo.connect.enforcer.security.Authenticator;
 import org.wso2.choreo.connect.enforcer.security.TokenValidationContext;
+import org.wso2.choreo.connect.enforcer.security.jwt.validator.JWTConstants;
 import org.wso2.choreo.connect.enforcer.security.jwt.validator.JWTValidator;
 import org.wso2.choreo.connect.enforcer.security.jwt.validator.RevokedJWTDataHolder;
 import org.wso2.choreo.connect.enforcer.util.FilterUtils;
@@ -242,7 +243,7 @@ public class JWTAuthenticator implements Authenticator {
             if (isGatewayTokenCacheEnabled) {
                 try {
                     Object token = CacheProvider.getGatewayJWTTokenCache().get(jwtTokenCacheKey);
-                    if (token != null) {
+                    if (token != null && !JWTConstants.UNAVAILABLE.equals(token)) {
                         endUserToken = (String) token;
                         String[] splitToken = ((String) token).split("\\.");
                         org.json.JSONObject payload = new org.json.JSONObject(new String(Base64.getUrlDecoder().


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
This pr fixes the ArryIndexOutOfBound exception in enforcer in the first request with JWT generation is enabled.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/1829

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
