### PR TITLE
Handle deletion of blocking conditions

### DIFF
--- a/adapter/internal/messaging/throttle_data_listener.go
+++ b/adapter/internal/messaging/throttle_data_listener.go
@@ -33,7 +33,6 @@ const (
 	blockIPRange        = "IPRANGE"
 	blockIP             = "IP"
 	blockStateTrue      = "true"
-	blockStateFalse     = "false"
 	templateStateAdd    = "add"
 	templateStateRemove = "remove"
 )
@@ -72,17 +71,13 @@ func handleThrottleData(deliveries <-chan amqp.Delivery, done chan error) {
 				}
 				if payload.State == blockStateTrue {
 					synchronizer.AddBlockingIPCondition(ip)
-				} else if payload.State == blockStateFalse {
-					if isIPCondition {
-						synchronizer.RemoveBlockingIPCondition(ip)
-					} else {
-						synchronizer.RemoveBlockingCondition(payload.ConditionValue)
-					}
+				} else {
+					synchronizer.RemoveBlockingIPCondition(ip)
 				}
 			} else {
 				if payload.State == blockStateTrue {
 					synchronizer.AddBlockingCondition(payload.ConditionValue)
-				} else if payload.State == blockStateFalse {
+				} else {
 					synchronizer.RemoveBlockingCondition(payload.ConditionValue)
 				}
 			}


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
Blocking condition events have three states.
- true (created/enabled)
- false (disabled)
- deleted (policy deleted)

Removing a blocking condition from `/admin` portal was not reflecting in enforcer throttle data map due to incorrect evaluation of above `delete` throttle event. This PR fixes it.
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1838

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Mac

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
