### PR TITLE
int-tests: add startup and eventhub groups

### DIFF
--- a/integration/test-integration/readme.md
+++ b/integration/test-integration/readme.md
@@ -1,6 +1,6 @@
 # Integration Tests
 
-## How to Add a Testcase for standalone mode
+## Standalone Mode - How to Add a Testcase 
 1. Add the testcase class to an existing or a new folder in 
    `src/test/java/org/wso2/choreo/connect/tests/testcases/standalone`
 2. If an api needs to be deployed,     
@@ -16,7 +16,7 @@
 5. Importantly, add the testcase to the `src/test/resources/testng-cc-standalone.xml` file. Pick the group
    according to the class you deployed your API in 2. ii. 
 
-## How to Add a Testcase for withAPIM mode
+## WithAPIM Mode - How to Add a Testcase
 1. Add the APIs, Applications, and Subscriptions that needs to be created, to the json files in 
    `src/test/resources/apimApisAppsSubs`. These will be added to API Manager before 
    starting any of the testcases.
@@ -41,7 +41,7 @@
         Therefore, the `ApimPreparer` first deletes the APIs, Applications, and Subscriptions that were already created.
         Then creates the same resources again, before running the tests.
 
-### How to Avoid API Manager restarting everytime the test are run
+### How to Avoid API Manager Restarting Everytime the Tests are Run
 1. Run the tests ones
 2. Copy the `apim` folder in the `integration/test-integration/target` to a different location
 3. cd into that `apim` folder and run `docker-compose up`
@@ -51,7 +51,7 @@
 6. Once done, uncomment the previously commented `ApimStartupShutdownExecutor` test class, stop the running apim 
    instance, and run all the tests with `mvn clean install`.
    
-## How to Test with a new CC instance (standalone or withapim mode)
+## Standalone Mode and Withapim Mode - How to Test with a new CC Instance
 NOTE: Only if an instance with a completely new config is extremely necessary
 1. Add the new config toml to `src/test/resources/configs` and rename it to resemble the requirement
 2. Create a `setup` class
