### PR TITLE
Updating APIDeployment type to match GA

### DIFF
--- a/adapter/pkg/synchronizer/types.go
+++ b/adapter/pkg/synchronizer/types.go
@@ -52,8 +52,10 @@ type DeploymentData struct {
 type APIDeployment struct {
 	APIFile      string         `json:"apiFile"`
 	Environments []GatewayLabel `json:"environments"`
-	// This property is used by global Adapter
+	// These properties are used by global Adapter
 	OrganizationID string `json:"organizationId"`
+	APIContext string `json:"apiContext"`
+	Version string `json:"version"`
 }
 
 // GatewayLabel represents gateway environment name and VHost of an API project


### PR DESCRIPTION
### Purpose
This is to reuse the `deployments.json` from `runtime-artifacts` endpoint for the same file received from `runtime-metadata` endpoint. The deployments.json from `runtime-metadata` has additional values `context` and `version` compared to the response from `runtime-artifacts`.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Related to #2040

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
