### PR TITLE
Remove copying unnecessary config files to adaptor and enforcer

### DIFF
--- a/resources/docker-compose/apim/docker-compose.yaml
+++ b/resources/docker-compose/apim/docker-compose.yaml
@@ -52,7 +52,6 @@ services:
         condition: service_healthy
     volumes:
       - ../resources/adapter/security:/home/wso2/security
-      - ./conf/log4j2.properties:/home/wso2/conf/log4j2.properties
       - ./conf/log_config.toml:/home/wso2/conf/log_config.toml
       - ./conf/config.toml:/home/wso2/conf/config.toml
     environment:
@@ -73,7 +72,7 @@ services:
         max-file: "5"
     volumes:
       - ../resources/enforcer/security:/home/wso2/security
-      - ./conf:/home/wso2/conf
+      - ./conf/log4j2.properties:/home/wso2/conf/log4j2.properties
       - ../resources/enforcer/dropins:/home/wso2/lib/dropins
     links:
       - adapter

--- a/resources/docker-compose/docker-compose.yaml
+++ b/resources/docker-compose/docker-compose.yaml
@@ -37,7 +37,8 @@ services:
         max-file: "5"
     volumes:
       - ../resources/adapter/security:/home/wso2/security
-      - ./conf:/home/wso2/conf
+      - ./conf/log_config.toml:/home/wso2/conf/log_config.toml
+      - ./conf/config.toml:/home/wso2/conf/config.toml
     environment:
       - ADAPTER_PRIVATE_KEY_PATH=/home/wso2/security/keystore/mg.key
       - ADAPTER_PUBLIC_CERT_PATH=/home/wso2/security/keystore/mg.pem
@@ -54,7 +55,7 @@ services:
         max-file: "5"
     volumes:
       - ../resources/enforcer/security:/home/wso2/security
-      - ./conf:/home/wso2/conf
+      - ./conf/log4j2.properties:/home/wso2/conf/log4j2.properties
       - ../resources/enforcer/dropins:/home/wso2/lib/dropins
     links:
       - adapter

--- a/resources/k8s-artifacts/choreo-connect/adapter-deployment.yaml
+++ b/resources/k8s-artifacts/choreo-connect/adapter-deployment.yaml
@@ -42,9 +42,6 @@ spec:
             - mountPath: /home/wso2/conf/config.toml
               subPath: config.toml
               name: config-toml-vol
-            - mountPath: /home/wso2/conf/log4j2.properties
-              subPath: log4j2.properties
-              name: log4j2-vol
             - mountPath: /home/wso2/conf/log_config.toml
               subPath: log_config.toml
               name: logconfig-toml-vol

--- a/resources/k8s-artifacts/choreo-connect/choreo-connect-deployment.yaml
+++ b/resources/k8s-artifacts/choreo-connect/choreo-connect-deployment.yaml
@@ -41,15 +41,9 @@ spec:
               name: enforcer-truststore-vol
             - mountPath: /home/wso2/security/keystore
               name: enforcer-keystore-vol
-            - mountPath: /home/wso2/conf/config.toml
-              subPath: config.toml
-              name: config-toml-vol
             - mountPath: /home/wso2/conf/log4j2.properties
               subPath: log4j2.properties
               name: log4j2-vol
-            - mountPath: /home/wso2/conf/log_config.toml
-              subPath: log_config.toml
-              name: logconfig-toml-vol
             - mountPath: /home/wso2/lib/dropins
               name: dropins-vol
           image: wso2/choreo-connect-enforcer:0.9.0-beta-SNAPSHOT


### PR DESCRIPTION
### Purpose
This pr to remove copying unnecessary configuration files to enforcer and adaptor nodes.

- Enforcer: only log4j2.properties file is used
- Adaptor: config.toml file and log_config.toml file are required.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/1924

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
