### PR TITLE
Mask connection url and improve jms retry 

### DIFF
--- a/adapter/internal/messaging/connection.go
+++ b/adapter/internal/messaging/connection.go
@@ -94,9 +94,9 @@ func connectionRetry(key string) (*Consumer, *amqp.Connection, error) {
 			retryInterval = 10 * time.Second
 		}
 		logger.LoggerMsg.Infof("Retrying to connect with %s in every %d seconds until exceed %d attempts",
-			maskUrl(amqpURIArray[j].url), amqpURIArray[j].connectionDelay, maxAttempt)
+			maskURL(amqpURIArray[j].url), amqpURIArray[j].connectionDelay, maxAttempt)
 
-		for i := 1; i <= maxAttempt; i++ {
+		for i = 1; i <= maxAttempt; i++ {
 
 			rabbitConn, err = amqp.Dial(amqpURIArray[j].url + "/")
 			if err == nil {
@@ -111,17 +111,50 @@ func connectionRetry(key string) (*Consumer, *amqp.Connection, error) {
 
 			if key != "" && len(key) > 0 {
 				logger.LoggerMsg.Infof("Retry attempt %d for the %s to connect with topic %s has failed. Retrying after %d seconds", i,
-					maskUrl(amqpURIArray[j].url), key, amqpURIArray[j].connectionDelay)
+					maskURL(amqpURIArray[j].url), key, amqpURIArray[j].connectionDelay)
 			} else {
-				logger.LoggerMsg.Infof("Retry attempt %d for the %s has failed. Retrying after %d seconds", i, maskUrl(amqpURIArray[j].url), amqpURIArray[j].connectionDelay)
+				logger.LoggerMsg.Infof("Retry attempt %d for the %s has failed. Retrying after %d seconds", i, maskURL(amqpURIArray[j].url), amqpURIArray[j].connectionDelay)
 			}
 			time.Sleep(retryInterval)
 		}
-		if i == maxAttempt {
-			logger.LoggerMsg.Infof("Exceeds maximum connection retry attempts %d for %s", maxAttempt, maskUrl(amqpURIArray[j].url))
+		if i >= maxAttempt {
+			logger.LoggerMsg.Infof("Exceeds maximum connection retry attempts %d for %s", maxAttempt, maskURL(amqpURIArray[j].url))
+			return retryExponentially(key, amqpURIArray[j].url, retryInterval)
 		}
 	}
 	return nil, rabbitConn, err
+}
+
+func retryExponentially(key string, url string, retryInterval time.Duration) (*Consumer, *amqp.Connection, error) {
+	logger.LoggerMsg.Infof("Trying to connect exponentially for %s", maskURL(url))
+	var err error = nil
+	initInterval := int(retryInterval.Seconds())
+	maxInterval := initInterval * 10
+	interval := initInterval
+	count := 0
+	for {
+		rabbitConn, err = amqp.Dial(url + "/")
+		if err != nil {
+			if interval < maxInterval {
+				interval = initInterval + (initInterval * count)
+				count = count + 1
+			}
+			if key != "" && len(key) > 0 {
+				logger.LoggerMsg.Infof("Retry attempt for the %s to connect with topic %s has failed. Retrying after %d seconds", maskURL(url), key, interval)
+			} else {
+				logger.LoggerMsg.Infof("Retry attempt for the %s has failed. Retrying after %d seconds", maskURL(url), interval)
+			}
+
+			time.Sleep(time.Duration(interval) * time.Second)
+		} else {
+			if key != "" && len(key) > 0 {
+				logger.LoggerMsg.Infof("Reconnected to topic %s", key)
+				// startup pull
+				c, err := StartConsumer(key)
+				return c, rabbitConn, err
+			}
+		}
+	}
 }
 
 //extract AMQPURLList from EventListening connection url
@@ -137,7 +170,7 @@ func retrieveAMQPURLList() []amqpFailoverURL {
 		amqpConnectionURL := strings.Split(conURL, "?")[0]
 		u, err := url.Parse(conURL)
 		if err != nil {
-			logger.LoggerMsg.Errorf("Error occured %s", maskUrl(err.Error()))
+			logger.LoggerMsg.Errorf("Error occured %s", maskURL(err.Error()))
 		} else {
 			m, _ := url.ParseQuery(u.RawQuery)
 			if m["connectdelay"] != nil {
@@ -158,7 +191,7 @@ func retrieveAMQPURLList() []amqpFailoverURL {
 	return amqlURLList
 }
 
-func maskUrl(url string) string {
+func maskURL(url string) string {
 	pattern := regexp.MustCompile(`\/\/([a-zA-Z].*)@\b`)
 	matches := pattern.FindStringSubmatch(url)
 	if len(matches) > 1 {

--- a/adapter/internal/messaging/listener.go
+++ b/adapter/internal/messaging/listener.go
@@ -56,7 +56,7 @@ func ProcessEvents(config *config.Config) {
 	amqpURIArray = retrieveAMQPURLList()
 	bindingKeys := []string{notification, keymanager, tokenRevocation, throttleData}
 
-	logger.LoggerMsg.Infof("dialing %q", maskUrl(amqpURIArray[0].url)+"/")
+	logger.LoggerMsg.Infof("dialing %q", maskURL(amqpURIArray[0].url)+"/")
 	rabbitConn, err = connectToRabbitMQ(amqpURIArray[0].url + "/")
 	health.SetControlPlaneJmsStatus(err == nil)
 

--- a/adapter/internal/messaging/listener.go
+++ b/adapter/internal/messaging/listener.go
@@ -20,9 +20,10 @@ package messaging
 
 import (
 	"fmt"
-	"github.com/wso2/adapter/internal/health"
 	"strings"
 	"time"
+
+	"github.com/wso2/adapter/internal/health"
 
 	"github.com/streadway/amqp"
 	"github.com/wso2/adapter/config"
@@ -55,7 +56,7 @@ func ProcessEvents(config *config.Config) {
 	amqpURIArray = retrieveAMQPURLList()
 	bindingKeys := []string{notification, keymanager, tokenRevocation, throttleData}
 
-	logger.LoggerMsg.Infof("dialing %q", amqpURIArray[0].url+"/")
+	logger.LoggerMsg.Infof("dialing %q", maskUrl(amqpURIArray[0].url)+"/")
 	rabbitConn, err = connectToRabbitMQ(amqpURIArray[0].url + "/")
 	health.SetControlPlaneJmsStatus(err == nil)
 


### PR DESCRIPTION
### Purpose
This PR introduces following changes.

1. Mask credentials in the jms connection url in logs.

   `Retrying to connect with amqp://******@apim:5672 in every 2 seconds until exceed 3 attempts
`
2. Introduce infinite retry for jms connection with exponential interval.

    When the configured retry count and the interval is exceeded, the connection will retry in exponential manner up to a maximum retry interval. This is 10X the configured retry interval.
Once the maximum retry interval is reached, the connection will be retried at the same max interval until the connection is successful.
  
Ex: 
Retry once every 30s for 5 times.
Maximum retry limit is reached, switching to exponential mode. 
(max retry interval is 10x30 (300s))
```
Retry in 30s
Retry in 60s (30 + 30)
Retry in 90s (30 + 60)
.
.
.
Retry in 300s (30 + 270)
Maximum retry interval reached....
Continue retry every 300s 
```

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/2007
Fixes https://github.com/wso2/product-microgateway/issues/2008

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
