### PR TITLE
Fix #2061 - Use same UUID to track request in router and enforcer

### DIFF
--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/HttpConstants.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/HttpConstants.java
@@ -25,4 +25,5 @@ public class HttpConstants {
     public static final int NO_CONTENT_STATUS_CODE = 204;
     public static final String OPTIONS = "OPTIONS";
     public static final String ALLOW_HEADER = "allow";
+    public static final String X_REQUEST_ID_HEADER = "x-request-id";
 }

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/grpc/ExtAuthService.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/grpc/ExtAuthService.java
@@ -48,7 +48,9 @@ public class ExtAuthService extends AuthorizationGrpc.AuthorizationImplBase {
 
     @Override
     public void check(CheckRequest request, StreamObserver<CheckResponse> responseObserver) {
-        ThreadContext.put(APIConstants.LOG_TRACE_ID, request.getAttributes().getRequest().getHttp().getId());
+        ThreadContext.put(APIConstants.LOG_TRACE_ID, request.getAttributes().getRequest().getHttp()
+                .getHeadersOrDefault(HttpConstants.X_REQUEST_ID_HEADER,
+                        request.getAttributes().getRequest().getHttp().getId()));
         ResponseObject responseObject = requestHandler.process(request);
         CheckResponse response = buildResponse(request, responseObject);
         responseObserver.onNext(response);

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/grpc/interceptors/AccessLogInterceptor.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/grpc/interceptors/AccessLogInterceptor.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.wso2.choreo.connect.discovery.service.websocket.WebSocketFrameRequest;
 import org.wso2.choreo.connect.discovery.service.websocket.WebSocketFrameResponse;
+import org.wso2.choreo.connect.enforcer.constants.HttpConstants;
 import org.wso2.choreo.connect.enforcer.websocket.MetadataConstants;
 
 /**
@@ -50,7 +51,12 @@ public class AccessLogInterceptor implements ServerInterceptor {
                     if (message instanceof CheckRequest) {
                         CheckRequest checkRequest = (CheckRequest) message;
                         enforcerServerCall.setStartTime(System.currentTimeMillis());
-                        enforcerServerCall.setTraceId(checkRequest.getAttributes().getRequest().getHttp().getId());
+                        String requestId = checkRequest.getAttributes().getRequest().getHttp().getId();
+                        // x-request-id equals to envoy access log entries "%REQ(X-REQUEST-ID)%". This allows
+                        // to correlate the same request in Router and the Enforcer. If this header is not coming then
+                        // we set the http request Id property as the default value.
+                        enforcerServerCall.setTraceId(checkRequest.getAttributes().getRequest().getHttp()
+                                .getHeadersOrDefault(HttpConstants.X_REQUEST_ID_HEADER, requestId));
                         super.onMessage(message);
                     } else if (message instanceof WebSocketFrameRequest) {
                         WebSocketFrameRequest webSocketFrameRequest = (WebSocketFrameRequest) message;


### PR DESCRIPTION
### Purpose
Uses the same UUID to track request in envoy and enforcer

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2061 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
