### PR TITLE
Use UUID to store APIs in SubscriptionDataStore

### DIFF
--- a/adapter/internal/discovery/xds/server.go
+++ b/adapter/internal/discovery/xds/server.go
@@ -228,6 +228,7 @@ func UpdateAPI(apiContent config.APIContent) {
 
 	if apiContent.APIType == mgw.HTTP {
 		mgwSwagger = operator.GetMgwSwagger(apiContent.APIDefinition)
+		mgwSwagger.SetID(apiContent.UUID)
 		mgwSwagger.SetName(apiContent.Name)
 		mgwSwagger.SetVersion(apiContent.Version)
 		mgwSwagger.SetSecurityScheme(apiContent.SecurityScheme)

--- a/adapter/internal/discovery/xds/server.go
+++ b/adapter/internal/discovery/xds/server.go
@@ -65,21 +65,21 @@ var (
 
 	// Vhosts entry maps, these maps updated with delta changes (when an API added, only added its entry only)
 	// These maps are managed separately for API-CTL and APIM, since when deploying an project from API-CTL there is no API uuid
-	apiUUIDToGatewayToVhosts map[string]map[string]string   // API_UUID to gateway-env to vhost (for un-deploying APIs from APIM or Choreo)
-	apiToVhostsMap           map[string]map[string]struct{} // APIName:Version to VHosts set (for un-deploying APIs from API-CTL)
+	apiUUIDToGatewayToVhosts map[string]map[string]string   // API_UUID -> gateway-env -> vhost (for un-deploying APIs from APIM or Choreo)
+	apiToVhostsMap           map[string]map[string]struct{} // APIName:Version -> VHosts set (for un-deploying APIs from API-CTL)
 
 	// Vhost:APIName:Version as map key
-	apiMgwSwaggerMap       map[string]mgw.MgwSwagger       // MgwSwagger struct map
-	openAPIEnvoyMap        map[string][]string             // Envoy Label Array map
-	openAPIRoutesMap       map[string][]*routev3.Route     // Envoy Routes map
-	openAPIClustersMap     map[string][]*clusterv3.Cluster // Envoy Clusters map
-	openAPIEndpointsMap    map[string][]*corev3.Address    // Envoy Endpoints map
-	openAPIEnforcerApisMap map[string]types.Resource       // API Resource map
+	apiMgwSwaggerMap       map[string]mgw.MgwSwagger       // Vhost:APIName:Version -> MgwSwagger struct map
+	openAPIEnvoyMap        map[string][]string             // Vhost:APIName:Version -> Envoy Label Array map
+	openAPIRoutesMap       map[string][]*routev3.Route     // Vhost:APIName:Version -> Envoy Routes map
+	openAPIClustersMap     map[string][]*clusterv3.Cluster // Vhost:APIName:Version -> Envoy Clusters map
+	openAPIEndpointsMap    map[string][]*corev3.Address    // Vhost:APIName:Version -> Envoy Endpoints map
+	openAPIEnforcerApisMap map[string]types.Resource       // Vhost:APIName:Version -> API Resource map
 
 	// Envoy Label as map key
-	envoyUpdateVersionMap  map[string]int64                       // XDS version map
-	envoyListenerConfigMap map[string][]*listenerv3.Listener      // Listener Configuration map
-	envoyRouteConfigMap    map[string]*routev3.RouteConfiguration // Routes Configuration map
+	envoyUpdateVersionMap  map[string]int64                       // GW-Label -> XDS version map
+	envoyListenerConfigMap map[string][]*listenerv3.Listener      // GW-Label -> Listener Configuration map
+	envoyRouteConfigMap    map[string]*routev3.RouteConfiguration // GW-Label -> Routes Configuration map
 
 	// Common Enforcer Label as map key
 	enforcerConfigMap                map[string][]types.Resource

--- a/adapter/internal/oasparser/model/mgw_swagger.go
+++ b/adapter/internal/oasparser/model/mgw_swagger.go
@@ -162,6 +162,11 @@ func (swagger *MgwSwagger) GetID() string {
 	return swagger.id
 }
 
+// SetID set the Id of the API
+func (swagger *MgwSwagger) SetID(id string) {
+	swagger.id = id
+}
+
 // SetName sets the name of the API
 func (swagger *MgwSwagger) SetName(name string) {
 	swagger.title = name

--- a/adapter/internal/oasparser/model/swagger.go
+++ b/adapter/internal/oasparser/model/swagger.go
@@ -34,7 +34,6 @@ import (
 //
 // No operation specific information is extracted.
 func (swagger *MgwSwagger) SetInfoSwagger(swagger2 spec.Swagger) {
-	swagger.id = swagger2.ID
 	if swagger2.Info != nil {
 		swagger.description = swagger2.Info.Description
 		swagger.title = swagger2.Info.Title

--- a/adapter/internal/oasparser/model/swagger_internal_test.go
+++ b/adapter/internal/oasparser/model/swagger_internal_test.go
@@ -48,7 +48,6 @@ func TestSetInfoSwagger(t *testing.T) {
 			},
 
 			MgwSwagger{
-				id:          "v1",
 				apiType:     "HTTP",
 				description: "Swagger definition",
 				title:       "petsore",
@@ -66,7 +65,6 @@ func TestSetInfoSwagger(t *testing.T) {
 				},
 			},
 			MgwSwagger{
-				id:          "",
 				apiType:     "HTTP",
 				description: "",
 				title:       "",

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/RestAPI.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/RestAPI.java
@@ -70,7 +70,7 @@ public class RestAPI implements API {
         }
 
         this.apiLifeCycleState = api.getApiLifeCycleState();
-        this.apiConfig = new APIConfig.Builder(name).vhost(vhost).basePath(basePath).version(version)
+        this.apiConfig = new APIConfig.Builder(name).uuid(api.getId()).vhost(vhost).basePath(basePath).version(version)
                 .resources(resources).apiType(apiType).apiLifeCycleState(apiLifeCycleState)
                 .securitySchema(securitySchemes).tier(api.getTier()).endpointSecurity(api.getEndpointSecurity())
                 .productionUrls(productionUrls).sandboxUrls(sandboxUrls)

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/config/APIConfig.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/config/APIConfig.java
@@ -38,6 +38,7 @@ public class APIConfig {
     private String authorizationHeader;
     private EndpointSecurity endpointSecurity;
     private String organizationId;
+    private String uuid;
 
     private List<String> securitySchemes = new ArrayList<>();
     private String tier = ThrottleConstants.UNLIMITED_TIER;
@@ -60,6 +61,10 @@ public class APIConfig {
         return organizationId;
     }
 
+    public String getUuid() {
+        return uuid;
+    }
+
     /**
      * Implements builder pattern to build an API Config object.
      */
@@ -76,6 +81,7 @@ public class APIConfig {
         private String authorizationHeader;
         private EndpointSecurity endpointSecurity;
         private String organizationId;
+        private String uuid;
 
         private List<String> securitySchemes = new ArrayList<>();
         private String tier = ThrottleConstants.UNLIMITED_TIER;
@@ -156,6 +162,11 @@ public class APIConfig {
             return this;
         }
 
+        public Builder uuid(String uuid) {
+            this.uuid = uuid;
+            return this;
+        }
+
         public APIConfig build() {
             APIConfig apiConfig = new APIConfig();
             apiConfig.name = this.name;
@@ -173,6 +184,7 @@ public class APIConfig {
             apiConfig.authorizationHeader = this.authorizationHeader;
             apiConfig.disableSecurity = this.disableSecurity;
             apiConfig.organizationId = this.organizationId;
+            apiConfig.uuid = this.uuid;
             return apiConfig;
         }
     }

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/models/API.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/models/API.java
@@ -118,7 +118,7 @@ public class API implements CacheableEntity<String> {
 
     public String getCacheKey() {
 
-        return context + DELEM_PERIOD + version;
+        return apiUUID;
     }
 
     public String getApiType() {

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/KeyValidator.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/KeyValidator.java
@@ -49,17 +49,17 @@ public class KeyValidator {
 
     private static final Logger log = LogManager.getLogger(KeyValidator.class);
 
-    public APIKeyValidationInfoDTO validateSubscription(String apiContext, String apiVersion, String consumerKey,
-                                                        String keyManager) {
+    public APIKeyValidationInfoDTO validateSubscription(String uuid, String apiContext, String apiVersion,
+                                                        String consumerKey, String keyManager) {
         APIKeyValidationInfoDTO apiKeyValidationInfoDTO = new APIKeyValidationInfoDTO();
 
         try {
             if (log.isDebugEnabled()) {
                 log.debug("Before validating subscriptions");
-                log.debug("Validation Info : { context : " + apiContext + " , " + "version : " + apiVersion
-                        + " , consumerKey : " + consumerKey + " }");
+                log.debug("Validation Info : { uuid : " + uuid + " , context : " + apiContext +
+                        " , version : " + apiVersion + " , consumerKey : " + consumerKey + " }");
             }
-            validateSubscriptionDetails(apiContext, apiVersion, consumerKey, keyManager, apiKeyValidationInfoDTO);
+            validateSubscriptionDetails(uuid, apiContext, apiVersion, consumerKey, keyManager, apiKeyValidationInfoDTO);
             if (log.isDebugEnabled()) {
                 log.debug("After validating subscriptions");
             }
@@ -127,8 +127,8 @@ public class KeyValidator {
         return scopesValidated;
     }
 
-    private boolean validateSubscriptionDetails(String context, String version, String consumerKey, String keyManager,
-            APIKeyValidationInfoDTO infoDTO) throws EnforcerException {
+    private boolean validateSubscriptionDetails(String uuid, String context, String version, String consumerKey,
+            String keyManager, APIKeyValidationInfoDTO infoDTO) throws EnforcerException {
         boolean defaultVersionInvoked = false;
         String apiTenantDomain = FilterUtils.getTenantDomainFromRequestURL(context);
         if (apiTenantDomain == null) {
@@ -141,12 +141,12 @@ public class KeyValidator {
             version = version.split(APIConstants.DEFAULT_VERSION_PREFIX)[1];
         }
 
-        validateSubscriptionDetails(infoDTO, context, version, consumerKey, keyManager, defaultVersionInvoked);
+        validateSubscriptionDetails(infoDTO, uuid, context, version, consumerKey, keyManager, defaultVersionInvoked);
         return infoDTO.isAuthorized();
     }
 
-    private APIKeyValidationInfoDTO validateSubscriptionDetails(APIKeyValidationInfoDTO infoDTO, String context,
-            String version, String consumerKey, String keyManager, boolean defaultVersionInvoked) {
+    private APIKeyValidationInfoDTO validateSubscriptionDetails(APIKeyValidationInfoDTO infoDTO, String uuid,
+            String context, String version, String consumerKey, String keyManager, boolean defaultVersionInvoked) {
         String apiTenantDomain = FilterUtils.getTenantDomainFromRequestURL(context);
         if (apiTenantDomain == null) {
             apiTenantDomain = APIConstants.SUPER_TENANT_DOMAIN_NAME;
@@ -162,7 +162,7 @@ public class KeyValidator {
         //TODO add a check to see whether datastore is initialized an load data using rest api if it is not loaded
         // TODO: (VirajSalaka) Handle the scenario where the event is dropped.
         if (datastore != null) {
-            api = datastore.getApiByContextAndVersion(context, version);
+            api = datastore.getApiByContextAndVersion(uuid);
             if (api != null) {
                 key = datastore.getKeyMappingByKeyAndKeyManager(consumerKey, keyManager);
                 if (key != null) {

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/KeyValidator.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/KeyValidator.java
@@ -192,7 +192,7 @@ public class KeyValidator {
                 }
             } else {
                 if (log.isDebugEnabled()) {
-                    log.debug("API not found in the datastore for " + context + ":" + version);
+                    log.debug("API not found in the datastore for API UUID :" + uuid);
                 }
             }
         } else {

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
@@ -361,11 +361,12 @@ public class JWTAuthenticator implements Authenticator {
 
         String apiContext = requestContext.getMatchedAPI().getAPIConfig().getBasePath();
         String apiVersion = requestContext.getMatchedAPI().getAPIConfig().getVersion();
-        return validateSubscriptionUsingKeyManager(apiContext, apiVersion, jwtValidationInfo);
+        String uuid = requestContext.getMatchedAPI().getAPIConfig().getUuid();
+        return validateSubscriptionUsingKeyManager(uuid, apiContext, apiVersion, jwtValidationInfo);
     }
 
-    private APIKeyValidationInfoDTO validateSubscriptionUsingKeyManager(String apiContext, String apiVersion,
-            JWTValidationInfo jwtValidationInfo) throws APISecurityException {
+    private APIKeyValidationInfoDTO validateSubscriptionUsingKeyManager(String uuid, String apiContext,
+            String apiVersion, JWTValidationInfo jwtValidationInfo) throws APISecurityException {
 
         String tenantDomain = "carbon.super"; //TODO : get correct tenant domain
 
@@ -373,7 +374,7 @@ public class JWTAuthenticator implements Authenticator {
         String keyManager = jwtValidationInfo.getKeyManager();
         if (consumerKey != null && keyManager != null) {
             return ReferenceHolder.getInstance().getKeyValidationHandler(tenantDomain)
-                    .validateSubscription(apiContext, apiVersion, consumerKey, keyManager);
+                    .validateSubscription(uuid, apiContext, apiVersion, consumerKey, keyManager);
         }
         log.debug("Cannot call Key Manager to validate subscription. "
                 + "Payload of the token does not contain the Authorized party - the party to which the ID Token was "

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/subscription/SubscriptionDataStore.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/subscription/SubscriptionDataStore.java
@@ -54,11 +54,10 @@ public interface SubscriptionDataStore {
     /**
      * Get API by Context and Version.
      *
-     * @param context Context of the API
-     * @param version Version of the API
+     * @param uuid UUID of the API
      * @return {@link API} entry represented by Context and Version.
      */
-    API getApiByContextAndVersion(String context, String version);
+    API getApiByContextAndVersion(String uuid);
 
     /**
      * Gets Subscription by ID.

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/subscription/SubscriptionDataStoreImpl.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/subscription/SubscriptionDataStoreImpl.java
@@ -103,10 +103,8 @@ public class SubscriptionDataStoreImpl implements SubscriptionDataStore {
     }
 
     @Override
-    public API getApiByContextAndVersion(String context, String version) {
-
-        String key = context + DELEM_PERIOD + version;
-        return apiMap.get(key);
+    public API getApiByContextAndVersion(String uuid) {
+        return apiMap.get(uuid);
     }
 
     @Override


### PR DESCRIPTION
### Purpose
$subject

### Issues
fix https://github.com/wso2/product-microgateway/issues/1915

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
APIM 4.0.0-beta
Docker-Compose

#### API Map of SubscriptionDataStoreImpl
```
Map<String, API> apiMap;

83af49dc-73e2-490d-9f8f-b7b0efec70a5 -> {API@6528} "API [apiId=38, provider=admin, name=SwaggerPetstore, 
version=1.0.5, context=/v2/1.0.5, policy=, apiType=HTTP, urlMappings=[]]"
6d42ab3a-fd05-49bd-8e92-d8f20a97ac74 -> {API@6531} "API [apiId=39, provider=admin, name=Web, version=v1, context=/websock/v1, policy=, apiType=WS, urlMappings=[]]"
d0093d81-ffef-4305-9645-a3d9fc2e84f7 -> {API@6525} "API [apiId=1, provider=admin, name=PizzaShackAPI, version=1.0.0, context=/pizzashack/1.0.0, policy=, apiType=HTTP, urlMappings=[]]"
```

#### Request context
![image](https://user-images.githubusercontent.com/23183042/115181961-b391ae00-a0f6-11eb-94f6-f4c569886f9b.png)

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
