### PR TITLE
Add callbacks to debug router connection

### DIFF
--- a/adapter/internal/adapter/adapter.go
+++ b/adapter/internal/adapter/adapter.go
@@ -32,6 +32,7 @@ import (
 	subscriptionservice "github.com/wso2/adapter/internal/discovery/api/wso2/discovery/service/subscription"
 	throttleservice "github.com/wso2/adapter/internal/discovery/api/wso2/discovery/service/throtlle"
 	wso2_server "github.com/wso2/adapter/internal/discovery/protocol/server/v3"
+	routercb "github.com/wso2/adapter/internal/discovery/xds/routercallbacks"
 	"github.com/wso2/adapter/internal/health"
 	healthservice "github.com/wso2/adapter/internal/health/api/wso2/health/service"
 	"github.com/wso2/adapter/internal/tlsutils"
@@ -178,7 +179,7 @@ func Run(conf *config.Config) {
 	enforcerRevokedTokenCache := xds.GetEnforcerRevokedTokenCache()
 	enforcerThrottleDataCache := xds.GetEnforcerThrottleDataCache()
 
-	srv := xdsv3.NewServer(ctx, cache, nil)
+	srv := xdsv3.NewServer(ctx, cache, &routercb.Callbacks{})
 	enforcerXdsSrv := wso2_server.NewServer(ctx, enforcerCache, &cb.Callbacks{})
 	enforcerSdsSrv := wso2_server.NewServer(ctx, enforcerSubscriptionCache, &cb.Callbacks{})
 	enforcerAppDsSrv := wso2_server.NewServer(ctx, enforcerApplicationCache, &cb.Callbacks{})

--- a/adapter/internal/discovery/xds/routercallbacks/router_callbacks.go
+++ b/adapter/internal/discovery/xds/routercallbacks/router_callbacks.go
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package routercallbacks
+
+import (
+	"context"
+
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	logger "github.com/wso2/adapter/loggers"
+)
+
+// Callbacks is used to debug the xds server related communication.
+type Callbacks struct {
+}
+
+// Report logs the fetches and requests.
+func (cb *Callbacks) Report() {}
+
+// OnStreamOpen prints debug logs
+func (cb *Callbacks) OnStreamOpen(_ context.Context, id int64, typ string) error {
+	logger.LoggerRouterXdsCallbacks.Debugf("stream %d open for %s\n", id, typ)
+	return nil
+}
+
+// OnStreamClosed prints debug logs
+func (cb *Callbacks) OnStreamClosed(id int64) {
+	logger.LoggerRouterXdsCallbacks.Debugf("stream %d closed\n", id)
+}
+
+// OnStreamRequest prints debug logs
+func (cb *Callbacks) OnStreamRequest(id int64, request *discovery.DiscoveryRequest) error {
+	logger.LoggerRouterXdsCallbacks.Debugf("stream request on stream id: %d, from node: %s, version: %s, for type: %s",
+		id, request.Node.Id, request.VersionInfo, request.TypeUrl)
+	return nil
+}
+
+// OnStreamResponse prints debug logs
+func (cb *Callbacks) OnStreamResponse(id int64, request *discovery.DiscoveryRequest, response *discovery.DiscoveryResponse) {
+	logger.LoggerRouterXdsCallbacks.Debugf("stream response on stream id: %d, to node: %s, version: %s, for type: %v", id,
+		request.Node.Id, response.VersionInfo, response.TypeUrl)
+}
+
+// OnFetchRequest prints debug logs
+func (cb *Callbacks) OnFetchRequest(_ context.Context, req *discovery.DiscoveryRequest) error {
+	logger.LoggerRouterXdsCallbacks.Debugf("fetch request from node %s, version: %s, for type %s", req.Node.Id, req.VersionInfo, req.TypeUrl)
+	return nil
+}
+
+// OnFetchResponse prints debug logs
+func (cb *Callbacks) OnFetchResponse(req *discovery.DiscoveryRequest, res *discovery.DiscoveryResponse) {
+	logger.LoggerRouterXdsCallbacks.Debugf("fetch response to node: %s, version: %s, for type %s", req.Node.Id, req.VersionInfo, res.TypeUrl)
+}

--- a/adapter/loggers/logger.go
+++ b/adapter/loggers/logger.go
@@ -32,34 +32,36 @@ When you add a new logger instance add the related package name as a constant
 
 // package name constants
 const (
-	pkgAPI          = "github.com/wso2/adapter/internal/api"
-	pkgAuth         = "github.com/wso2/adapter/internal/auth"
-	pkgMgw          = "github.com/wso2/adapter/internal/adapter"
-	pkgOasparser    = "github.com/wso2/adapter/internal/oasparser"
-	pkgXds          = "github.com/wso2/adapter/internal/discovery/xds"
-	pkgSync         = "github.com/wso2/adapter/internal/synchronizer"
-	pkgMsg          = "github.com/wso2/adapter/internal/messaging"
-	pkgSvcDiscovery = "github.com/wso2/adapter/internal/svcDiscovery"
-	pkgTLSUtils     = "github.com/wso2/adapter/internal/tlsutils"
-	pkgSubscription = "github.com/wso2/adapter/internal/subscription"
-	pkgXdsCallbacks = "github.com/wso2/adapter/internal/discovery/xds"
-	pkgHealth       = "github.com/wso2/adapter/internal/health"
+	pkgAPI                = "github.com/wso2/adapter/internal/api"
+	pkgAuth               = "github.com/wso2/adapter/internal/auth"
+	pkgMgw                = "github.com/wso2/adapter/internal/adapter"
+	pkgOasparser          = "github.com/wso2/adapter/internal/oasparser"
+	pkgXds                = "github.com/wso2/adapter/internal/discovery/xds"
+	pkgSync               = "github.com/wso2/adapter/internal/synchronizer"
+	pkgMsg                = "github.com/wso2/adapter/internal/messaging"
+	pkgSvcDiscovery       = "github.com/wso2/adapter/internal/svcDiscovery"
+	pkgTLSUtils           = "github.com/wso2/adapter/internal/tlsutils"
+	pkgSubscription       = "github.com/wso2/adapter/internal/subscription"
+	pkgXdsCallbacks       = "github.com/wso2/adapter/internal/discovery/xds/enforcercallbacks"
+	pkgHealth             = "github.com/wso2/adapter/internal/health"
+	pkgRouterXdsCallbacks = "github.com/wso2/adapter/internal/discovery/xds/routercallbacks"
 )
 
 // logger package references
 var (
-	LoggerAPI          *logrus.Logger
-	LoggerAuth         *logrus.Logger
-	LoggerMgw          *logrus.Logger
-	LoggerOasparser    *logrus.Logger
-	LoggerXds          *logrus.Logger
-	LoggerSync         *logrus.Logger
-	LoggerMsg          *logrus.Logger
-	LoggerSvcDiscovery *logrus.Logger
-	LoggerTLSUtils     *logrus.Logger
-	LoggerSubscription *logrus.Logger
-	LoggerXdsCallbacks *logrus.Logger
-	LoggerHealth       *logrus.Logger
+	LoggerAPI                *logrus.Logger
+	LoggerAuth               *logrus.Logger
+	LoggerMgw                *logrus.Logger
+	LoggerOasparser          *logrus.Logger
+	LoggerXds                *logrus.Logger
+	LoggerSync               *logrus.Logger
+	LoggerMsg                *logrus.Logger
+	LoggerSvcDiscovery       *logrus.Logger
+	LoggerTLSUtils           *logrus.Logger
+	LoggerSubscription       *logrus.Logger
+	LoggerXdsCallbacks       *logrus.Logger
+	LoggerHealth             *logrus.Logger
+	LoggerRouterXdsCallbacks *logrus.Logger
 )
 
 func init() {
@@ -81,5 +83,6 @@ func UpdateLoggers() {
 	LoggerSubscription = logging.InitPackageLogger(pkgSubscription)
 	LoggerXdsCallbacks = logging.InitPackageLogger(pkgXdsCallbacks)
 	LoggerHealth = logging.InitPackageLogger(pkgHealth)
+	LoggerRouterXdsCallbacks = logging.InitPackageLogger(pkgRouterXdsCallbacks)
 	logrus.Info("Updated loggers")
 }


### PR DESCRIPTION
### Purpose
$subject

these logs can be enabled by adding following entry to the log_config.toml

```
#for router
[[pkg]]
name = "github.com/wso2/adapter/internal/discovery/xds/routercallbacks"
logLevel = "DEBG"

# for enforcer
[[pkg]]
name = "github.com/wso2/adapter/internal/discovery/xds/enforcercallbacks"
logLevel = "DEBG"
```

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1988 

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
