### PR TITLE
Fix maven build warnings

### DIFF
--- a/adapter/src/main/assembly/assembly.xml
+++ b/adapter/src/main/assembly/assembly.xml
@@ -34,7 +34,7 @@
     <files>
         <file>
             <source>target/adapter-ubuntu</source>
-            <outputDirectory></outputDirectory>
+            <outputDirectory/>
         </file>
         <file>
             <source>../resources/security/mg.key</source>
@@ -50,11 +50,11 @@
         </file>
         <file>
             <source>target/grpc_health_probe-linux-amd64</source>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory/>
         </file>
         <file>
             <source>LICENSE.txt</source>
-            <outputDirectory></outputDirectory>
+            <outputDirectory/>
         </file>
     </files>
 </assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,21 @@
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>${exec.maven.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.googlecode.maven-download-plugin</groupId>
+                    <artifactId>download-maven-plugin</artifactId>
+                    <version>${googlecode.download.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.xolstice.maven.plugins</groupId>
+                    <artifactId>protobuf-maven-plugin</artifactId>
+                    <version>${protobuf.maven.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>${build.helper.plugin.version}</version>
                 </plugin>
@@ -436,5 +451,7 @@
         <apache.httpcomponents.version>4.5.13</apache.httpcomponents.version>
         <jackson.databind.version>2.10.5.1</jackson.databind.version>
         <snakeyaml.version>1.26</snakeyaml.version>
+        <exec.maven.plugin.version>3.0.0</exec.maven.plugin.version>
+        <googlecode.download.plugin.version>1.6.3</googlecode.download.plugin.version>
     </properties>
 </project>

--- a/resources/conf/log_config.toml
+++ b/resources/conf/log_config.toml
@@ -1,27 +1,30 @@
-# The logging configuration file for control plane
-######### root Level ########
-logfile = "logs/adapter.log"
-logLevel = "INFO"
+# The logging configuration for Adapter
+
+## Adapter root Level configurations
+
+logfile = "logs/adapter.log" # This file will be created inside adapter container.
+logLevel = "INFO" # LogLevels can be "DEBG", "FATL", "ERRO", "WARN", "INFO", "PANC"
 
 [rotation]
-MaxSize = 10    #meabytes
+MaxSize = 10    # In MegaBytes (MB)
 MaxBackups = 3
-MaxAge =  2   #days
+MaxAge =  2   # In days
 Compress = true
 
-######### package Level ############
-# LogLevels = "DEBG", "FATL", "ERRO", "WARN", "INFO", "PANC"
+## Adapter package Level configurations
 
 [[pkg]]
 name = "github.com/wso2/product-microgateway/adapter/internal/adapter"
-logLevel = "INFO"
+logLevel = "INFO" # LogLevels can be "DEBG", "FATL", "ERRO", "WARN", "INFO", "PANC"
 
 [[pkg]]
 name = "github.com/wso2/product-microgateway/adapter/internal/oasparser"
 logLevel = "INFO"
 
 
+# The logging configuration for Router
+
 [accessLogs]
 enable = false
-logfile = "/tmp/envoy.access.log"
+logfile = "/tmp/envoy.access.log" # This file will be created inside router container.
 format = "[%START_TIME%] '%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%' %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% '%REQ(X-FORWARDED-FOR)%' '%REQ(USER-AGENT)%' '%REQ(X-REQUEST-ID)%' '%REQ(:AUTHORITY)%' '%UPSTREAM_HOST%'\n"

--- a/router/src/main/assembly/assembly.xml
+++ b/router/src/main/assembly/assembly.xml
@@ -24,7 +24,7 @@
     <files>
         <file>
             <source>../resources/envoy.yaml</source>
-            <outputDirectory></outputDirectory>
+            <outputDirectory/>
         </file>
         <file>
             <source>../resources/security/mg.key</source>


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
1. Improve comments in log_config.toml
2. Fix following warnings
```
[WARNING] Some problems were encountered while building the effective model for org.wso2.am.choreo.connect:router:pom:0.9.0.2
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:exec-maven-plugin is missing. @ line 33, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.wso2.am.choreo.connect:adapter:pom:0.9.0.2
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:exec-maven-plugin is missing. @ line 58, column 21
[WARNING] 'build.plugins.plugin.version' for com.googlecode.maven-download-plugin:download-maven-plugin is missing. @ line 109, column 21
```

```
[WARNING] The assembly descriptor contains a filesystem-root relative reference, which is not cross platform compatible /
```

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2027

### Automation tests
 - Unit tests added:/No
 - Integration tests added:/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
