### PR TITLE
Remove org.json from shade jar and pack json.wso2 to docker image

### DIFF
--- a/enforcer/pom.xml
+++ b/enforcer/pom.xml
@@ -141,6 +141,7 @@
                             <exclude>org.apache.logging:*</exclude>
                             <exclude>log4j:*</exclude>
                             <exclude>org.ops4j.pax.logging:*</exclude>
+                            <exclude>org.json:json</exclude>
                         </excludes>
                     </artifactSet>
                 </configuration>
@@ -166,10 +167,10 @@
                         <configuration>
                             <outputDirectory>${project.build.directory}/</outputDirectory>
                             <includeGroupIds>
-                                org.apache.logging.log4j
+                                org.apache.logging.log4j, org.json.wso2
                             </includeGroupIds>
                             <includeArtifactIds>
-                                log4j-api, log4j-core, log4j-jcl
+                                log4j-api, log4j-core, log4j-jcl, json
                             </includeArtifactIds>
                         </configuration>
                     </execution>


### PR DESCRIPTION
### Purpose
Remove  org.json:json dependency from shaded jar and use org.json.wso2 dependency

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Task

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
