### PR TITLE
Support ssl binary throttle data publishing

### DIFF
--- a/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/globalthrottle/databridge/agent/DataPublisher.java
+++ b/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/globalthrottle/databridge/agent/DataPublisher.java
@@ -137,14 +137,26 @@ public class DataPublisher {
              * we need to start iterating from 2nd element.
              */
             for (int j = 1; j < receiverGroup.length; j++) {
-                DataEndpointConfiguration endpointConfiguration =
-                        new DataEndpointConfiguration((String) receiverGroup[j],
-                                (String) authGroup[j], username, password, dataEndpointAgent.getTransportPool(),
-                                dataEndpointAgent.getSecuredTransportPool(), dataEndpointAgent.
-                                getAgentConfiguration().getBatchSize(),
-                                dataEndpointAgent.getAgentConfiguration().getCorePoolSize(),
-                                dataEndpointAgent.getAgentConfiguration().getMaxPoolSize(),
-                                dataEndpointAgent.getAgentConfiguration().getKeepAliveTimeInPool());
+                DataEndpointConfiguration endpointConfiguration;
+                String[] urlParams = DataPublisherUtil.getProtocolHostPort((String) receiverGroup[j]);
+
+                if (urlParams[0].equalsIgnoreCase(DataEndpointConfiguration.Protocol.TCP.toString())) {
+                    endpointConfiguration = new DataEndpointConfiguration((String) receiverGroup[j],
+                            (String) authGroup[j], username, password, dataEndpointAgent.getTransportPool(),
+                            dataEndpointAgent.getSecuredTransportPool(),
+                            dataEndpointAgent.getAgentConfiguration().getBatchSize(),
+                            dataEndpointAgent.getAgentConfiguration().getCorePoolSize(),
+                            dataEndpointAgent.getAgentConfiguration().getMaxPoolSize(),
+                            dataEndpointAgent.getAgentConfiguration().getKeepAliveTimeInPool());
+                } else {
+                    endpointConfiguration = new DataEndpointConfiguration((String) receiverGroup[j],
+                            (String) authGroup[j], username, password, dataEndpointAgent.getSecuredTransportPool(),
+                            dataEndpointAgent.getSecuredTransportPool(),
+                            dataEndpointAgent.getAgentConfiguration().getBatchSize(),
+                            dataEndpointAgent.getAgentConfiguration().getCorePoolSize(),
+                            dataEndpointAgent.getAgentConfiguration().getMaxPoolSize(),
+                            dataEndpointAgent.getAgentConfiguration().getKeepAliveTimeInPool());
+                }
                 DataEndpoint dataEndpoint = dataEndpointAgent.getNewDataEndpoint();
                 dataEndpoint.initialize(endpointConfiguration);
                 endpointGroup.addDataEndpoint(dataEndpoint);


### PR DESCRIPTION
### Purpose
With the fix we can use the ssl binary receiver urls in microgateway

```toml
[[throttlingConfig.binary.URLGroup]]
      receiverURL = "ssl://localhost:9711"
      authURL = "ssl://localhost:9711"
```

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
