### PR TITLE
Add connection retry for failover endpoints

### DIFF
--- a/adapter/internal/api/apis_impl.go
+++ b/adapter/internal/api/apis_impl.go
@@ -167,8 +167,8 @@ func extractAPIProject(payload []byte) (apiProject ProjectAPI, err error) {
 			}
 
 			if apiObject.Data.EndpointImplementationType == inlineEndpointType {
-				errmsg := "inline endpointImplementationType is not currently supported with WSO2 micro-gateway"
-				loggers.LoggerAPI.Infof(errmsg)
+				errmsg := "inline endpointImplementationType is not currently supported with Choreo Connect"
+				loggers.LoggerAPI.Warnf(errmsg)
 				err = errors.New(errmsg)
 				return apiProject, err
 			}
@@ -181,8 +181,8 @@ func extractAPIProject(payload []byte) (apiProject ProjectAPI, err error) {
 		loggers.LoggerAPI.Errorf("Error occured while reading the api type : %v", err.Error())
 		return apiProject, err
 	} else if apiProject.APIType != mgw.HTTP && apiProject.APIType != mgw.WS {
-		errMsg := "API type is not currently supported with WSO2 micro-gateway"
-		loggers.LoggerAPI.Infof(errMsg)
+		errMsg := "API type is not currently supported with Choreo Connect"
+		loggers.LoggerAPI.Warnf(errMsg)
 		err = errors.New(errMsg)
 		return apiProject, err
 	}
