### PR TITLE
Add correct environment variable name to be read for connection param

### DIFF
--- a/adapter/config/default_config.go
+++ b/adapter/config/default_config.go
@@ -250,6 +250,8 @@ var defaultConfig = &Config{
 		JmsConnectionParameters: jmsConnectionParameters{
 			EventListeningEndpoints: []string{"amqp://admin:$env{cp_admin_pwd}@apim:5672?retries='10'&connectdelay='30'"},
 		},
+		ASBConnectionParameters: asbConnectionParameters{
+			EventListeningEndpoint: "$env{ASB_CONNECTION_STRING}"},
 	},
 	Analytics: analytics{
 		Enabled: false,

--- a/adapter/config/types.go
+++ b/adapter/config/types.go
@@ -381,10 +381,15 @@ type controlPlane struct {
 	RetryInterval           time.Duration           `toml:"retryInterval"`
 	SkipSSLVerification     bool                    `toml:"skipSSLVerification"`
 	JmsConnectionParameters jmsConnectionParameters `toml:"jmsConnectionParameters"`
+	ASBConnectionParameters asbConnectionParameters `toml:"asbConnectionParameters"`
 }
 
 type jmsConnectionParameters struct {
 	EventListeningEndpoints []string `toml:"eventListeningEndpoints"`
+}
+
+type asbConnectionParameters struct {
+	EventListeningEndpoint string `toml:"eventListeningEndpoint"`
 }
 
 // APIContent contains everything necessary to create an API

--- a/adapter/internal/messaging/azure_listener.go
+++ b/adapter/internal/messaging/azure_listener.go
@@ -27,9 +27,8 @@ import (
 // InitiateAndProcessEvents to pass event consumption
 func InitiateAndProcessEvents(config *config.Config) {
 	logger.LoggerMgw.Info("[TEST][FEATURE_FLAG_REPLACE_EVENT_HUB] Starting InitiateAndProcessEvents method")
-	logger.LoggerMgw.Info("[TEST][FEATURE_FLAG_REPLACE_EVENT_HUB] EventListeningEndpoints are ", config.ControlPlane.
-		JmsConnectionParameters.EventListeningEndpoints)
-	//dummy payload sent for now
-	msg.InitiateBrokerConnection(config.ControlPlane.JmsConnectionParameters.EventListeningEndpoints)
+	logger.LoggerMgw.Info("[TEST][FEATURE_FLAG_REPLACE_EVENT_HUB] EventListeningEndpoint is ",
+		config.ControlPlane.ASBConnectionParameters.EventListeningEndpoint)
+	msg.InitiateBrokerConnection(config.ControlPlane.ASBConnectionParameters.EventListeningEndpoint)
 
 }

--- a/adapter/pkg/messaging/azure_connection.go
+++ b/adapter/pkg/messaging/azure_connection.go
@@ -32,9 +32,10 @@ func init() {
 }
 
 // InitiateBrokerConnection to pass event consumption
-func InitiateBrokerConnection(eventListeningEndpoints []string) error {
+func InitiateBrokerConnection(eventListeningEndpoint string) error {
 	var err error
-	logger.LoggerMgw.Info("[TEST][FEATURE_FLAG_REPLACE_EVENT_HUB] Trying to connect to azure service bus")
+	logger.LoggerMgw.Info("[TEST][FEATURE_FLAG_REPLACE_EVENT_HUB] Trying to connect to azure service bus with " +
+		"connection string " + eventListeningEndpoint)
 	err = nil
 	return err
 }

--- a/resources/conf/config.toml.template
+++ b/resources/conf/config.toml.template
@@ -363,6 +363,8 @@ idleTimeoutInSeconds = 3600
   # Message broker connection URL of the control plane
   [controlPlane.jmsConnectionParameters]
     eventListeningEndpoints = ["amqp://admin:$env{cp_admin_pwd}@apim:5672?retries='10'&connectdelay='30'"]
+  [controlPlane.asbConnectionParameters]
+    eventListeningEndpoint = "$env{ASB_CONNECTION_STRING}"
 
 # Analytics configurations for Choreo Connect
 [analytics]

--- a/resources/conf/config.toml.template
+++ b/resources/conf/config.toml.template
@@ -363,6 +363,7 @@ idleTimeoutInSeconds = 3600
   # Message broker connection URL of the control plane
   [controlPlane.jmsConnectionParameters]
     eventListeningEndpoints = ["amqp://admin:$env{cp_admin_pwd}@apim:5672?retries='10'&connectdelay='30'"]
+  # TODO: (dnwick) remove this config once a common connection parameter is introduced
   [controlPlane.asbConnectionParameters]
     eventListeningEndpoint = "$env{ASB_CONNECTION_STRING}"
 


### PR DESCRIPTION
### Purpose
Correctly set the the valid connection string to be used for receiving events from azure service bus

### Issues
Fixes https://github.com/wso2/product-microgateway/issues/2187

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
