### PR TITLE
Upgrade balleirna to 1.2.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -575,7 +575,7 @@
     </build>
 
     <properties>
-        <ballerina.platform.version>1.2.19</ballerina.platform.version>
+        <ballerina.platform.version>1.2.21</ballerina.platform.version>
         <broker.version>0.970.5</broker.version>
         <assembly.plugin.version>3.1.1</assembly.plugin.version>
         <compiler.plugin.version>3.7.0</compiler.plugin.version>


### PR DESCRIPTION
### Purpose
As $subject, this will upgrade the balleirna to 1.2.21 and it will fix the oauth2 token validation cache issue.

### Issues

Fixes https://github.com/wso2/product-microgateway/issues/2357
