### PR TITLE
Fix #2081 - Internal key cache issue

### DIFF
--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/dto/JWTTokenPayloadInfo.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/dto/JWTTokenPayloadInfo.java
@@ -28,7 +28,7 @@ public class JWTTokenPayloadInfo implements Serializable {
 
 
     JWTClaimsSet payload;
-    String rawPayload;
+    String accessToken;
 
     public JWTClaimsSet getPayload() {
         return payload;
@@ -38,11 +38,11 @@ public class JWTTokenPayloadInfo implements Serializable {
         this.payload = payload;
     }
 
-    public String getRawPayload() {
-        return rawPayload;
+    public String getAccessToken() {
+        return accessToken;
     }
 
-    public void setRawPayload(String rawPayload) {
-        this.rawPayload = rawPayload;
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
     }
 }


### PR DESCRIPTION
### Purpose
Fixes the issue of able to invoke with tampered internal key once the correct token gets cached.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2081 

### Automation tests
 - Unit tests added: No
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
