### PR TITLE
Fix #2116 - Improve enforcer side logs to print app, sub counts

### DIFF
--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApiDiscoveryClient.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApiDiscoveryClient.java
@@ -129,6 +129,7 @@ public class ApiDiscoveryClient implements Runnable {
                 try {
                     List<Api> apis = handleResponse(response);
                     apiFactory.addApis(apis);
+                    logger.info("Number of API artifacts received : " + apis.size());
                     // TODO: (Praminda) fix recursive ack on ack failure
                     ack();
                 } catch (Exception e) {

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApiListDiscoveryClient.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApiListDiscoveryClient.java
@@ -134,6 +134,7 @@ public class ApiListDiscoveryClient implements Runnable {
                         apiList.addAll(res.unpack(APIList.class).getListList());
                     }
                     subscriptionDataStore.addApis(apiList);
+                    logger.info("Number of APIs received : " + apiList.size());
                     ack();
                 } catch (Exception e) {
                     // catching generic error here to wrap any grpc communication errors in the runtime

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationDiscoveryClient.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationDiscoveryClient.java
@@ -135,6 +135,7 @@ public class ApplicationDiscoveryClient implements Runnable {
                         applicationList.addAll(res.unpack(ApplicationList.class).getListList());
                     }
                     subscriptionDataStore.addApplications(applicationList);
+                    logger.info("Number of applications received : " + applicationList.size());
                     ack();
                 } catch (Exception e) {
                     // catching generic error here to wrap any grpc communication errors in the runtime

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationKeyMappingDiscoveryClient.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationKeyMappingDiscoveryClient.java
@@ -135,6 +135,7 @@ public class ApplicationKeyMappingDiscoveryClient implements Runnable {
                         applicationKeyMappingLis.addAll(res.unpack(ApplicationKeyMappingList.class).getListList());
                     }
                     subscriptionDataStore.addApplicationKeyMappings(applicationKeyMappingLis);
+                    logger.info("Number of application key mappings received : " + applicationKeyMappingLis.size());
                     ack();
                 } catch (Exception e) {
                     // catching generic error here to wrap any grpc communication errors in the runtime

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationPolicyDiscoveryClient.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationPolicyDiscoveryClient.java
@@ -135,6 +135,7 @@ public class ApplicationPolicyDiscoveryClient implements Runnable {
                         applicationPolicyList.addAll(res.unpack(ApplicationPolicyList.class).getListList());
                     }
                     subscriptionDataStore.addApplicationPolicies(applicationPolicyList);
+                    logger.info("Number of application policies received : " + applicationPolicyList.size());
                     ack();
                 } catch (Exception e) {
                     // catching generic error here to wrap any grpc communication errors in the runtime

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/KeyManagerDiscoveryClient.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/KeyManagerDiscoveryClient.java
@@ -131,6 +131,7 @@ public class KeyManagerDiscoveryClient implements Runnable {
                 try {
                     List<KeyManagerConfig> keyManagerConfig = handleResponse(response);
                     kmHolder.populateKMIssuerConfiguration(keyManagerConfig);
+                    logger.info("Number of key managers received : " + keyManagerConfig.size());
                     // TODO: fix recursive ack on ack failure
                     ack();
                 } catch (Exception e) {

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/SubscriptionDiscoveryClient.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/SubscriptionDiscoveryClient.java
@@ -135,6 +135,7 @@ public class SubscriptionDiscoveryClient implements Runnable {
                         subscriptionList.addAll(res.unpack(SubscriptionList.class).getListList());
                     }
                     subscriptionDataStore.addSubscriptions(subscriptionList);
+                    logger.info("Number of subscriptions received : " + subscriptionList.size());
                     ack();
 
                 } catch (Exception e) {

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/SubscriptionPolicyDiscoveryClient.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/SubscriptionPolicyDiscoveryClient.java
@@ -135,6 +135,7 @@ public class SubscriptionPolicyDiscoveryClient implements Runnable {
                         subscriptionPolicyList.addAll(res.unpack(SubscriptionPolicyList.class).getListList());
                     }
                     subscriptionDataStore.addSubscriptionPolicies(subscriptionPolicyList);
+                    logger.info("Number of subscription policies received : " + subscriptionPolicyList.size());
                     ack();
                 } catch (Exception e) {
                     // catching generic error here to wrap any grpc communication errors in the runtime


### PR DESCRIPTION
### Purpose
Add improvements to logs, It will print below logs

```
Number of API artifacts received : 1
Number of applications received : 2
Number of subscriptions received : 2
Number of application key mappings received : 3
```

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2116 

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
