### PR TITLE
Fix not giving priority to x-wso2 extensions when server url is malformed

### DIFF
--- a/adapter/internal/oasparser/model/open_api.go
+++ b/adapter/internal/oasparser/model/open_api.go
@@ -85,7 +85,7 @@ func (swagger *MgwSwagger) SetInfoOpenAPI(swagger3 openapi3.Swagger) error {
 				swagger.productionUrls = append(swagger.productionUrls, *endpoint)
 				swagger.xWso2Basepath = endpoint.Basepath
 			} else {
-				logger.LoggerOasparser.Errorf("error encountered when parsing the endpoint")
+				logger.LoggerOasparser.Errorf("error encountered when parsing the endpoint under openAPI servers object")
 			}
 		}
 	}

--- a/adapter/internal/oasparser/model/open_api.go
+++ b/adapter/internal/oasparser/model/open_api.go
@@ -142,7 +142,7 @@ func setResourcesOpenAPI(openAPI openapi3.Swagger) ([]Resource, error) {
 					if err == nil {
 						resource.productionUrls = append(resource.productionUrls, *endpoint)
 					} else {
-						logger.LoggerOasparser.Errorf("error encountered when parsing the endpoint")
+						logger.LoggerOasparser.Errorf("error encountered when parsing the endpoint under openAPI servers object")
 					}
 
 				}

--- a/adapter/internal/oasparser/model/open_api.go
+++ b/adapter/internal/oasparser/model/open_api.go
@@ -85,7 +85,7 @@ func (swagger *MgwSwagger) SetInfoOpenAPI(swagger3 openapi3.Swagger) error {
 				swagger.productionUrls = append(swagger.productionUrls, *endpoint)
 				swagger.xWso2Basepath = endpoint.Basepath
 			} else {
-				return errors.New("error encountered when parsing the endpoint")
+				logger.LoggerOasparser.Errorf("error encountered when parsing the endpoint")
 			}
 		}
 	}
@@ -142,7 +142,7 @@ func setResourcesOpenAPI(openAPI openapi3.Swagger) ([]Resource, error) {
 					if err == nil {
 						resource.productionUrls = append(resource.productionUrls, *endpoint)
 					} else {
-						return nil, errors.New("error encountered when parsing the endpoint")
+						logger.LoggerOasparser.Errorf("error encountered when parsing the endpoint")
 					}
 
 				}


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
Fix not giving priority to x-wso2 extensions when server url is malformed. As the solution, stop throwing error if malformed URL/ templated URL is found under servers object

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #https://github.com/wso2/product-microgateway/issues/2226

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Manually tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
