### PR TITLE
Fix missing cors headers in token & other services

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/templates/tokenServices.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/tokenServices.mustache
@@ -24,6 +24,7 @@ string tokenContext = gateway:removePrePostSlash(gateway:getConfigValue(gateway:
 service authorizeService on tokenListenerEndpoint, apiSecureListener {
 
     @http:ResourceConfig {
+        methods:["GET"],
         path: "/*",
         auth: {
             enabled: false
@@ -70,6 +71,7 @@ service authorizeService on tokenListenerEndpoint, apiSecureListener {
 service revokeService on tokenListenerEndpoint, apiSecureListener {
 
     @http:ResourceConfig {
+        methods:["POST"],
         path: "/*",
         auth: {
             enabled: false
@@ -116,6 +118,7 @@ service revokeService on tokenListenerEndpoint, apiSecureListener {
 service tokenService on tokenListenerEndpoint, apiSecureListener {
 
     @http:ResourceConfig {
+        methods:["POST"],
         path: "/*",
         auth: {
             enabled: false
@@ -161,6 +164,7 @@ service tokenService on tokenListenerEndpoint, apiSecureListener {
 }
 service apiKeyService on apiSecureListener {
     @http:ResourceConfig {
+        methods:["GET"],
         path: "/*",
         auth: {
             enabled: true,
@@ -203,6 +207,7 @@ service apiKeyService on apiSecureListener {
 service userInfoService on tokenListenerEndpoint, apiSecureListener {
 
     @http:ResourceConfig {
+        methods:["GET"],
         path: "/*",
         auth: {
             enabled: false


### PR DESCRIPTION
## Purpose
As $subject this will fix the missing cors headers in /token , /revoke, /userInfo, /authorize, /apiKey services


## Approach
Before the fix, it doesn't define the extract method for all the service resources.
Hence ballerina treats Option call also as a supported method in particular resources.

As a fix, we have defined the extract method when creating particular service resources.

## Fixes
https://github.com/wso2/product-microgateway/issues/2165