### PR TITLE
Keep existing environments when undeploy an API from APIM which is deployed with same vhosts

### DIFF
--- a/adapter/internal/api/apis_impl.go
+++ b/adapter/internal/api/apis_impl.go
@@ -137,7 +137,7 @@ func extractAPIProject(payload []byte) (apiProject ProjectAPI, err error) {
 			upstreamCerts = append(upstreamCerts, unzippedFileBytes...)
 			upstreamCerts = append(upstreamCerts, newLineByteArray...)
 		} else if (strings.Contains(file.Name, apiYAMLFile) || strings.Contains(file.Name, apiJSONFile)) &&
-			!strings.Contains(file.Name, openAPIDir){
+			!strings.Contains(file.Name, openAPIDir) {
 			loggers.LoggerAPI.Debugf("fileName : %v", file.Name)
 			unzippedFileBytes, err := readZipFile(file)
 			if err != nil {
@@ -256,8 +256,11 @@ func ApplyAPIProjectFromAPIM(payload []byte, vhostToEnvsMap map[string][]string)
 				}
 			}
 		}
+
+		// allEnvironments represent all the environments the API should be deployed
+		allEnvironments := xds.GetAllEnvironments(apiInfo.ID, environments)
 		// first update the API for vhost
-		updateAPI(vhost, apiInfo, apiProject, environments)
+		updateAPI(vhost, apiInfo, apiProject, allEnvironments)
 	}
 
 	// undeploy APIs with other vhosts in the same gateway environment

--- a/adapter/internal/api/apis_impl.go
+++ b/adapter/internal/api/apis_impl.go
@@ -258,7 +258,9 @@ func ApplyAPIProjectFromAPIM(payload []byte, vhostToEnvsMap map[string][]string)
 		}
 
 		// allEnvironments represent all the environments the API should be deployed
-		allEnvironments := xds.GetAllEnvironments(apiInfo.ID, environments)
+		allEnvironments := xds.GetAllEnvironments(apiInfo.ID, vhost, environments)
+		loggers.LoggerAPI.Debugf("Update all environments (%v) of API %v %v:%v with UUID \"%v\".",
+			allEnvironments, vhost, apiInfo.Name, apiInfo.Version, apiInfo.ID)
 		// first update the API for vhost
 		updateAPI(vhost, apiInfo, apiProject, allEnvironments)
 	}

--- a/adapter/internal/discovery/xds/server.go
+++ b/adapter/internal/discovery/xds/server.go
@@ -296,6 +296,25 @@ func UpdateAPI(apiContent config.APIContent) {
 	}
 }
 
