### PR TITLE
Enable readiness probe when the eventhub is disabled

### DIFF
--- a/adapter/internal/adapter/adapter.go
+++ b/adapter/internal/adapter/adapter.go
@@ -234,6 +234,10 @@ func Run(conf *config.Config) {
 		synchronizer.FetchKeyManagersOnStartUp(conf)
 		go synchronizer.UpdateKeyTemplates()
 		go synchronizer.UpdateBlockingConditions()
+	} else {
+		// We need to deploy the readiness probe when eventhub is disabled
+		xds.DeployReadinessAPI(envs)
+		logger.LoggerMgw.Info("Event hub disabled and hence deployed readiness probe")
 	}
 
 OUTER:


### PR DESCRIPTION
### Purpose
If the `eventhub` configuration is not enabled, then the readiness probe doesn't get activated and hence the pod goes into a `CrashLoopBack`. Therefore we need to enable the probe if the event hub configuration is disabled

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/2172

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
