### PR TITLE
Adding www-authenticate header to auth failures

### DIFF
--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/APIConstants.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/APIConstants.java
@@ -61,6 +61,7 @@ public class APIConstants {
     public static final String API_SECURITY_API_KEY = "api_key";
     public static final String API_SECURITY_MUTUAL_SSL_MANDATORY = "mutualssl_mandatory";
     public static final String API_SECURITY_OAUTH_BASIC_AUTH_API_KEY_MANDATORY = "oauth_basic_auth_api_key_mandatory";
+    public static final String WWW_AUTHENTICATE = "WWW-Authenticate";
 
     public static final String BEGIN_CERTIFICATE_STRING = "-----BEGIN CERTIFICATE-----\n";
     public static final String END_CERTIFICATE_STRING = "-----END CERTIFICATE-----";

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/AuthFilter.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/AuthFilter.java
@@ -111,6 +111,10 @@ public class AuthFilter implements Filter {
         if (!canAuthenticated) {
             FilterUtils.setUnauthenticatedErrorToContext(requestContext);
         }
+        //set WWW_AUTHENTICATE header to error response
+        requestContext.addResponseHeaders(APIConstants.WWW_AUTHENTICATE, getAuthenticatorsChallengeString() +
+                ", error=\"invalid_token\"" +
+                ", error_description=\"The access token expired\"");
         return false;
     }
 
@@ -186,5 +190,15 @@ public class AuthFilter implements Filter {
                         "Sandbox key offered to the API with no sandbox endpoint");
             }   
         }
+    }
+
+    private String getAuthenticatorsChallengeString() {
+        StringBuilder challengeString = new StringBuilder();
+        if (authenticators != null) {
+            for (Authenticator authenticator : authenticators) {
+                challengeString.append(authenticator.getChallengeString()).append(" ");
+            }
+        }
+        return challengeString.toString().trim();
     }
 }

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/AuthFilter.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/AuthFilter.java
@@ -114,7 +114,7 @@ public class AuthFilter implements Filter {
         //set WWW_AUTHENTICATE header to error response
         requestContext.addResponseHeaders(APIConstants.WWW_AUTHENTICATE, getAuthenticatorsChallengeString() +
                 ", error=\"invalid_token\"" +
-                ", error_description=\"The access token expired\"");
+                ", error_description=\"The provided token is invalid\"");
         return false;
     }
 

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/Authenticator.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/Authenticator.java
@@ -30,5 +30,14 @@ public interface Authenticator {
 
     AuthenticationContext authenticate(RequestContext requestContext) throws APISecurityException;
 
+    /**
+     * Returns a string representation of the authentication challenge imposed by this
+     * authenticator. In case of an authentication failure this value will be sent back
+     * to the API consumer in the form of a WWW-Authenticate header.
+     *
+     * @return A string representation of the authentication challenge
+     */
+    String getChallengeString();
+
     int getPriority();
 }

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
@@ -193,7 +193,7 @@ public class InternalAPIKeyAuthenticator implements Authenticator {
 
     @Override
     public String getChallengeString() {
-        return null;
+        return "";
     }
 
     public static JSONObject validateAPISubscription(String apiContext, String apiVersion, JWTClaimsSet payload,

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
@@ -191,6 +191,11 @@ public class InternalAPIKeyAuthenticator implements Authenticator {
                 APISecurityConstants.API_AUTH_GENERAL_ERROR, APISecurityConstants.API_AUTH_GENERAL_ERROR_MESSAGE);
     }
 
+    @Override
+    public String getChallengeString() {
+        return null;
+    }
+
     public static JSONObject validateAPISubscription(String apiContext, String apiVersion, JWTClaimsSet payload,
                                                      String[] splitToken, boolean isOauth)
             throws APISecurityException {

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
@@ -211,6 +211,11 @@ public class JWTAuthenticator implements Authenticator {
 
     }
 
+    @Override
+    public String getChallengeString() {
+        return "Bearer realm=\"Choreo Connect\"";
+    }
+
     private String retrieveAuthHeaderValue(RequestContext requestContext) {
         Map<String, String> headers = requestContext.getHeaders();
         String authHeader = requestContext.getMatchedAPI().getAPIConfig().getAuthHeader().toLowerCase();

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/UnsecuredAPIAuthenticator.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/UnsecuredAPIAuthenticator.java
@@ -46,7 +46,7 @@ public class UnsecuredAPIAuthenticator implements Authenticator {
 
     @Override
     public String getChallengeString() {
-        return null;
+        return "";
     }
 
     @Override public int getPriority() {

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/UnsecuredAPIAuthenticator.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/UnsecuredAPIAuthenticator.java
@@ -44,6 +44,11 @@ public class UnsecuredAPIAuthenticator implements Authenticator {
         return FilterUtils.generateAuthenticationContext(requestContext);
     }
 
+    @Override
+    public String getChallengeString() {
+        return null;
+    }
+
     @Override public int getPriority() {
         return -20;
     }

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testCases/jwtValidator/JwtTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testCases/jwtValidator/JwtTestCase.java
@@ -65,6 +65,8 @@ public class JwtTestCase {
 
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK,"Response code mismatched");
+        Assert.assertTrue(response.getHeaders().containsKey("www-authenticate"),
+                "\"www-authenticate\" is available");
     }
 
     @Test(description = "Test to check the JWT auth validate invalida signature token")
@@ -78,6 +80,8 @@ public class JwtTestCase {
 
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_UNAUTHORIZED, "Response code mismatched");
+        Assert.assertTrue(response.getHeaders().containsKey("www-authenticate"),
+                "\"www-authenticate\" is not available");
     }
 
     @Test(description = "Test to check the JWT auth validate expired token")
@@ -92,5 +96,7 @@ public class JwtTestCase {
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_UNAUTHORIZED,
                 "Response code mismatched");
+        Assert.assertTrue(response.getHeaders().containsKey("www-authenticate"),
+                "\"www-authenticate\" is not available");
     }
 }

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testCases/jwtValidator/JwtTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testCases/jwtValidator/JwtTestCase.java
@@ -65,7 +65,7 @@ public class JwtTestCase {
 
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK,"Response code mismatched");
-        Assert.assertTrue(response.getHeaders().containsKey("www-authenticate"),
+        Assert.assertFalse(response.getHeaders().containsKey("www-authenticate"),
                 "\"www-authenticate\" is available");
     }
 


### PR DESCRIPTION
### Purpose
This Pr will add the www-authenticate header to authentication failed responses 

### Issues
Fixes https://github.com/wso2/product-microgateway/issues/1713 https://github.com/wso2/product-microgateway/issues/1454

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
