### PR TITLE
Upgrade ballerina to 1.2.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -575,7 +575,7 @@
     </build>
 
     <properties>
-        <ballerina.platform.version>1.2.18</ballerina.platform.version>
+        <ballerina.platform.version>1.2.19</ballerina.platform.version>
         <broker.version>0.970.5</broker.version>
         <assembly.plugin.version>3.1.1</assembly.plugin.version>
         <compiler.plugin.version>3.7.0</compiler.plugin.version>


### PR DESCRIPTION
## Purpose
As $subject, this will upgrade the ballerina version to 1.2.19 and it will solve the Jaeger tracing starup issue.

### Issues

- https://github.com/wso2/product-microgateway/issues/2199