@@ -76,7 +76,7 @@ NOTE: Only if an instance with a completely new config is extremely necessary
    </test>
    ```
 
-## How to Test with a new API-M instance
+## Withapim Mode - How to Test with a new API-M instance
 NOTE: Not encouraged at all
 1. Create a class similar to `org.wso2.choreo.connect.tests.setup.withapim.ApimStartupExecutor` and add a
    `beforeSuite` methods that starts the apim instance. (Don't have to write a new "shutdownExecuter",

--- a/integration/test-integration/readme.md
+++ b/integration/test-integration/readme.md
@@ -11,9 +11,10 @@
         `setup/standalone` folder represents different Choreo Connect instances with different configurations. 
         You can pick accordingly.
 3. Within the testcase, assume that the api has already been deployed and invoke as needed.
-4. In testcases for standalone mode, a base testcase is not used. Therefore, the testcase is not expected to extend 
+4. Test classes does not have a base test class in the standalone mode. Therefore, the test class does not need to extend 
    a parent class.
-5. Importantly, add the testcase to the `src/test/resources/testng-cc-standalone.xml` file
+5. Importantly, add the testcase to the `src/test/resources/testng-cc-standalone.xml` file. Pick the group
+   according to the class you deployed your API in 2. ii. 
 
 ## How to Add a Testcase for withAPIM mode
 1. Add the APIs, Applications, and Subscriptions that needs to be created, to the json files in 
@@ -25,11 +26,20 @@
 4. Assume that API-M and CC have already started and invoke APIs using the util methods. 
    NOTE: Currently, only APIs, Applications, and Subscriptions are deployed via the above json files. Therefore, changes
    on admin side needs to be deployed within the testcase and cleaned within the testcase as well.
-3. Finally, add the class to the `start-pull-and-events-via-eventhub-combined` test group in the `src/test/resources/testng-cc-with-apim.xml`.
-      - here, the APIs, Applications, and Subscriptions gets created first, 
-        and CC starts afterwords. Thus, CC pulls them during startup, rather than pulling it after getting a 
-        notification from eventhub. 
-     - The above events, for the eventhub path, we add the tests in a separate class "BasicEventsTestCase"
+5. Finally, add the same class to one or both of the following test groups in the `src/test/resources/testng-cc-with-apim.xml`. in the `src/test/resources/testng-cc-with-apim.xml`.
+      - `apis-apps-subs-pulled-at-startup`: Here, we create the APIs, Applications, and Subscriptions first 
+        and start CC afterwords. Thus, CC pulls them during startup, rather than pulling it after getting a 
+        notification from eventhub. Since only the 1st method of the class actually tests whether the startup pull was
+        successful, we only run the 1st method of the test class. Ex:
+        ```
+        <class name="org.wso2.choreo.connect.tests.testcases.withapim.BlockedApiTestCase">
+            <methods><include name="testPublishedStateAPI"/></methods>
+        </class>
+        ```
+      - `all-events-received-via-eventhub`: In this group, we test the eventhub scenario.
+        By the time this group starts running, CC has already started.
+        Therefore, the `ApimPreparer` first deletes the APIs, Applications, and Subscriptions that were already created.
+        Then creates the same resources again, before running the tests.
 
 ### How to Avoid API Manager restarting everytime the test are run
 1. Run the tests ones

--- a/integration/test-integration/src/test/resources/testng-cc-with-apim.xml
+++ b/integration/test-integration/src/test/resources/testng-cc-with-apim.xml
@@ -28,7 +28,7 @@
         <listener class-name="org.wso2.choreo.connect.tests.listener.TestNGListener"/>
     </listeners>
 
-    <test name="before-suite-preparations" parallel="false">
+    <test name="apim-startup-and-cc-startup" parallel="false">
         <classes>
             <!-- To avoid apim restarting everytime while writing tests, follow the instructions in integration/test-integration/readme.md -->
             <class name="org.wso2.choreo.connect.tests.setup.withapim.ApimStartupExecutor"/>
@@ -39,8 +39,24 @@
             <class name="org.wso2.choreo.connect.tests.setup.withapim.CcStartupExecutor"/>
         </classes>
     </test>
-    <test name="start-pull-and-events-via-eventhub-combined" parallel="false">
+    <test name="apis-apps-subs-pulled-at-startup" parallel="false">
         <classes>
+            <class name="org.wso2.choreo.connect.tests.testcases.withapim.BlockedApiTestCase">
+                <methods><include name="testPublishedStateAPI"/></methods>
+            </class>
+            <class name="org.wso2.choreo.connect.tests.testcases.withapim.SubscriptionValidationTestCase">
+                <methods><include name="testAPIsForInvalidSubscription"/></methods>
+            </class>
+            <class name="org.wso2.choreo.connect.tests.testcases.withapim.VhostApimTestCase">
+                <methods><include name="testAPIsWithDeployedVhost"/></methods>
+            </class>
+        </classes>
+    </test>
+    <test name="all-events-received-via-eventhub" parallel="false">
+        <classes>
+            <!-- Clean and create APIs, Applications, Subscriptions AFTER starting Choreo Connect  -->
+            <class name="org.wso2.choreo.connect.tests.setup.withapim.ApimPreparer"/>
+
             <class name="org.wso2.choreo.connect.tests.testcases.withapim.BasicEventsTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.withapim.throttle.AdvanceThrottlingTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.withapim.throttle.ApplicationThrottlingTestCase"/>


### PR DESCRIPTION
### Purpose
Add the two test groups: startup-pull and via-eventhub
Partially reverts https://github.com/wso2/product-microgateway/pull/2080
Validates https://github.com/wso2/product-microgateway/pull/2128

### Automation tests
 - Integration tests added: Yes

### Tested environments
OS name: "linux", arch: "amd64", family: "unix"
OpenJDK Runtime Environment (build 11.0.10+9-Ubuntu-0ubuntu1.20.04)
4 cores, 8 threads

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
