### PR TITLE
Revert: creating APIList from jms event rather than calling /apis endpoint.

### DIFF
--- a/adapter/internal/eventhub/subscription.go
+++ b/adapter/internal/eventhub/subscription.go
@@ -132,8 +132,8 @@ func LoadSubscriptionData(configFile *config.Config) {
 		go InvokeService(ApisEndpoint, APIListMap[configuredEnv], queryParamMap, APIListChannel, 0)
 	}
 
+	go retrieveAPIListFromChannel(APIListChannel)
 	var response response
-
 	for i := 1; i <= len(resources); i++ {
 		response = <-responseChannel
 
@@ -173,11 +173,9 @@ func LoadSubscriptionData(configFile *config.Config) {
 			}
 		}
 	}
-	retrieveAPIListFromChannel(APIListChannel)
 }
 
 // InvokeService invokes the internal data resource
-// This function is only called during the startup in all the cases.
 func InvokeService(endpoint string, responseType interface{}, queryParamMap map[string]string, c chan response,
 	retryAttempt int) {
 
@@ -253,11 +251,9 @@ func InvokeService(endpoint string, responseType interface{}, queryParamMap map[
 }
 
 func retrieveAPIListFromChannel(c chan response) {
-	responseCount := 0
 	for response := range c {
 		responseType := reflect.TypeOf(response.Type).Elem()
 		newResponse := reflect.New(responseType).Interface()
-		responseCount++
 		if response.Error == nil && response.Payload != nil {
 			err := json.Unmarshal(response.Payload, &newResponse)
 			if err != nil {
@@ -272,17 +268,21 @@ func retrieveAPIListFromChannel(c chan response) {
 							logger.LoggerSubscription.Debugf("Received API List information for API : %s", api.UUID)
 						}
 					}
-					APIListMap[response.GatewayLabel] = newResponse.(*types.APIList)
+					if _, ok := APIListMap[response.GatewayLabel]; !ok {
+						// During the startup
+						APIListMap[response.GatewayLabel] = newResponse.(*types.APIList)
+					} else {
+						// API Details retrieved after startup contains single API per response.
+						if len(apiListResponse.List) == 1 {
+							APIListMap[response.GatewayLabel].List = append(APIListMap[response.GatewayLabel].List,
+								apiListResponse.List[0])
+						}
+					}
 					xds.UpdateEnforcerAPIList(response.GatewayLabel, xds.MarshalAPIList(APIListMap[response.GatewayLabel]))
 				default:
 					logger.LoggerSubscription.Warnf("APIList Type DTO is not recieved. Unknown type %T", t)
 				}
 			}
-		}
-		// As this method is only triggered during the startup, the response count should be equal to number of gateway labels
-		// If the number of gateway labels is zero, then the default label will be assigned. So the for loop is only iterated once
-		if responseCount == len(conf.ControlPlane.EnvironmentLabels) || len(conf.ControlPlane.EnvironmentLabels) == 0 {
-			break
 		}
 	}
 }

--- a/adapter/internal/messaging/notification_listener.go
+++ b/adapter/internal/messaging/notification_listener.go
@@ -150,36 +150,12 @@ func handleAPIEvents(data []byte, eventType string) {
 								return
 							}
 						}
-						var apiEvent APIEvent
-						json.Unmarshal([]byte(string(data)), &apiEvent)
-						api := types.API{
-							APIID:    apiEvent.APIID,
-							UUID:     apiEvent.UUID,
-							Provider: apiEvent.APIProvider,
-							// hardcoded as default version is not assigned at the moment.
-							IsDefaultVersion: false,
-							APIStatus:        apiEvent.APIStatus,
-							TenantID:         apiEvent.TenantID,
-							TenantDomain:     apiEvent.TenantDomain,
-							TimeStamp:        apiEvent.TimeStamp,
-						}
-
-						// Currently the API Deploy/Remove event and the other API events use different keys
-						// Added this logic to prevent any failures if the API Manager implementation is changed.
-						if apiEvent.APIName != "" {
-							api.Name = apiEvent.APIName
-						} else {
-							api.Name = apiEvent.Name
-						}
-
-						if apiEvent.APIVersion != "" {
-							api.Version = apiEvent.APIVersion
-						} else {
-							api.Version = apiEvent.Version
-						}
-
-						eh.APIListMap[env].List = append(eh.APIListMap[env].List, api)
-						xds.UpdateEnforcerAPIList(env, xds.MarshalAPIList(eh.APIListMap[env]))
+						queryParamMap := make(map[string]string, 3)
+						queryParamMap[eh.GatewayLabelParam] = configuredEnv
+						queryParamMap[eh.ContextParam] = apiEvent.Context
+						queryParamMap[eh.VersionParam] = apiEvent.Version
+						go eh.InvokeService(eh.ApisEndpoint, eh.APIListMap[env], queryParamMap,
+							eh.APIListChannel, 0)
 					}
 				}
 			}

--- a/adapter/internal/oasparser/model/mgw_swagger.go
+++ b/adapter/internal/oasparser/model/mgw_swagger.go
@@ -318,6 +318,20 @@ func (swagger *MgwSwagger) Validate() error {
 			return err
 		}
 	}
+
+	err := swagger.validateBasePath()
+	if err != nil {
+		logger.LoggerOasparser.Errorf("Error while parsing the API %s:%s - %v", swagger.title, swagger.version, err)
+		return err
+	}
+	return nil
+}
+
+func (swagger *MgwSwagger) validateBasePath() error {
+	if xWso2BasePath == "" {
+		return errors.New("Empty Basepath is provided. Either use x-wso2-basePath extension or assign basePath (if OpenAPI v2 definition is used)" +
+			" / servers entry (if OpenAPI v3 definition is used) with non empty context.")
+	}
 	return nil
 }
 


### PR DESCRIPTION
### Purpose

Earlier, there is a change introduced to avoid pulling the apis from /apis REST endpoint and generating the APIList from jms events. This could lead to inconsistencies as the JMS event contains less information (ex. the deploy_event does not contain API state)

Hence this change is reverted . (introduced with #1651)

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
