### PR TITLE
Read response code from "responseCode" in direct response

### DIFF
--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testCases/standalone/interceptor/InterceptorRequestFlowTestcase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testCases/standalone/interceptor/InterceptorRequestFlowTestcase.java
@@ -222,7 +222,7 @@ public class InterceptorRequestFlowTestcase extends InterceptorBaseTestCase {
         // test updating body is also work with dynamic endpoint
         interceptorRespBodyJSON.put("body", Base64.getEncoder().encodeToString(interceptorRespBody.getBytes()));
         interceptorRespBodyJSON.put("directRespond", true);
-        interceptorRespBodyJSON.put("responseCode", "201");
+        interceptorRespBodyJSON.put("responseCode", 202);
         setResponseOfInterceptor(interceptorRespBodyJSON.toString(), true);
 
         // setting client
@@ -232,7 +232,7 @@ public class InterceptorRequestFlowTestcase extends InterceptorBaseTestCase {
                 basePath + "/pet/findByStatus/resp-intercept-enabled"), "INITIAL BODY", headers);
 
         Assert.assertNotNull(response);
-        Assert.assertEquals(response.getResponseCode(), 201, "Response code mismatched");
+        Assert.assertEquals(response.getResponseCode(), 202, "Response code mismatched");
 
         // check which flows are invoked in interceptor service
         JSONObject status = getInterceptorStatus();

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testCases/standalone/interceptor/InterceptorServiceRequestBodyTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testCases/standalone/interceptor/InterceptorServiceRequestBodyTestCase.java
@@ -88,7 +88,7 @@ public class InterceptorServiceRequestBodyTestCase extends InterceptorBaseTestCa
 
         // status code only available in response flow
         if (!isRequestFlow) {
-            Assert.assertEquals(interceptReqBodyJSON.getString(RESPONSE_CODE), "200", "Response code mismatched in request body");
+            Assert.assertEquals(interceptReqBodyJSON.getInt(RESPONSE_CODE), 200, "Response code mismatched in request body");
         }
     }
 

--- a/router/src/main/resources/interceptor/lib/interceptor.lua
+++ b/router/src/main/resources/interceptor/lib/interceptor.lua
@@ -241,11 +241,13 @@ local function handle_direct_respond(handle, interceptor_response_body, shared_i
 
         -- if interceptor_response_body.body is nil send empty, do not send client its payload back
         local body = interceptor_response_body[RESPONSE.BODY] or ""
+        local status_code = interceptor_response_body[REQUEST.RESP_CODE]
         if body == "" then
-            headers[STATUS] = interceptor_response_body[REQUEST.RESP_CODE] or "204"
+            status_code = status_code or 204
         else
-            headers[STATUS] = interceptor_response_body[REQUEST.RESP_CODE] or "200"
+            status_code = status_code or 200
         end
+        headers[STATUS] = tostring(status_code)
 
         local decoded_body, err = base64_decode(body, handle, shared_info, request_id, true)
         if err then
@@ -411,7 +413,7 @@ function interceptor.handle_response_interceptor(response_handle, intercept_serv
     --#endregion
 
     --#region status code
-    interceptor_request_body[REQUEST.RESP_CODE] = response_handle:headers():get(STATUS)
+    interceptor_request_body[REQUEST.RESP_CODE] = tonumber(response_handle:headers():get(STATUS))
     --#endregion
 
     include_request_info(resp_flow_includes, interceptor_request_body, shared_info[REQUEST.REQ_HEADERS], shared_info[REQUEST.REQ_BODY], shared_info[REQUEST.REQ_TRAILERS])
@@ -445,7 +447,7 @@ function interceptor.handle_response_interceptor(response_handle, intercept_serv
 
     --#region status code
     if interceptor_response_body[RESPONSE.RESPONSE_CODE] then
-        response_handle:headers():replace(STATUS, interceptor_response_body[RESPONSE.RESPONSE_CODE])
+        response_handle:headers():replace(STATUS, tostring(interceptor_response_body[RESPONSE.RESPONSE_CODE]))
     end
     --#endregion
 end


### PR DESCRIPTION
### Purpose
Read response code from "responseCode" in direct response instead of reading envoy ":status" header

In case, if envoy changes the header name ":status" (rare case) and plus in response flow interceptor we support "responseCode" (internally we add the header ":status"), so to make it compatible with the direct response in request interceptor flow lets do the same.

```json
{
    "directRespond": true,
    "responseCode": 200,
    "dynamicEndpoint":{
        "endpointName": "my-dynamic-endpoint"
    },
    ...
}
```

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2339

### Automation tests
 - Unit tests added: No
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Docker Desktop

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
