### PR TITLE
Add router build to maven profile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Build with Maven
         run: |
           export PATH="${HOME}/go/bin:${PATH}"
-          mvn clean install
+          mvn clean install -PRelease

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ target
 vendor
 
 # envoy filters
-envoy-filters/bazel-*
+envoy-filters/**/bazel-*
 envoy-filters/.vscode
 envoy-filters/.idea
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install: skip
 # Run maven build in quiet mode to avoid log file limit in Travis CI.
 # Only errors and Maven version information will be printed in the CI logs.
 script:
-  - mvn clean install -B -V | grep -e "\[ERROR\]" -e Maven -e "// Start Running" -e "Building"; test ${PIPESTATUS[0]} -eq 0;
+  - mvn clean install -PRelease -B -V | grep -e "\[ERROR\]" -e Maven -e "// Start Running" -e "Building"; test ${PIPESTATUS[0]} -eq 0;
 cache:
   directories:
     - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -43,13 +43,34 @@
         <tag>HEAD</tag>
     </scm>
 
-    <modules>
-        <module>adapter</module>
-        <module>enforcer</module>
-        <module>router</module>
-        <module>distribution</module>
-        <module>integration</module>
-    </modules>
+    <profiles>
+        <profile>
+            <id>Dev</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>adapter</module>
+                <module>enforcer</module>
+                <module>distribution</module>
+                <module>integration</module>
+            </modules>
+        </profile>
+
+        <!-- Building the router module during a release build only. In dev mode building router is not needed
+        frequently as it not changed-->
+        <profile>
+            <id>Release</id>
+            <modules>
+                <module>router</module>
+                <module>adapter</module>
+                <module>enforcer</module>
+                <module>distribution</module>
+                <module>integration</module>
+            </modules>
+        </profile>
+    </profiles>
+
     <build>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
### Purpose
We do not need to build the router in each every dev build. We need to build it during a release only. and in the jenkins pipelines. Hence moved it out to a separate maven profile

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes Task

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
