### PR TITLE
bug fix: GRPC Error status is not properly passed when java backend used with interceptor

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/authz_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/authz_filter.bal
@@ -59,7 +59,7 @@ public type OAuthzFilter object {
 
     }
 
-    public function filterResponse(http:Response response, http:FilterContext context) returns boolean {
+    public function filterResponse(@tainted http:Response response, http:FilterContext context) returns boolean {
         if (context.attributes.hasKey(SKIP_ALL_FILTERS) && <boolean>context.attributes[SKIP_ALL_FILTERS]) {
             printDebug(KEY_AUTHZ_FILTER, "Skip all filter annotation set in the service. Skip the filter");
             return true;
@@ -74,7 +74,7 @@ public type OAuthzFilter object {
 
 
 
-public function doAuthzFilterResponse(http:Response response, http:FilterContext context) returns boolean {
+public function doAuthzFilterResponse(@tainted http:Response response, http:FilterContext context) returns boolean {
     // In authorization filter we have specifically set the error payload since we are using ballerina in built
     // authzFilter
     // when unauthorized response is coming from a backend/interceptor,
@@ -97,7 +97,7 @@ public function doAuthzFilterResponse(http:Response response, http:FilterContext
 }
 
 
-public function setAuthorizationFailureMessage(http:Response response, http:FilterContext context) {
+public function setAuthorizationFailureMessage(@tainted http:Response response, http:FilterContext context) {
     string errorDescription = INVALID_SCOPE_MESSAGE;
     string errorMessage = INVALID_SCOPE_MESSAGE;
     int errorCode = INVALID_SCOPE;

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/filter_wrappers/authz_filter_wrapper.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/filter_wrappers/authz_filter_wrapper.bal
@@ -34,7 +34,7 @@ public type OAuthzFilterWrapper object {
         return result;
     }
 
-    public function filterResponse(http:Response response, http:FilterContext context) returns boolean {
+    public function filterResponse(@tainted http:Response response, http:FilterContext context) returns boolean {
         //Start a new root span without attaching to the system span.
         int | error | () spanIdRes = startSpan(AUTHZ_FILTER_RESPONSE);
         boolean result = self.oAuthzFilter.filterResponse(response, context);


### PR DESCRIPTION
## Purpose
> When the grpc backend's response error code looks like following, 
```
[2021-06-03 11:06:44,557] TRACE {http.tracelog.upstream} - [id: 0x08df5ae3, L:/127.0.0.1:56777 - R:localhost/127.0.0.1:9091] INBOUND HEADERS: streamId=3 headers=DefaultHttp2Headers[:status: 200, content-type: application/grpc, grpc-status: 7] streamDependency=0 weight=16 exclusive=false padding=0 endStream=true
```
the microgateway modifies it prior to sending to client. Hence the grpc protocol is violated.
```
[2021-06-03 11:06:44,561] TRACE {http.tracelog.downstream} - [id: 0x853de0c3, L:/127.0.0.1:9090 - R:/127.0.0.1:56776] OUTBOUND HEADERS: streamId=1 headers=DefaultHttp2Headers[:status: 200, content-type: application/grpc, grpc-status: 7, trailer: grpc-status, server: ballerina, date: Thu, 3 Jun 2021 11:06:44 +0530] padding=0 endStream=false  
[2021-06-02 23:56:15,364] TRACE {http.tracelog.downstream} - [id: 0x9fd3b3b6, L:/127.0.0.1:9090 - R:/127.0.0.1:55070] OUTBOUND DATA: streamId=1 padding=0 endStream=true length=0 data= 0B  
```

With this fix,
- if grpc-status header is identified as a regular header, then it would be added again as a trailing header. And this approach is accepted according to the protocol.
- grpc-status header is available, then no modification is done. it would be forwarded to the client as it is.




### Fixes
1. https://github.com/wso2/product-apim/issues/11804