@@ -221,7 +221,7 @@ func verifyMandatoryFields(apiJSON config.APIJsonData) error {
 
 	if strings.HasPrefix(apiJSON.Data.EndpointConfig.ProductionEndpoints.Endpoint, "/") ||
 		strings.HasPrefix(apiJSON.Data.EndpointConfig.SandBoxEndpoints.Endpoint, "/") {
-		errMsg = "relative urls are not supported for API production and sandbox endpoints"
+		errMsg = "Relative urls are not supported for API production and sandbox endpoints"
 		return errors.New(errMsg)
 	}
 	return nil
@@ -242,6 +242,7 @@ func ApplyAPIProjectFromAPIM(payload []byte, vhostToEnvsMap map[string][]string)
 	if apiProject.OrganizationID == "" {
 		apiProject.OrganizationID = config.GetControlPlaneConnectedTenantDomain()
 	}
+	loggers.LoggerAPI.Infof("Deploying api %s:%s in Organization %s", apiInfo.Name, apiInfo.Version, apiProject.OrganizationID)
 
 	// vhostsToRemove contains vhosts and environments to undeploy
 	vhostsToRemove := make(map[string][]string)
@@ -251,7 +252,7 @@ func ApplyAPIProjectFromAPIM(payload []byte, vhostToEnvsMap map[string][]string)
 		// search for vhosts in the given environments
 		for _, env := range environments {
 			if existingVhost, exists := xds.GetVhostOfAPI(apiInfo.ID, env); exists {
-				loggers.LoggerAPI.Debugf("API %v:%v with UUID \"%v\" already deployed to vhost: %v",
+				loggers.LoggerAPI.Infof("API %v:%v with UUID \"%v\" already deployed to vhost: %v",
 					apiInfo.Name, apiInfo.Version, apiInfo.ID, existingVhost)
 				if vhost != existingVhost {
 					loggers.LoggerAPI.Infof("Un-deploying API %v:%v with UUID \"%v\" which is already deployed to vhost: %v",

--- a/adapter/internal/discovery/xds/enforcercallbacks/enforcer_callbacks.go
+++ b/adapter/internal/discovery/xds/enforcercallbacks/enforcer_callbacks.go
@@ -46,6 +46,9 @@ func (cb *Callbacks) OnStreamClosed(id int64) {
 func (cb *Callbacks) OnStreamRequest(id int64, request *discovery.DiscoveryRequest) error {
 	logger.LoggerEnforcerXdsCallbacks.Debugf("stream request on stream id: %d, from node: %s, version: %s, for type: %s",
 		id, request.GetNode(), request.GetVersionInfo(), request.GetTypeUrl())
+	if request.ErrorDetail != nil {
+		logger.LoggerEnforcerXdsCallbacks.Errorf("Stream request for type %s on stream id: %d Error: %s", request.GetTypeUrl(), id, request.ErrorDetail.Message)
+	}
 	// TODO: (VirajSalaka) Remove the commented logic once the fallback is implemented.
 	// requestEventChannel := xds.GetRequestEventChannel()
 	// if resource.APIType == request.GetTypeUrl() {

--- a/adapter/internal/discovery/xds/routercallbacks/router_callbacks.go
+++ b/adapter/internal/discovery/xds/routercallbacks/router_callbacks.go
@@ -46,6 +46,9 @@ func (cb *Callbacks) OnStreamClosed(id int64) {
 func (cb *Callbacks) OnStreamRequest(id int64, request *discovery.DiscoveryRequest) error {
 	logger.LoggerRouterXdsCallbacks.Debugf("stream request on stream id: %d, from node: %s, version: %s, for type: %s",
 		id, request.Node.Id, request.VersionInfo, request.TypeUrl)
+	if request.ErrorDetail != nil {
+		logger.LoggerEnforcerXdsCallbacks.Errorf("Stream request for type %s on stream id: %d Error: %s", request.GetTypeUrl(), id, request.ErrorDetail.Message)
+	}
 	return nil
 }
 

--- a/adapter/internal/discovery/xds/server.go
+++ b/adapter/internal/discovery/xds/server.go
@@ -457,7 +457,7 @@ func DeleteAPIWithAPIMEvent(uuid, name, version string, environments []string, o
 		} else {
 			// if no error, update internal vhost maps
 			// error only happens when API not found in deleteAPI func
-			logger.LoggerXds.Debugf("Successfully undeployed API %v of Organization %v from environments %v", apiIdentifier, organizationID, environments)
+			logger.LoggerXds.Infof("Successfully undeployed API %v of Organization %v from environments %v", apiIdentifier, organizationID, environments)
 			for _, environment := range environments {
 				// delete environment if exists
 				delete(apiUUIDToGatewayToVhosts[uuid], environment)

--- a/adapter/internal/eventhub/subscription.go
+++ b/adapter/internal/eventhub/subscription.go
@@ -267,7 +267,7 @@ func retrieveAPIListFromChannel(c chan response) {
 					apiListResponse := newResponse.(*types.APIList)
 					if logger.LoggerSubscription.Level == logrus.DebugLevel {
 						for _, api := range apiListResponse.List {
-							logger.LoggerSubscription.Infof("Received API List information for API : %s in Organization: %s", api.UUID)
+							logger.LoggerSubscription.Infof("Received API List information for API : %s", api.UUID)
 						}
 					}
 					if _, ok := APIListMap[response.GatewayLabel]; !ok {

--- a/adapter/internal/eventhub/subscription.go
+++ b/adapter/internal/eventhub/subscription.go
@@ -267,7 +267,7 @@ func retrieveAPIListFromChannel(c chan response) {
 					apiListResponse := newResponse.(*types.APIList)
 					if logger.LoggerSubscription.Level == logrus.DebugLevel {
 						for _, api := range apiListResponse.List {
-							logger.LoggerSubscription.Debugf("Received API List information for API : %s", api.UUID)
+							logger.LoggerSubscription.Infof("Received API List information for API : %s in Organization: %s", api.UUID)
 						}
 					}
 					if _, ok := APIListMap[response.GatewayLabel]; !ok {


### PR DESCRIPTION
### Purpose
This PR introduces the connection retry support for failover amqp endpoints.

Failover reconnection strategy.. (example for 2 endpoints)

1. Try connecting to endpoint [0] with configured retry interval
2. If not successful, after the max retry count, try connecting to endpoint[1]
3. If not successful, after the max retry count, try connecting to endpoint[0] 

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/2090

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
