### PR TITLE
int-tests: combine startup pull and via eventhub tests

### DIFF
--- a/integration/test-integration/readme.md
+++ b/integration/test-integration/readme.md
@@ -25,20 +25,11 @@
 4. Assume that API-M and CC have already started and invoke APIs using the util methods. 
    NOTE: Currently, only APIs, Applications, and Subscriptions are deployed via the above json files. Therefore, changes
    on admin side needs to be deployed within the testcase and cleaned within the testcase as well.
-3. Finally, add the same class to both of the following test groups in the `src/test/resources/testng-cc-with-apim.xml`.
-      - `apis-apps-subs-pulled-at-startup`: here, the APIs, Applications, and Subscriptions gets created first, 
+3. Finally, add the class to the `start-pull-and-events-via-eventhub-combined` test group in the `src/test/resources/testng-cc-with-apim.xml`.
+      - here, the APIs, Applications, and Subscriptions gets created first, 
         and CC starts afterwords. Thus, CC pulls them during startup, rather than pulling it after getting a 
-        notification from eventhub. Since only the 1st method of the class actually tests whether the startup pull was
-        successful, we only run the 1st method of the tastcase class. Ex:
-        ```
-        <class name="org.wso2.choreo.connect.tests.testcases.withapim.BlockedApiTestCase">
-            <methods><include name="testPublishedStateAPI"/></methods>
-        </class>
-        ```
-     - `apis-apps-subs-received-via-eventhub`: the eventhub scenario is tested in the second group of tests. 
-       By the time this group starts running, CC has already started (in the previous group). 
-       Therefore, the `ApimPreparer` first deletes the APIs, Applications, and Subscriptions that were already created, 
-       testing the "DELETE" events that arrive via eventhub. Then creates the same resources again.
+        notification from eventhub. 
+     - The above events, for the eventhub path, we add the tests in a separate class "BasicEventsTestCase"
 
 ### How to Avoid API Manager restarting everytime the test are run
 1. Run the tests ones
@@ -63,24 +54,17 @@ NOTE: Only if an instance with a completely new config is extremely necessary
    `1.`
 4. in the testng file,
    i. for standalone mode, add a new test tag group, and add the new `Cc` class as the first in the group
-   ii. for withapim mode, create **two new** test tag groups and follow the pattern given below
+   ii. for withapim mode, create a test group, and follow the pattern given below
    ```
    <test>
         <class name="ApimPreparer"/>
         <class name="CcStartupExecutor"/>
-        .
-        . . test methods to run . .
-        .
-   </test>
-   <test>
-        <class name="ApimPreparer"/>
         .
         . . test classes to run . .
         .
         <class name="CcShutdownExecutor"/>
    </test>
    ```
-   NOTE: Adding to both modes is not compulsory
 
 ## How to Test with a new API-M instance
 NOTE: Not encouraged at all

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/withapim/ApimPreparer.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/withapim/ApimPreparer.java
@@ -22,7 +22,6 @@ import org.wso2.choreo.connect.tests.apim.ApimBaseTest;
 import org.wso2.choreo.connect.tests.apim.ApimResourceProcessor;
 import org.wso2.choreo.connect.tests.apim.utils.PublisherUtils;
 import org.wso2.choreo.connect.tests.apim.utils.StoreUtils;
-import org.wso2.choreo.connect.tests.context.CcInstance;
 import org.wso2.choreo.connect.tests.context.ChoreoConnectImpl;
 import org.wso2.choreo.connect.tests.util.TestConstant;
 import org.wso2.choreo.connect.tests.util.Utils;