+// GetAllEnvironments returns all the environments merging new environments with already deployed environments
+// of the API
+func GetAllEnvironments(apiUUID string, newEnvironments []string) []string {
+	// allEnvironments represent all the environments the API should be deployed
+	var allEnvironments []string
+	if existingEnvs, exists := apiUUIDToGatewayToVhosts[apiUUID]; exists {
+		for _, env := range newEnvironments {
+			// update allEnvironments with already existing environments
+			existingEnvs[env] = "_" // add env as key to the map
+		}
+		for env := range existingEnvs {
+			allEnvironments = append(allEnvironments, env)
+		}
+	} else {
+		allEnvironments = newEnvironments
+	}
+	return allEnvironments
+}
+
 // GetVhostOfAPI returns the vhost of API deployed in the given gateway environment
 func GetVhostOfAPI(apiUUID, environment string) (vhost string, exists bool) {
 	if envToVhost, ok := apiUUIDToGatewayToVhosts[apiUUID]; ok {

--- a/adapter/internal/discovery/xds/server.go
+++ b/adapter/internal/discovery/xds/server.go
@@ -297,20 +297,17 @@ func UpdateAPI(apiContent config.APIContent) {
 }
 
 // GetAllEnvironments returns all the environments merging new environments with already deployed environments
-// of the API
-func GetAllEnvironments(apiUUID string, newEnvironments []string) []string {
+// of the given vhost of the API
+func GetAllEnvironments(apiUUID, vhost string, newEnvironments []string) []string {
 	// allEnvironments represent all the environments the API should be deployed
-	var allEnvironments []string
+	allEnvironments := newEnvironments
 	if existingEnvs, exists := apiUUIDToGatewayToVhosts[apiUUID]; exists {
-		for _, env := range newEnvironments {
+		for env, vh := range existingEnvs {
 			// update allEnvironments with already existing environments
-			existingEnvs[env] = "_" // add env as key to the map
+			if vh == vhost && !arrayContains(allEnvironments, env) {
+				allEnvironments = append(allEnvironments, env)
+			}
 		}
-		for env := range existingEnvs {
-			allEnvironments = append(allEnvironments, env)
-		}
-	} else {
-		allEnvironments = newEnvironments
 	}
 	return allEnvironments
 }

--- a/adapter/internal/discovery/xds/server_test.go
+++ b/adapter/internal/discovery/xds/server_test.go
@@ -17,6 +17,8 @@
 package xds
 
 import (
+	"reflect"
+	"sort"
 	"testing"
 )
 
@@ -59,6 +61,53 @@ func TestGetVhostOfAPI(t *testing.T) {
 			}
 			if exists != test.exists {
 				t.Errorf("expected existing bool value %v but found %v", test.exists, exists)
+			}
+		})
+	}
+}
+
+func TestGetAllEnvironments(t *testing.T) {
+	setupInternalMemoryMapsWithTestSamples()
+
+	tests := []struct {
+		name            string
+		uuid            string
+		newEnvironment  []string
+		allEnvironments []string
+	}{
+		{
+			name:            "No_existing_environments",
+			uuid:            "new-uuid-xxxxx",
+			newEnvironment:  []string{"Default", "eu-region"},
+			allEnvironments: []string{"Default", "eu-region"},
+		},
+		{
+			name:            "Some_existing_environments-1",
+			uuid:            "222-PetStore-org2",
+			newEnvironment:  []string{"Default", "eu-region"},
+			allEnvironments: []string{"Default", "eu-region"},
+		},
+		{
+			name:            "Some_existing_environments-2",
+			uuid:            "222-PetStore-org2",
+			newEnvironment:  []string{"us-region", "eu-region"},
+			allEnvironments: []string{"Default", "us-region", "eu-region"},
+		},
+		{
+			name:            "All_existing_environments",
+			uuid:            "444-Pizza-org2",
+			newEnvironment:  []string{"Default", "us-region"},
+			allEnvironments: []string{"Default", "us-region"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			allEnvironments := GetAllEnvironments(test.uuid, test.newEnvironment)
+			sort.Strings(allEnvironments)
+			sort.Strings(test.allEnvironments)
+			if !reflect.DeepEqual(test.allEnvironments, allEnvironments) {
+				t.Errorf("expected environments %v but found %v", test.allEnvironments, allEnvironments)
 			}
 		})
 	}

--- a/adapter/internal/discovery/xds/server_test.go
+++ b/adapter/internal/discovery/xds/server_test.go
@@ -71,31 +71,43 @@ func TestGetAllEnvironments(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		uuid            string
+		uuid, vhost     string
 		newEnvironment  []string
 		allEnvironments []string
 	}{
 		{
-			name:            "No_existing_environments",
+			name:            "No_existing_environments_new_API",
 			uuid:            "new-uuid-xxxxx",
+			vhost:           "us.wso2.com",
 			newEnvironment:  []string{"Default", "eu-region"},
 			allEnvironments: []string{"Default", "eu-region"},
 		},
 		{
-			name:            "Some_existing_environments-1",
-			uuid:            "222-PetStore-org2",
+			name:            "Existing_API_new_vhost",
+			uuid:            "333-Pizza-org1",
+			vhost:           "new.vhost",
 			newEnvironment:  []string{"Default", "eu-region"},
 			allEnvironments: []string{"Default", "eu-region"},
 		},
 		{
-			name:            "Some_existing_environments-2",
+			name:            "Some_existing_environments",
 			uuid:            "222-PetStore-org2",
-			newEnvironment:  []string{"us-region", "eu-region"},
-			allEnvironments: []string{"Default", "us-region", "eu-region"},
+			vhost:           "org2.foo.com",
+			newEnvironment:  []string{"eu-region"},
+			allEnvironments: []string{"Default", "eu-region"},
+		},
+
+		{
+			name:            "new_environments",
+			uuid:            "222-PetStore-org2",
+			vhost:           "org2.foo.com",
+			newEnvironment:  []string{"Default", "eu-region"},
+			allEnvironments: []string{"Default", "eu-region"},
 		},
 		{
 			name:            "All_existing_environments",
-			uuid:            "444-Pizza-org2",
+			uuid:            "111-PetStore-org",
+			vhost:           "org2.foo.com",
 			newEnvironment:  []string{"Default", "us-region"},
 			allEnvironments: []string{"Default", "us-region"},
 		},
@@ -103,7 +115,7 @@ func TestGetAllEnvironments(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			allEnvironments := GetAllEnvironments(test.uuid, test.newEnvironment)
+			allEnvironments := GetAllEnvironments(test.uuid, test.vhost, test.newEnvironment)
 			sort.Strings(allEnvironments)
 			sort.Strings(test.allEnvironments)
 			if !reflect.DeepEqual(test.allEnvironments, allEnvironments) {


### PR DESCRIPTION
### Purpose
$subject
![image](https://user-images.githubusercontent.com/23183042/115857056-dd2a3c80-a44a-11eb-9883-c1e896766f6f.png)

This is also not breaking the following scenario, tested with the following scenario as well.
![image](https://user-images.githubusercontent.com/23183042/115859460-dd780700-a44d-11eb-806a-b61dda8b4776.png)

### Issues
Fixes https://github.com/wso2/product-microgateway/issues/1965

### Automation tests
 - Unit tests added: Yes
 - Integration tests added: No

### Tested environments
Docker-Desktop - Docker-Compose
macOS

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
