### PR TITLE
Addition of wait time to API key test case

### DIFF
--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/APIKeyTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/APIKeyTestCase.java
@@ -104,6 +104,8 @@ public class APIKeyTestCase extends ApimBaseTest {
         APIKeyDTO refererTestAPIKeyDTO = storeRestClient.generateAPIKeys(applicationId, TestConstant.KEY_TYPE_PRODUCTION,
                 -1, null, "www.abc.com");
         apiKeyForRefererTest = refererTestAPIKeyDTO.getApikey();
+
+        Utils.delay(TestConstant.DEPLOYMENT_WAIT_TIME, "Could not wait till initial setup completion.");
     }
 
     //    Invokes with tampered API key and this will fail.


### PR DESCRIPTION
### Purpose
Adds a waiting time until API key relevant test setup properly prepares.

### Issues
There were intermittent test cases in API key related tests.
https://github.com/wso2/product-microgateway/issues/2235

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
Mac OS Big Sur
java version "11.0.12" 2021-07-20 LTS

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
