### PR TITLE
[Inprogress] Router error handling

### DIFF
--- a/adapter/internal/adapter/adapter.go
+++ b/adapter/internal/adapter/adapter.go
@@ -178,7 +178,7 @@ func Run(conf *config.Config) {
 	enforcerRevokedTokenCache := xds.GetEnforcerRevokedTokenCache()
 	enforcerThrottleDataCache := xds.GetEnforcerThrottleDataCache()
 
-	srv := xdsv3.NewServer(ctx, cache, nil)
+	srv := xdsv3.NewServer(ctx, cache, &cb.RouterCallbacks{})
 	enforcerXdsSrv := wso2_server.NewServer(ctx, enforcerCache, &cb.Callbacks{})
 	enforcerSdsSrv := wso2_server.NewServer(ctx, enforcerSubscriptionCache, &cb.Callbacks{})
 	enforcerAppDsSrv := wso2_server.NewServer(ctx, enforcerApplicationCache, &cb.Callbacks{})
@@ -206,7 +206,7 @@ func Run(conf *config.Config) {
 
 	for _, env := range envs {
 		listeners, clusters, routes, endpoints, apis := xds.GenerateEnvoyResoucesForLabel(env)
-		xds.UpdateXdsCacheWithLock(env, endpoints, clusters, routes, listeners)
+		xds.UpdateXdsCacheWithLock(env, endpoints, clusters, routes, listeners, "")
 		xds.UpdateEnforcerApis(env, apis, "")
 	}
 

--- a/adapter/internal/discovery/xds/consul.go
+++ b/adapter/internal/discovery/xds/consul.go
@@ -178,7 +178,7 @@ func updateXDSClusterCache(apiKey string) {
 		if key == apiKey {
 			for _, label := range envoyLabelList {
 				listeners, clusters, routes, endpoints, _ := GenerateEnvoyResoucesForLabel(label)
-				UpdateXdsCacheWithLock(label, endpoints, clusters, routes, listeners)
+				UpdateXdsCacheWithLock(label, endpoints, clusters, routes, listeners, "")
 				logger.LoggerXds.Info("Updated XDS cache by consul service discovery for API: ", apiKey)
 			}
 		}

--- a/adapter/internal/discovery/xds/router_callbacks.go
+++ b/adapter/internal/discovery/xds/router_callbacks.go
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package xds
+
+import (
+	"context"
+
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	logger "github.com/wso2/adapter/loggers"
+)
+
+type typeState struct {
+	version          string
+	isEventPublished bool
+	isError          bool
+}
+
+// RouterCallbacks is used to debug the xds server related communication.
+type RouterCallbacks struct {
+}
+
+// Report logs the fetches and requests.
+func (cb *RouterCallbacks) Report() {}
+
+// OnStreamOpen prints debug logs
+func (cb *RouterCallbacks) OnStreamOpen(_ context.Context, id int64, typ string) error {
+	logger.LoggerXdsCallbacks.Debugf("stream %d open for %s\n", id, typ)
+	return nil
+}
+
+// OnStreamClosed prints debug logs
+func (cb *RouterCallbacks) OnStreamClosed(id int64) {
+	logger.LoggerXdsCallbacks.Debugf("stream %d closed\n", id)
+}
+
+// OnStreamRequest prints debug logs
+func (cb *RouterCallbacks) OnStreamRequest(id int64, request *discovery.DiscoveryRequest) error {
+	logger.LoggerXdsCallbacks.Debugf("stream request on stream id: %d Request: %v", id, request)
+	enforcerEventChannel := GetRequestEventChannel()
+
+	enforcerEvent := NewRequestEvent()
+	enforcerEvent.Node = request.GetNode().GetId()
+	enforcerEvent.Version = request.VersionInfo
+	enforcerEvent.Router = true
+	if request.ErrorDetail != nil {
+		logger.LoggerXdsCallbacks.Errorf("Error stream request on stream id: %d Error: %s", id, request.ErrorDetail.Message)
+		enforcerEvent.IsError = true
+	}
+	enforcerEventChannel <- enforcerEvent
+	return nil
+}
+
+// OnStreamResponse prints debug logs
+func (cb *RouterCallbacks) OnStreamResponse(id int64, request *discovery.DiscoveryRequest, response *discovery.DiscoveryResponse) {
+	logger.LoggerXdsCallbacks.Debugf("stream request on stream id: %d Response: %v", id, response)
+}
+
+// OnFetchRequest prints debug logs
+func (cb *RouterCallbacks) OnFetchRequest(_ context.Context, req *discovery.DiscoveryRequest) error {
+	logger.LoggerXdsCallbacks.Debugf("fetch request : %v", req)
+	return nil
+}
+
+// OnFetchResponse prints debug logs
+func (cb *RouterCallbacks) OnFetchResponse(req *discovery.DiscoveryRequest, res *discovery.DiscoveryResponse) {
+	logger.LoggerXdsCallbacks.Debugf("fetch response : %v", res)
+}

--- a/adapter/internal/discovery/xds/router_callbacks.go
+++ b/adapter/internal/discovery/xds/router_callbacks.go
@@ -34,12 +34,6 @@ type typeState struct {
 type RouterCallbacks struct {
 }
 
-var lastReceived = typeState{
-	version:          "",
-	isEventPublished: false,
-	isError:          false,
-}
-
 // Report logs the fetches and requests.
 func (cb *RouterCallbacks) Report() {}
 

--- a/adapter/internal/discovery/xds/router_callbacks.go
+++ b/adapter/internal/discovery/xds/router_callbacks.go
@@ -34,6 +34,12 @@ type typeState struct {
 type RouterCallbacks struct {
 }
 
+var lastReceived = typeState{
+	version:          "",
+	isEventPublished: false,
+	isError:          false,
+}
+
 // Report logs the fetches and requests.
 func (cb *RouterCallbacks) Report() {}
 
@@ -57,8 +63,9 @@ func (cb *RouterCallbacks) OnStreamRequest(id int64, request *discovery.Discover
 	enforcerEvent.Node = request.GetNode().GetId()
 	enforcerEvent.Version = request.VersionInfo
 	enforcerEvent.Router = true
+	logger.LoggerXdsCallbacks.Debugf("stream request with type %s version %s", request.GetTypeUrl(), request.GetVersionInfo())
 	if request.ErrorDetail != nil {
-		logger.LoggerXdsCallbacks.Errorf("Error stream request on stream id: %d Error: %s", id, request.ErrorDetail.Message)
+		logger.LoggerXdsCallbacks.Errorf("Error stream request on stream id: %d type: %s Error: %s", id, request.GetTypeUrl(), request.ErrorDetail.Message)
 		enforcerEvent.IsError = true
 	}
 	enforcerEventChannel <- enforcerEvent

--- a/adapter/internal/discovery/xds/state_cache.go
+++ b/adapter/internal/discovery/xds/state_cache.go
@@ -33,6 +33,7 @@ type RequestEvent struct {
 	IsError bool
 	Version string
 	Node    string
+	Router  bool
 }
 
 // EnforcerAPIState Stores the last success state of the enforcer apis
@@ -65,11 +66,15 @@ var (
 
 	// routerState is to store the current success state of the router
 	routerState = make(map[string]RouterResourceState)
+
+	// enforcerToRouterVersion map stores the success enforcer config version to the success router version.
+	// helps in rollback
+	enforcerToRouterVersion = make(map[string]string)
 )
 
 // NewRequestEvent create new change event
 func NewRequestEvent() RequestEvent {
-	return RequestEvent{false, "", ""}
+	return RequestEvent{false, "", "", false}
 }
 
 // GetRequestEventChannel returns the state change channel.

--- a/adapter/internal/oasparser/model/mgw_swagger.go
+++ b/adapter/internal/oasparser/model/mgw_swagger.go
@@ -328,6 +328,9 @@ func (endpoint *Endpoint) validateEndpoint() error {
 	if len(endpoint.Host) == 0 {
 		return errors.New("Empty Hostname is provided")
 	}
+	if endpoint.Port >= 65535 {
+		return errors.New("Port value should be less than 65535")
+	}
 	if strings.HasPrefix(endpoint.Host, "/") {
 		return errors.New("Relative paths are not supported as endpoint URLs")
 	}

--- a/adapter/internal/oasparser/model/mgw_swagger.go
+++ b/adapter/internal/oasparser/model/mgw_swagger.go
@@ -335,9 +335,9 @@ func (endpoint *Endpoint) validateEndpoint() error {
 	if len(endpoint.Host) == 0 {
 		return errors.New("Empty Hostname is provided")
 	}
-	if endpoint.Port >= 65535 {
-		return errors.New("Port value should be less than 65535")
-	}
+	// if endpoint.Port >= 65535 {
+	// 	return errors.New("Port value should be less than 65535")
+	// }
 	if strings.HasPrefix(endpoint.Host, "/") {
 		return errors.New("Relative paths are not supported as endpoint URLs")
 	}

--- a/adapter/internal/oasparser/model/mgw_swagger.go
+++ b/adapter/internal/oasparser/model/mgw_swagger.go
@@ -19,6 +19,7 @@ package model
 import (
 	"errors"
 	"net/url"
+	"regexp"
 	"strings"
 
 	parser "github.com/mitchellh/mapstructure"
@@ -296,6 +297,12 @@ func (swagger *MgwSwagger) setDisableSecurity() {
 // Validate method confirms that the mgwSwagger has all required fields in the required format.
 // This needs to be checked prior to generate router/enforcer related resources.
 func (swagger *MgwSwagger) Validate() error {
+	versionMatcher := regexp.MustCompile(`^[a-zA-Z0-9_.-]*$`)
+	if !versionMatcher.Match([]byte(swagger.version)) {
+		logger.LoggerOasparser.Errorf("API version should be in proper format '^[a-zA-Z0-9_.-]*$' %s:%s",
+			swagger.title, swagger.version)
+		return errors.New("API Version should be in proper format '^[a-zA-Z0-9_.-]*$'")
+	}
 	if len(swagger.productionUrls) == 0 && len(swagger.sandboxUrls) == 0 {
 		logger.LoggerOasparser.Errorf("No Endpoints are provided for the API %s:%s",
 			swagger.title, swagger.version)


### PR DESCRIPTION
### Purpose
This pr for the implementation of router error handling.

**Deploy API Success Flow.**
- Deploy an API in the enforcer
- Deploy API in the router
- Set the current state as the success state in the cache

**Failure scenario 1: Failed in enforcer**
- Deploy the API in the enforcer; Failed to deploy the API
- Restore the previous state from the cache.

**Failure Scenario 2: Success in Enforcer, failed in the router**
- Deploy an API in the enforcer
- Deploy API in the router; Failed 
- Restore the previous success state from the cache
- Update the enforcer 
- Update the router

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/1708

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
