### PR TITLE
Remove redundant resource appearances in observability client metrics

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/observability_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/observability_util.bal
@@ -62,7 +62,13 @@ public function gaugeTagDetails(http:Request request, http:FilterContext context
         return ();
     }
 
-    map<string> gaugeTags = {"Category": category, "Method": request.method, "ServicePath": request.rawPath, "Service": context.getServiceName()};
+    string resourceName = context.getResourceName();
+    string resource_Path = "";
+    http:HttpResourceConfig? httpResourceConfig = resourceAnnotationMap[resourceName];
+        if (httpResourceConfig is http:HttpResourceConfig) {
+            resource_Path = httpResourceConfig.path;
+        }
+    map<string> gaugeTags = {"Category": category, "Method": request.method, "ServicePath": resource_Path, "Service": context.getServiceName()};
     return gaugeTags;
 }
 
@@ -72,7 +78,13 @@ public function gaugeTagDetailsFromContext(http:FilterContext context, string ca
     }
     string requestMethod = runtime:getInvocationContext().attributes[REQUEST_METHOD].toString();
     string requestRawPath = runtime:getInvocationContext().attributes[REQUEST_RAWPATH].toString();
-    map<string> gaugeTags = {"Category": category, "Method": requestMethod, "ServicePath": requestRawPath, "Service": context.getServiceName()};
+    string resourceName = context.getResourceName();
+    string resource_Path = "";
+    http:HttpResourceConfig? httpResourceConfig = resourceAnnotationMap[resourceName];
+        if (httpResourceConfig is http:HttpResourceConfig) {
+            resource_Path = httpResourceConfig.path;
+        }
+    map<string> gaugeTags = {"Category": category, "Method": requestMethod, "ServicePath": resource_Path, "Service": context.getServiceName()};
     return gaugeTags;
 }
 
@@ -82,7 +94,13 @@ public function gaugeTagDetails_authn(http:Request request, string category) ret
     }
 
     string serviceName = runtime:getInvocationContext().attributes[http:SERVICE_NAME].toString();
-    map<string> gaugeTags = {"Category": category, "Method": request.method, "ServicePath": request.rawPath, "Service": serviceName};
+    string resourceName = runtime:getInvocationContext().attributes[http:RESOURCE_NAME].toString();
+    string resource_Path = "";
+    http:HttpResourceConfig? httpResourceConfig = resourceAnnotationMap[resourceName];
+        if (httpResourceConfig is http:HttpResourceConfig) {
+            resource_Path = httpResourceConfig.path;
+        }
+    map<string> gaugeTags = {"Category": category, "Method": request.method, "ServicePath": resource_Path, "Service": serviceName};
     return gaugeTags;
 }
 
@@ -94,7 +112,13 @@ public function gaugeTagDetails_basicAuth(string category) returns map<string> |
     string requestMethod = runtime:getInvocationContext().attributes[REQUEST_METHOD].toString();
     string requestRawPath = runtime:getInvocationContext().attributes[REQUEST_RAWPATH].toString();
     string serviceName = runtime:getInvocationContext().attributes[http:SERVICE_NAME].toString();
-    map<string> gaugeTags = {"Category": category, "Method": requestMethod, "ServicePath": requestRawPath, "Service": serviceName};
+    string resourceName = runtime:getInvocationContext().attributes[http:RESOURCE_NAME].toString();
+    string resource_Path = "";
+    http:HttpResourceConfig? httpResourceConfig = resourceAnnotationMap[resourceName];
+        if (httpResourceConfig is http:HttpResourceConfig) {
+            resource_Path = httpResourceConfig.path;
+        }
+    map<string> gaugeTags = {"Category": category, "Method": requestMethod, "ServicePath": resource_Path, "Service": serviceName};
     return gaugeTags;
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -575,7 +575,7 @@
     </build>
 
     <properties>
-        <ballerina.platform.version>1.2.17</ballerina.platform.version>
+        <ballerina.platform.version>1.2.18</ballerina.platform.version>
         <broker.version>0.970.5</broker.version>
         <assembly.plugin.version>3.1.1</assembly.plugin.version>
         <compiler.plugin.version>3.7.0</compiler.plugin.version>


### PR DESCRIPTION
## Purpose
AS $subject, this will remove the remove redundant resource appearances in observability metrics for **Per_Request_Duration_mean** attribute and,
 introduce a config to remove HttpClient metrics which includes **ballerina_http_HttpClient_requests_total_value** and **ballerina_http_HttpClient_response_time_seconds_value** attributes.

#### New config to remove HttpClient metrics:  
`--b7a.observability.metrics.client.http.url.disabled=true`