@@ -30,7 +29,7 @@ import org.wso2.choreo.connect.tests.util.Utils;
 /**
  * APIs, Apps, Subs created here will be used to test whether
  * resources that existed in APIM were pulled by CC during startup
- * (in StartupDiscoveryTestCase). This class must run before CcStartupExecutor
+ * This class must run before CcStartupExecutor
  */
 public class ApimPreparer extends ApimBaseTest {
     /**
@@ -39,8 +38,8 @@ public class ApimPreparer extends ApimBaseTest {
     @BeforeTest
     private void createApiAppSubsEtc() throws Exception {
         super.initWithSuperTenant();
-        // Here, there is a reason we clean first: Within the test tag "apis-apps-subs-received-via-eventhub", we
-        // not only test the "CREATE" events, but also the "DELETE" events
+        // The tests can be run against the same API Manager instance. Therefore, we clean first
+        // in case the tests get interrupted before it ends in the previous run
         StoreUtils.removeAllSubscriptionsAndAppsFromStore(storeRestClient);
         PublisherUtils.removeAllApisFromPublisher(publisherRestClient);
 

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/BasicEventsTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/BasicEventsTestCase.java
@@ -19,15 +19,13 @@ package org.wso2.choreo.connect.tests.testcases.withapim;
 
 import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus;
 import com.google.common.net.HttpHeaders;
-import io.netty.handler.codec.http.HttpHeaderNames;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.am.integration.test.utils.bean.APIRequest;
-import org.wso2.choreo.connect.mockbackend.ResponseConstants;
 import org.wso2.choreo.connect.tests.apim.ApimBaseTest;
-import org.wso2.choreo.connect.tests.apim.ApimResourceProcessor;
 import org.wso2.choreo.connect.tests.apim.dto.AppWithConsumerKey;
 import org.wso2.choreo.connect.tests.apim.dto.Application;
 import org.wso2.choreo.connect.tests.apim.utils.PublisherUtils;
@@ -38,16 +36,21 @@ import org.wso2.choreo.connect.tests.util.HttpsClientRequest;
 import org.wso2.choreo.connect.tests.util.TestConstant;
 import org.wso2.choreo.connect.tests.util.Utils;
 
+import java.net.MalformedURLException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-public class RestartedApimTestCase extends ApimBaseTest {
-    private static final String VHOST_API_ENDPOINT = "vhostApi1/1.0.0/pet/findByStatus";
-    private static final String API_NAME = "AfterApimRestartApi";
-    private static final String API_CONTEXT = "afterApimRestart";
+public class BasicEventsTestCase extends ApimBaseTest {
+    private static final String API_NAME = "BasicEventsApi";
+    private static final String API_CONTEXT = "basicEvents";
     private static final String API_VERSION = "1.0.0";
-    private static final String APP_NAME = "AfterApimRestartApp";
+    private static final String APP_NAME = "BasicEventsApp";
+
+    String apiId;
+    String applicationId;
+    Map<String, String> headers;
+    String endpoint;
 
     @BeforeClass(alwaysRun = true, description = "initialize setup")
     void setup() throws Exception {
@@ -55,29 +58,17 @@ public class RestartedApimTestCase extends ApimBaseTest {
     }
 
     @Test
-    public void testExistingApiWithSubscriptions() throws CCTestException {
-        // Get App ID and API IDs
-        String applicationId = ApimResourceProcessor.applicationNameToId.get(VhostApimTestCase.APPLICATION_NAME);
-        String accessToken = StoreUtils.generateUserAccessToken(apimServiceURLHttps, applicationId,
-                user, storeRestClient);
-
-        Map<String, String> requestHeaders = new HashMap<>();
-        requestHeaders.put(TestConstant.AUTHORIZATION_HEADER, "Bearer " + accessToken);
-        requestHeaders.put(HttpHeaderNames.HOST.toString(), "localhost");
-        VhostApimTestCase.testInvokeAPI(VHOST_API_ENDPOINT, requestHeaders, HttpStatus.SC_SUCCESS, ResponseConstants.RESPONSE_BODY);
-    }
-
-    @Test
-    public void testNewApiEvents() throws CCTestException {
-        //Create, deploy and publish API
+    public void testCreateEvents() throws CCTestException, MalformedURLException {
+        //Create, deploy and publish API - only to specifically test events.
+        // For other testcases the json is used to create APIs, Apps, Subscriptions
         APIRequest apiRequest = PublisherUtils.createSampleAPIRequest(API_NAME, API_CONTEXT, API_VERSION, user.getUserName());
-        String apiId = PublisherUtils.createAndPublishAPI(apiRequest, publisherRestClient);
+        apiId = PublisherUtils.createAndPublishAPI(apiRequest, publisherRestClient);
 
         //Create App. Subscribe.
         Application app = new Application(APP_NAME, TestConstant.APPLICATION_TIER.UNLIMITED);
         AppWithConsumerKey appWithConsumerKey = StoreUtils.createApplicationWithKeys(app, storeRestClient);
-        StoreUtils.subscribeToAPI(apiId, appWithConsumerKey.getApplicationId(),
-                TestConstant.SUBSCRIPTION_TIER.UNLIMITED, storeRestClient);
+        applicationId = appWithConsumerKey.getApplicationId();
+        StoreUtils.subscribeToAPI(apiId, applicationId, TestConstant.SUBSCRIPTION_TIER.UNLIMITED, storeRestClient);
         Utils.delay(TestConstant.DEPLOYMENT_WAIT_TIME, "Interrupted when waiting for the " +
                 "subscription to be deployed");
         String accessToken = StoreUtils.generateUserAccessToken(apimServiceURLHttps,
@@ -85,14 +76,31 @@ public class RestartedApimTestCase extends ApimBaseTest {
                 new String[]{}, user, storeRestClient);
 
         //Invoke API
-        Map<String, String> headers = new HashMap<>();
+        headers = new HashMap<>();
         headers.put(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
-        String endpoint = API_CONTEXT + "/1.0.0/pet/findByStatus";
-        Awaitility.await().pollInterval(2, TimeUnit.SECONDS).atMost(60, TimeUnit.SECONDS).until(
-                HttpsClientRequest.isResponseAvailable(endpoint, headers));
-        HttpResponse response = HttpsClientRequest.doGet(endpoint, headers);
+        endpoint = Utils.getServiceURLHttps(API_CONTEXT + "/1.0.0/pet/findByStatus");
+        HttpResponse response = HttpsClientRequest.retryGetRequestUntilDeployed(endpoint, headers);
         Assert.assertNotNull(response, "Error occurred while invoking the endpoint " + endpoint + " HttpResponse ");
-        Assert.assertEquals(response.getResponseCode(), 200,
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_SUCCESS,
+                "Status code mismatched. Endpoint:" + endpoint + " HttpResponse ");
+    }
+
+    @Test
+    void testDeleteEvents() throws Exception{
+        StoreUtils.removeAllSubscriptionsForAnApp(applicationId, storeRestClient);
+        Utils.delay(TestConstant.DEPLOYMENT_WAIT_TIME, "Interrupted while waiting to subscription delete event");
+
+        HttpResponse response1 = HttpsClientRequest.doGet(endpoint, headers);
+        Assert.assertNotNull(response1, "Error occurred while invoking the endpoint " + endpoint + " HttpResponse ");
+        Assert.assertEquals(response1.getResponseCode(), HttpStatus.SC_FORBIDDEN,
+                "Status code mismatched. Endpoint:" + endpoint + " HttpResponse ");
+
+        storeRestClient.removeApplicationById(applicationId);
+        publisherRestClient.deleteAPI(apiId);
+        Utils.delay(TestConstant.DEPLOYMENT_WAIT_TIME, "Interrupted while waiting to API delete event");
+        HttpResponse response2 = HttpsClientRequest.doGet(endpoint, headers);
+        Assert.assertNotNull(response2, "Error occurred while invoking the endpoint " + endpoint + " HttpResponse ");
+        Assert.assertEquals(response2.getResponseCode(), HttpStatus.SC_NOT_FOUND,
                 "Status code mismatched. Endpoint:" + endpoint + " HttpResponse ");
     }
 

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/ExistingApiTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/ExistingApiTestCase.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.choreo.connect.tests.testcases.withapim;
+
+import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.choreo.connect.mockbackend.ResponseConstants;
+import org.wso2.choreo.connect.tests.apim.ApimBaseTest;
+import org.wso2.choreo.connect.tests.apim.ApimResourceProcessor;
+import org.wso2.choreo.connect.tests.apim.utils.StoreUtils;
+import org.wso2.choreo.connect.tests.context.CCTestException;
+import org.wso2.choreo.connect.tests.util.TestConstant;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ExistingApiTestCase extends ApimBaseTest {
+    private static final String VHOST_API_ENDPOINT = "vhostApi1/1.0.0/pet/findByStatus";
+
+    @BeforeClass(alwaysRun = true, description = "initialize setup")
+    void setup() throws Exception {
+        super.initWithSuperTenant();
+    }
+
+    @Test
+    public void testExistingApiWithSubscriptions() throws CCTestException {
+        String applicationId = ApimResourceProcessor.applicationNameToId.get(VhostApimTestCase.APPLICATION_NAME);
+        String accessToken = StoreUtils.generateUserAccessToken(apimServiceURLHttps, applicationId,
+                user, storeRestClient);
+
+        Map<String, String> requestHeaders = new HashMap<>();
+        requestHeaders.put(TestConstant.AUTHORIZATION_HEADER, "Bearer " + accessToken);
+        requestHeaders.put(HttpHeaderNames.HOST.toString(), "localhost");
+        VhostApimTestCase.testInvokeAPI(VHOST_API_ENDPOINT, requestHeaders, HttpStatus.SC_SUCCESS, ResponseConstants.RESPONSE_BODY);
+    }
+}

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/HttpsClientRequest.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/HttpsClientRequest.java
@@ -81,7 +81,7 @@ public class HttpsClientRequest {
     }
 
     public static HttpResponse retryGetRequestUntilDeployed(String requestUrl, Map<String, String> headers)
-            throws CCTestException, InterruptedException {
+            throws CCTestException {
         HttpResponse response;
         int retryCount = 0;
         do {
@@ -93,12 +93,12 @@ public class HttpsClientRequest {
         return response;
     }
 
-    private static boolean shouldRetry(int retryCount) throws InterruptedException {
+    private static boolean shouldRetry(int retryCount) {
         if(retryCount >= maxRetryCount) {
             log.info("Retrying of the request is finished");
             return false;
         }
-        Thread.sleep(retryIntervalMillis);
+        Utils.delay(retryIntervalMillis, "Interrupted while waiting for endpoint to be available");
         return true;
     }
 

--- a/integration/test-integration/src/test/resources/testng-cc-with-apim.xml
+++ b/integration/test-integration/src/test/resources/testng-cc-with-apim.xml
@@ -33,30 +33,15 @@
             <!-- To avoid apim restarting everytime while writing tests, follow the instructions in integration/test-integration/readme.md -->
             <class name="org.wso2.choreo.connect.tests.setup.withapim.ApimStartupExecutor"/>
             <class name="org.wso2.choreo.connect.tests.setup.withapim.ApimClientsPreparer"/>
-        </classes>
-    </test>
-    <test name="apis-apps-subs-pulled-at-startup" parallel="false">
-        <classes>
+
             <!-- Clean and create APIs, Applications, Subscriptions BEFORE starting Choreo Connect  -->
             <class name="org.wso2.choreo.connect.tests.setup.withapim.ApimPreparer"/>
             <class name="org.wso2.choreo.connect.tests.setup.withapim.CcStartupExecutor"/>
-
-            <class name="org.wso2.choreo.connect.tests.testcases.withapim.BlockedApiTestCase">
-                <methods><include name="testPublishedStateAPI"/></methods>
-            </class>
-            <class name="org.wso2.choreo.connect.tests.testcases.withapim.SubscriptionValidationTestCase">
-                <methods><include name="testAPIsForInvalidSubscription"/></methods>
-            </class>
-            <class name="org.wso2.choreo.connect.tests.testcases.withapim.VhostApimTestCase">
-                <methods><include name="testAPIsWithDeployedVhost"/></methods>
-            </class>
         </classes>
     </test>
-    <test name="apis-apps-subs-received-via-eventhub" parallel="false">
+    <test name="start-pull-and-events-via-eventhub-combined" parallel="false">
         <classes>
-            <!-- Clean and create APIs, Applications, Subscriptions AFTER starting Choreo Connect  -->
-            <class name="org.wso2.choreo.connect.tests.setup.withapim.ApimPreparer"/>
-
+            <class name="org.wso2.choreo.connect.tests.testcases.withapim.BasicEventsTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.withapim.throttle.AdvanceThrottlingTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.withapim.throttle.ApplicationThrottlingTestCase"/>
             <!--            TODO: (Praminda) this requires upgrade in apim throttle dependency. enable after upgrade-->
@@ -70,7 +55,8 @@
 <!--    <test name="apis-apps-subs-received-after-apim-restart" parallel="false">-->
 <!--        <classes>-->
 <!--            <class name="org.wso2.choreo.connect.tests.setup.withapim.ApimRestartExecutor"/>-->
-<!--            <class name="org.wso2.choreo.connect.tests.testcases.withapim.RestartedApimTestCase"/>-->
+<!--            <class name="org.wso2.choreo.connect.tests.testcases.withapim.ExistingApiTestCase"/>-->
+<!--            <class name="org.wso2.choreo.connect.tests.testcases.withapim.BasicEventsTestCase"/>-->
 <!--        </classes>-->
 <!--    </test>-->
     <test name="cc-shutdown-and-apim-shutdown" parallel="false">


### PR DESCRIPTION
### Purpose
- Combine the two test groups: `startup-pull` and `via-eventhub`
- Add a new testcase to test the events "create_api", "create_app", "create_sub", "delete_sub", "delete_api" 

### Tested environments
OS name: "linux", arch: "amd64", family: "unix"
OpenJDK Runtime Environment (build 11.0.10+9-Ubuntu-0ubuntu1.20.04)
4 cores, 8 threads

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
