### PR TITLE
Fix #2146 - Remove x-envoy-upstream-service-time header from response

### DIFF
--- a/adapter/internal/oasparser/envoyconf/constants.go
+++ b/adapter/internal/oasparser/envoyconf/constants.go
@@ -67,6 +67,8 @@ const (
 const (
 	// clusterHeaderName denotes the constant used for header based routing decisions.
 	clusterHeaderName string = "x-wso2-cluster-header"
+	// upstreamServiceTimeHeader the header which is used to denote the upstream service time
+	upstreamServiceTimeHeader string = "x-envoy-upstream-service-time"
 )
 
 const (

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -371,11 +371,12 @@ func createRoute(params *routeCreateParams) *routev3.Route {
 
 	logger.LoggerOasparser.Debug("creating a route....")
 	var (
-		router       routev3.Route
-		action       *routev3.Route_Route
-		match        *routev3.RouteMatch
-		decorator    *routev3.Decorator
-		resourcePath string
+		router                  routev3.Route
+		action                  *routev3.Route_Route
+		match                   *routev3.RouteMatch
+		decorator               *routev3.Decorator
+		resourcePath            string
+		responseHeadersToRemove []string
 	)
 
 	// OPTIONS is always added even if it is not listed under resources
@@ -516,6 +517,8 @@ func createRoute(params *routeCreateParams) *routev3.Route {
 	if corsPolicy != nil {
 		action.Route.Cors = corsPolicy
 	}
+    // remove the 'x-envoy-upstream-service-time' from the response.
+	responseHeadersToRemove = append(responseHeadersToRemove, upstreamServiceTimeHeader)
 
 	logger.LoggerOasparser.Debug("adding route ", resourcePath)
 	router = routev3.Route{
@@ -527,6 +530,7 @@ func createRoute(params *routeCreateParams) *routev3.Route {
 		TypedPerFilterConfig: map[string]*any.Any{
 			wellknown.HTTPExternalAuthorization: filter,
 		},
+		ResponseHeadersToRemove: responseHeadersToRemove,
 	}
 	return &router
 }

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/SubscriptionValidationTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/SubscriptionValidationTestCase.java
@@ -45,6 +45,7 @@ public class SubscriptionValidationTestCase extends ApimBaseTest {
     public static final String API_NAME = "SubscriptionValidationApi";
     private static final String API_CONTEXT = "subs_validation";
     public static final String APPLICATION_NAME = "SubscriptionValidationApp";
+    public static final String X_ENVOY_UPSTREAM_SERVICE_TIME_HEADER= "x-envoy-upstream-service-time";
 
     @BeforeClass(alwaysRun = true, description = "initialise the setup")
     void setEnvironment() throws Exception {
@@ -86,7 +87,9 @@ public class SubscriptionValidationTestCase extends ApimBaseTest {
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_SUCCESS,
                             "Valid subscription should be able to invoke the associated API");
         Assert.assertEquals(response.getData(), ResponseConstants.RESPONSE_BODY,
-                            "Response message mismatched. Response Data: " + response.getData());
+                "Response message mismatched. Response Data: " + response.getData());
+        Assert.assertTrue(!response.getHeaders().containsKey(X_ENVOY_UPSTREAM_SERVICE_TIME_HEADER),
+                "Response contains the " + X_ENVOY_UPSTREAM_SERVICE_TIME_HEADER + " header.");
         try {
             // To publish analytics it takes at most one second.
             Thread.sleep(2000);


### PR DESCRIPTION
### Purpose
Remove the `x-envoy-upstream-service-time` from response

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2146 

### Automation tests
 - Unit tests added: No
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
