### PR TITLE
Add Jaeger metric exporting

### DIFF
--- a/adapter/config/default_config.go
+++ b/adapter/config/default_config.go
@@ -180,7 +180,7 @@ var defaultConfig = &Config{
 			Type: "azure",
 			ConfigProperties: map[string]string{
 				"connectionString":   "",
-				"instrumentationName": "WSO2-CHOREO",
+				"instrumentationName": "CHOREO-CONNECT",
 				"maximumTracesPerSecond": "2",
 			},
 		},

--- a/enforcer/pom.xml
+++ b/enforcer/pom.xml
@@ -406,5 +406,13 @@
             <artifactId>jackson-annotations</artifactId>
             <version>${jackson.annotations.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-jaeger</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/enforcer/pom.xml
+++ b/enforcer/pom.xml
@@ -426,5 +426,10 @@
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/enforcer/pom.xml
+++ b/enforcer/pom.xml
@@ -390,6 +390,16 @@
             <groupId>com.azure</groupId>
             <artifactId>azure-monitor-opentelemetry-exporter</artifactId>
             <version>${azure.monitor.opentelemetry.exporter.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.opentelemetry</groupId>
+                    <artifactId>opentelemetry-sdk</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.opentelemetry</groupId>
+                    <artifactId>opentelemetry-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
@@ -408,11 +418,19 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-jaeger</artifactId>
+            <artifactId>opentelemetry-exporter-jaeger-thrift</artifactId>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-semconv</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/enforcer/pom.xml
+++ b/enforcer/pom.xml
@@ -375,11 +375,9 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jcl</artifactId>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.java-websocket/Java-WebSocket -->
         <dependency>
             <groupId>org.java-websocket</groupId>
             <artifactId>Java-WebSocket</artifactId>
-            <version>1.5.1</version>
         </dependency>
         <!-- slf4j binding -->
         <dependency>
@@ -389,7 +387,6 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-monitor-opentelemetry-exporter</artifactId>
-            <version>${azure.monitor.opentelemetry.exporter.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.opentelemetry</groupId>
@@ -404,17 +401,14 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>applicationinsights-core</artifactId>
-            <version>${applicationinsights.core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${enforcer.jackson.databind.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.annotations.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/config/ConfigDefaults.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/config/ConfigDefaults.java
@@ -32,7 +32,7 @@ public class ConfigDefaults {
     public static final boolean TRACING_ENABLED_VALUE = false;
     public static final String AZURE_TRACE_EXPORTER = "azure";
     public static final int MAXIMUM_TRACES_PER_SECOND = 2;
-    public static final String INSTRUMENTATION_NAME = "WSO2-CHOREO";
+    public static final String INSTRUMENTATION_NAME = "CHOREO-CONNECT";
 
     //Metrics related default values
     public static final boolean METRICS_ENABLED_VALUE = false;

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/RateLimitingSampler.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/RateLimitingSampler.java
@@ -9,7 +9,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.sdk.internal.SystemClock;
+import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
@@ -38,7 +38,7 @@ public class RateLimitingSampler implements Sampler {
     public RateLimitingSampler(int maxTracesPerSecond) {
         this.maxTracesPerSecond = maxTracesPerSecond;
         double maxBalance = maxTracesPerSecond < 1.0 ? 1.0 : maxTracesPerSecond;
-        this.rateLimiter = new RateLimiter(maxTracesPerSecond, maxBalance, SystemClock.getInstance());
+        this.rateLimiter = new RateLimiter(maxTracesPerSecond, maxBalance, Clock.getDefault());
         Attributes attributes = Attributes.empty();
         this.onSamplingResult = SamplingResult.create(SamplingDecision.RECORD_AND_SAMPLE, attributes);
         this.offSamplingResult = SamplingResult.create(SamplingDecision.DROP, attributes);

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/TracerFactory.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/TracerFactory.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.Logger;
 import org.wso2.choreo.connect.enforcer.config.ConfigHolder;
 import org.wso2.choreo.connect.enforcer.config.dto.TracingDTO;
 import org.wso2.choreo.connect.enforcer.server.AuthServer;
+import org.wso2.choreo.connect.enforcer.tracing.exporters.AzureExporter;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -66,7 +67,7 @@ public class TracerFactory {
             exporterType = TracingConstants.AZURE_TRACE_EXPORTER;
         }
         if (exporterType.equalsIgnoreCase(TracingConstants.AZURE_TRACE_EXPORTER)) {
-            this.tracer = AzureTraceExporter.getInstance().initTracer(properties);
+            this.tracer = AzureExporter.getInstance().initTracer(properties);
         } else {
             logger.error("Tracer exporter type: " + exporterType + " not found!");
         }

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/TracerFactory.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/TracerFactory.java
@@ -26,6 +26,7 @@ import org.wso2.choreo.connect.enforcer.config.ConfigHolder;
 import org.wso2.choreo.connect.enforcer.config.dto.TracingDTO;
 import org.wso2.choreo.connect.enforcer.server.AuthServer;
 import org.wso2.choreo.connect.enforcer.tracing.exporters.AzureExporter;
+import org.wso2.choreo.connect.enforcer.tracing.exporters.JaegerExporter;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -68,6 +69,8 @@ public class TracerFactory {
         }
         if (exporterType.equalsIgnoreCase(TracingConstants.AZURE_TRACE_EXPORTER)) {
             this.tracer = AzureExporter.getInstance().initTracer(properties);
+        } else if (TracingConstants.JAEGER_TRACE_EXPORTER.equalsIgnoreCase(exporterType)) {
+            this.tracer = JaegerExporter.getInstance().initTracer(properties);
         } else {
             logger.error("Tracer exporter type: " + exporterType + " not found!");
         }

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/TracingConstants.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/TracingConstants.java
@@ -25,7 +25,9 @@ package org.wso2.choreo.connect.enforcer.tracing;
 public class TracingConstants {
 
     public static final String CONNECTION_STRING = "connectionString";
+    public static final String SERVICE_NAME = "choreo_connect";
     public static final String AZURE_TRACE_EXPORTER = "azure";
+    public static final String JAEGER_TRACE_EXPORTER = "jaeger";
     public static final String MAXIMUM_TRACES_PER_SECOND = "maximumTracesPerSecond";
     public static final String INSTRUMENTATION_NAME = "instrumentationName";
     public static final String DO_THROTTLE_SPAN = "ThrottleFilter:doThrottle():Throttling function";

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/AzureExporter.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/AzureExporter.java
@@ -35,7 +35,7 @@ import org.wso2.choreo.connect.enforcer.tracing.TracingException;
 import java.util.Map;
 
 /**
- * This class is responsible for managing and exporting tracing spans
+ * This class is responsible for managing and exporting tracing spans.
  */
 public class AzureExporter implements TracerBuilder {
 
@@ -54,7 +54,7 @@ public class AzureExporter implements TracerBuilder {
     }
 
     /**
-     * Initialize the tracer with AzureMonitorTraceExporter
+     * Initialize the tracer with AzureMonitorTraceExporter.
      */
     @Override
     public Tracer initTracer(Map<String, String> properties) throws TracingException {
@@ -62,25 +62,24 @@ public class AzureExporter implements TracerBuilder {
         String connectionString = properties.get(TracingConstants.CONNECTION_STRING);
         if (StringUtils.isEmpty(connectionString)) {
             throw new TracingException("Error initializing Azure Trace Exporter. ConnectionString is null or empty.");
-        } else {
-            String maxTracesPerSecondString = properties.get(TracingConstants.MAXIMUM_TRACES_PER_SECOND);
-            int maxTracesPerSecond = StringUtils.isEmpty(maxTracesPerSecondString) ?
-                    ConfigDefaults.MAXIMUM_TRACES_PER_SECOND : Integer.valueOf(maxTracesPerSecondString);
-            String instrumentationName = StringUtils.isEmpty(properties.get(TracingConstants.INSTRUMENTATION_NAME)) ?
-                    ConfigDefaults.INSTRUMENTATION_NAME : properties.get(TracingConstants.INSTRUMENTATION_NAME);
-
-            AzureMonitorTraceExporter exporter = new AzureMonitorExporterBuilder()
-                    .connectionString(connectionString).buildTraceExporter();
-
-            SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
-                    .setSampler(new RateLimitingSampler(maxTracesPerSecond))
-                    .addSpanProcessor(SimpleSpanProcessor.create(exporter)).build();
-
-            OpenTelemetrySdk openTelemetrySdk = OpenTelemetrySdk.builder()
-                    .setTracerProvider(tracerProvider).buildAndRegisterGlobal();
-            LOGGER.info("Tracer successfully initialized with Azure Trace Exporter.");
-
-            return openTelemetrySdk.getTracer(instrumentationName);
         }
+        String maxTracesPerSecondString = properties.get(TracingConstants.MAXIMUM_TRACES_PER_SECOND);
+        int maxTracesPerSecond = StringUtils.isEmpty(maxTracesPerSecondString) ?
+                ConfigDefaults.MAXIMUM_TRACES_PER_SECOND : Integer.valueOf(maxTracesPerSecondString);
+        String instrumentationName = StringUtils.isEmpty(properties.get(TracingConstants.INSTRUMENTATION_NAME)) ?
+                ConfigDefaults.INSTRUMENTATION_NAME : properties.get(TracingConstants.INSTRUMENTATION_NAME);
+
+        AzureMonitorTraceExporter exporter = new AzureMonitorExporterBuilder()
+                .connectionString(connectionString).buildTraceExporter();
+
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+                .setSampler(new RateLimitingSampler(maxTracesPerSecond))
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter)).build();
+
+        OpenTelemetrySdk openTelemetrySdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider).buildAndRegisterGlobal();
+        LOGGER.info("Tracer successfully initialized with Azure Trace Exporter.");
+
+        return openTelemetrySdk.getTracer(instrumentationName);
     }
 }

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/AzureExporter.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/AzureExporter.java
@@ -11,12 +11,11 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
-package org.wso2.choreo.connect.enforcer.tracing;
+package org.wso2.choreo.connect.enforcer.tracing.exporters;
 
 import com.azure.monitor.opentelemetry.exporter.AzureMonitorExporterBuilder;
 import com.azure.monitor.opentelemetry.exporter.AzureMonitorTraceExporter;
@@ -28,26 +27,30 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.wso2.choreo.connect.enforcer.config.ConfigDefaults;
+import org.wso2.choreo.connect.enforcer.tracing.RateLimitingSampler;
+import org.wso2.choreo.connect.enforcer.tracing.TracerBuilder;
+import org.wso2.choreo.connect.enforcer.tracing.TracingConstants;
+import org.wso2.choreo.connect.enforcer.tracing.TracingException;
 
 import java.util.Map;
 
 /**
  * This class is responsible for managing and exporting tracing spans
  */
-public class AzureTraceExporter implements TracerBuilder {
+public class AzureExporter implements TracerBuilder {
 
-    private static final Logger LOGGER = LogManager.getLogger(AzureTraceExporter.class);
-    private static AzureTraceExporter azureTraceExporter;
+    private static final Logger LOGGER = LogManager.getLogger(AzureExporter.class);
+    private static AzureExporter exporter;
 
-    public static AzureTraceExporter getInstance() {
-        if (azureTraceExporter == null) {
+    public static AzureExporter getInstance() {
+        if (exporter == null) {
             synchronized (new Object()) {
-                if (azureTraceExporter == null) {
-                    azureTraceExporter = new AzureTraceExporter();
+                if (exporter == null) {
+                    exporter = new AzureExporter();
                 }
             }
         }
-        return azureTraceExporter;
+        return exporter;
     }
 
     /**
@@ -75,7 +78,7 @@ public class AzureTraceExporter implements TracerBuilder {
 
             OpenTelemetrySdk openTelemetrySdk = OpenTelemetrySdk.builder()
                     .setTracerProvider(tracerProvider).buildAndRegisterGlobal();
-            LOGGER.debug("Tracer successfully initialized with Azure Trace Exporter.");
+            LOGGER.info("Tracer successfully initialized with Azure Trace Exporter.");
 
             return openTelemetrySdk.getTracer(instrumentationName);
         }

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/AzureExporter.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/AzureExporter.java
@@ -65,7 +65,7 @@ public class AzureExporter implements TracerBuilder {
         }
         String maxTracesPerSecondString = properties.get(TracingConstants.MAXIMUM_TRACES_PER_SECOND);
         int maxTracesPerSecond = StringUtils.isEmpty(maxTracesPerSecondString) ?
-                ConfigDefaults.MAXIMUM_TRACES_PER_SECOND : Integer.valueOf(maxTracesPerSecondString);
+                ConfigDefaults.MAXIMUM_TRACES_PER_SECOND : Integer.parseInt(maxTracesPerSecondString);
         String instrumentationName = StringUtils.isEmpty(properties.get(TracingConstants.INSTRUMENTATION_NAME)) ?
                 ConfigDefaults.INSTRUMENTATION_NAME : properties.get(TracingConstants.INSTRUMENTATION_NAME);
 

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/JaegerExporter.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/JaegerExporter.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.choreo.connect.enforcer.tracing.exporters;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.wso2.choreo.connect.enforcer.config.ConfigDefaults;
+import org.wso2.choreo.connect.enforcer.tracing.RateLimitingSampler;
+import org.wso2.choreo.connect.enforcer.tracing.TracerBuilder;
+import org.wso2.choreo.connect.enforcer.tracing.TracingConstants;
+import org.wso2.choreo.connect.enforcer.tracing.TracingException;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This class is responsible for exporting tracing spans for jaeger.
+ */
+public class JaegerExporter implements TracerBuilder {
+
+    private static final Logger LOGGER = LogManager.getLogger(JaegerExporter.class);
+    private static JaegerExporter exporter;
+
+    public static JaegerExporter getInstance() {
+        if (exporter == null) {
+            synchronized (new Object()) {
+                if (exporter == null) {
+                    exporter = new JaegerExporter();
+                }
+            }
+        }
+        return exporter;
+    }
+
+    /**
+     * Initialize the tracer with {@link JaegerExporter}.
+     */
+    @Override
+    public Tracer initTracer(Map<String, String> properties) throws TracingException {
+        String jaegerEp = properties.get(TracingConstants.CONNECTION_STRING);
+
+        if (StringUtils.isEmpty(jaegerEp)) {
+            throw new TracingException("Error initializing Jaeger Trace Exporter. Connection url is missing.");
+        }
+        // Create a channel towards Jaeger end point
+        // TODO: Make possible to enable ssl
+        ManagedChannel jaegerChannel = ManagedChannelBuilder.forTarget(jaegerEp).usePlaintext().build();
+        JaegerGrpcSpanExporter jaegerExporter = JaegerGrpcSpanExporter.builder()
+                .setChannel(jaegerChannel)
+                .setTimeout(30, TimeUnit.SECONDS)
+                .build();
+
+        Resource serviceNameResource =
+                Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, TracingConstants.SERVICE_NAME));
+
+
+        String maxTracesPerSecondString = properties.get(TracingConstants.MAXIMUM_TRACES_PER_SECOND);
+        int maxTracesPerSecond = StringUtils.isEmpty(maxTracesPerSecondString) ?
+                ConfigDefaults.MAXIMUM_TRACES_PER_SECOND : Integer.parseInt(maxTracesPerSecondString);
+        String instrumentationName = StringUtils.isEmpty(properties.get(TracingConstants.INSTRUMENTATION_NAME)) ?
+                ConfigDefaults.INSTRUMENTATION_NAME : properties.get(TracingConstants.INSTRUMENTATION_NAME);
+
+        // Set to process the spans by the Jaeger Exporter
+        SdkTracerProvider provider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(jaegerExporter))
+                .setSampler(new RateLimitingSampler(maxTracesPerSecond))
+                .setResource(Resource.getDefault().merge(serviceNameResource))
+                .build();
+        OpenTelemetrySdk ot = OpenTelemetrySdk.builder().setTracerProvider(provider).buildAndRegisterGlobal();
+
+        LOGGER.info("Tracer successfully initialized with Jaeger Trace Exporter.");
+        return ot.getTracer(instrumentationName);
+    }
+}

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/JaegerExporter.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/JaegerExporter.java
@@ -17,11 +17,9 @@
  */
 package org.wso2.choreo.connect.enforcer.tracing.exporters;
 
-import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
+import io.opentelemetry.exporter.jaeger.thrift.JaegerThriftSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -37,7 +35,6 @@ import org.wso2.choreo.connect.enforcer.tracing.TracingConstants;
 import org.wso2.choreo.connect.enforcer.tracing.TracingException;
 
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 /**
  * This class is responsible for exporting tracing spans for jaeger.
@@ -68,12 +65,8 @@ public class JaegerExporter implements TracerBuilder {
         if (StringUtils.isEmpty(jaegerEp)) {
             throw new TracingException("Error initializing Jaeger Trace Exporter. Connection url is missing.");
         }
-        // Create a channel towards Jaeger end point
-        // TODO: Make possible to enable ssl
-        ManagedChannel jaegerChannel = ManagedChannelBuilder.forTarget(jaegerEp).usePlaintext().build();
-        JaegerGrpcSpanExporter jaegerExporter = JaegerGrpcSpanExporter.builder()
-                .setChannel(jaegerChannel)
-                .setTimeout(30, TimeUnit.SECONDS)
+        JaegerThriftSpanExporter jaegerExporter = JaegerThriftSpanExporter.builder()
+                .setEndpoint(jaegerEp)
                 .build();
 
         Resource serviceNameResource =

--- a/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/JaegerExporter.java
+++ b/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/JaegerExporter.java
@@ -68,11 +68,8 @@ public class JaegerExporter implements TracerBuilder {
         JaegerThriftSpanExporter jaegerExporter = JaegerThriftSpanExporter.builder()
                 .setEndpoint(jaegerEp)
                 .build();
-
         Resource serviceNameResource =
                 Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, TracingConstants.SERVICE_NAME));
-
-
         String maxTracesPerSecondString = properties.get(TracingConstants.MAXIMUM_TRACES_PER_SECOND);
         int maxTracesPerSecond = StringUtils.isEmpty(maxTracesPerSecondString) ?
                 ConfigDefaults.MAXIMUM_TRACES_PER_SECOND : Integer.parseInt(maxTracesPerSecondString);

--- a/enforcer/src/test/java/org/wso2/choreo/connect/enforcer/tracing/exporters/JaegerExporterTest.java
+++ b/enforcer/src/test/java/org/wso2/choreo/connect/enforcer/tracing/exporters/JaegerExporterTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.choreo.connect.enforcer.tracing.exporters;
 
 import io.opentelemetry.api.trace.Tracer;

--- a/enforcer/src/test/java/org/wso2/choreo/connect/enforcer/tracing/exporters/JaegerExporterTest.java
+++ b/enforcer/src/test/java/org/wso2/choreo/connect/enforcer/tracing/exporters/JaegerExporterTest.java
@@ -1,0 +1,45 @@
+package org.wso2.choreo.connect.enforcer.tracing.exporters;
+
+import io.opentelemetry.api.trace.Tracer;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wso2.choreo.connect.enforcer.tracing.TracingConstants;
+import org.wso2.choreo.connect.enforcer.tracing.TracingException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class JaegerExporterTest {
+    private static Map<String, String> okProps;
+    private static Map<String, String> badProps;
+
+    @BeforeClass
+    public static void setup() {
+        okProps = new HashMap<>();
+        badProps = new HashMap<>();
+        okProps.put(TracingConstants.CONNECTION_STRING, "http://localhost:9411/api/v2/span");
+        okProps.put(TracingConstants.MAXIMUM_TRACES_PER_SECOND, "3");
+        okProps.put(TracingConstants.INSTRUMENTATION_NAME, "CC");
+        badProps.put(TracingConstants.CONNECTION_STRING, "localhost:9411");
+    }
+
+    @Test
+    public void testSuccessExporterInit() throws TracingException {
+        Tracer t = JaegerExporter.getInstance().initTracer(okProps);
+        Assert.assertNotNull("Tracer can't be null", t);
+    }
+
+    @Test
+    public void testInitWithInvalidEP() {
+        Assert.assertThrows("Incorrect exception was thrown", IllegalArgumentException.class, () ->
+                JaegerExporter.getInstance().initTracer(badProps));
+    }
+
+    @Test
+    public void testInitWithoutEP() {
+        badProps.put(TracingConstants.CONNECTION_STRING, "");
+        Assert.assertThrows("Incorrect exception was thrown", TracingException.class, () ->
+                JaegerExporter.getInstance().initTracer(badProps));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -381,9 +381,19 @@
                 <version>${analytics.publisher.client.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.java-websocket</groupId>
+                <artifactId>Java-WebSocket</artifactId>
+                <version>${java.websocket.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson.databind.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.awaitility</groupId>
@@ -400,6 +410,16 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
                 <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-monitor-opentelemetry-exporter</artifactId>
+                <version>${azure.monitor.opentelemetry.exporter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>applicationinsights-core</artifactId>
+                <version>${applicationinsights.core.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry</groupId>
@@ -442,6 +462,7 @@
         <io.fabric8.docker.plugin.version>0.34.1</io.fabric8.docker.plugin.version>
         <io.netty.version>4.1.68.Final</io.netty.version>
         <jaeger.exporter.version>1.6.0</jaeger.exporter.version>
+        <java.websocket.version>1.5.1</java.websocket.version>
         <json.smart.version>2.4.7</json.smart.version>
         <log4j.version>2.13.3</log4j.version>
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
@@ -472,13 +493,12 @@
         <analytics.publisher.client.version>1.0.4</analytics.publisher.client.version>
         <awaitility.version>3.1.2</awaitility.version>
         <apache.httpcomponents.version>4.5.13</apache.httpcomponents.version>
-        <jackson.databind.version>2.10.5.1</jackson.databind.version>
+        <jackson.databind.version>2.12.4</jackson.databind.version>
         <snakeyaml.version>1.26</snakeyaml.version>
         <exec.maven.plugin.version>3.0.0</exec.maven.plugin.version>
         <googlecode.download.plugin.version>1.6.3</googlecode.download.plugin.version>
 
         <!-- Enforcer metrics, tracing related dependencies -->
-        <enforcer.jackson.databind.version>2.12.4</enforcer.jackson.databind.version>
         <jackson.annotations.version>2.12.4</jackson.annotations.version>
         <applicationinsights.core.version>2.6.3</applicationinsights.core.version>
         <azure.monitor.opentelemetry.exporter.version>1.0.0-beta.4</azure.monitor.opentelemetry.exporter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -441,6 +441,12 @@
                 <artifactId>opentelemetry-api</artifactId>
                 <version>${otel.version}</version>
             </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -464,6 +470,7 @@
         <jaeger.exporter.version>1.6.0</jaeger.exporter.version>
         <java.websocket.version>1.5.1</java.websocket.version>
         <json.smart.version>2.4.7</json.smart.version>
+        <junit.version>4.13.2</junit.version>
         <log4j.version>2.13.3</log4j.version>
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
         <maven.checkstyle.version>8.18</maven.checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -401,6 +401,16 @@
                 <artifactId>log4j-slf4j-impl</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-exporter-jaeger</artifactId>
+                <version>${jaeger.exporter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-semconv</artifactId>
+                <version>${otel.semconv.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -421,6 +431,7 @@
         <guava.version>30.0-jre</guava.version>
         <io.fabric8.docker.plugin.version>0.34.1</io.fabric8.docker.plugin.version>
         <io.netty.version>4.1.68.Final</io.netty.version>
+        <jaeger.exporter.version>1.6.0</jaeger.exporter.version>
         <json.smart.version>2.4.7</json.smart.version>
         <log4j.version>2.13.3</log4j.version>
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
@@ -430,6 +441,7 @@
         <nimbus.jose.jwt.version>7.9</nimbus.jose.jwt.version>
         <org.json.version>3.0.0.wso2v1</org.json.version>
         <os.mvn.plugin.version>1.6.2</os.mvn.plugin.version>
+        <otel.semconv.version>1.6.0-alpha</otel.semconv.version>
         <shade.plugin.version>3.2.4</shade.plugin.version>
         <slf4j.version>1.7.21</slf4j.version>
         <swagger.v3.parser.version>2.0.12</swagger.v3.parser.version>

--- a/pom.xml
+++ b/pom.xml
@@ -403,13 +403,23 @@
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry</groupId>
-                <artifactId>opentelemetry-exporter-jaeger</artifactId>
+                <artifactId>opentelemetry-exporter-jaeger-thrift</artifactId>
                 <version>${jaeger.exporter.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-semconv</artifactId>
-                <version>${otel.semconv.version}</version>
+                <version>${otel.alpha.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-sdk</artifactId>
+                <version>${otel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-api</artifactId>
+                <version>${otel.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -441,7 +451,8 @@
         <nimbus.jose.jwt.version>7.9</nimbus.jose.jwt.version>
         <org.json.version>3.0.0.wso2v1</org.json.version>
         <os.mvn.plugin.version>1.6.2</os.mvn.plugin.version>
-        <otel.semconv.version>1.6.0-alpha</otel.semconv.version>
+        <otel.alpha.version>1.6.0-alpha</otel.alpha.version>
+        <otel.version>1.6.0</otel.version>
         <shade.plugin.version>3.2.4</shade.plugin.version>
         <slf4j.version>1.7.21</slf4j.version>
         <swagger.v3.parser.version>2.0.12</swagger.v3.parser.version>

--- a/resources/conf/config.toml.template
+++ b/resources/conf/config.toml.template
@@ -443,7 +443,7 @@ enable = true
     # Exporter ConnectionString
     connectionString = "$env{APPLICATIONINSIGHTS_CONNECTION_STRING}"
     # Instrumentation Name
-    instrumentationName = "WSO2-CHOREO"
+    instrumentationName = "CHOREO-CONNECT"
     # Maximum number of sampled traces per second string
     maximumTracesPerSecond = "2"
 


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
Add jaeger exporter to enable exporting open telemetry metrics to jaeger. Only thrift exporter is supported at the moment.
# Tracing configurations for Choreo Connect
```toml
[enforcer.tracing]
  enabled = true
  type = "jaeger"
  [enforcer.tracing.configProperties]
    connectionString = "http://jaeger:14268/api/traces"
    instrumentationName = "CHOREO-CONNECT"
    maximumTracesPerSecond = "2"
```
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Partially fixes #2234 

### Automation tests
 - Unit tests added: Yes
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Mac OS. docker-compose-with-apim

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
