### PR TITLE
Bug fix: [Enforcer] Fix the issue where path parameters does not resolve depending on the trailing slash

### DIFF
--- a/enforcer-parent/commons/src/main/java/org/wso2/choreo/connect/enforcer/commons/model/ParameterResolver.java
+++ b/enforcer-parent/commons/src/main/java/org/wso2/choreo/connect/enforcer/commons/model/ParameterResolver.java
@@ -35,8 +35,10 @@ class ParameterResolver {
     private final Pattern pattern;
 
     public ParameterResolver(final String parameterTemplate) {
-
-        final Matcher matcher = PARAMETER_PATTERN.matcher(parameterTemplate);
+        // This formatting is required since /foo and /foo/ are considered to be equal
+        String formattedPathParamTemplate = parameterTemplate.endsWith("/") ?
+                parameterTemplate.substring(0, parameterTemplate.length() - 1) : parameterTemplate;
+        final Matcher matcher = PARAMETER_PATTERN.matcher(formattedPathParamTemplate);
 
         while (matcher.find()) {
             if (matcher.groupCount() == 1) {
@@ -55,7 +57,10 @@ class ParameterResolver {
     }
 
     public Map<String, String> parametersByName(final String uriString) throws IllegalArgumentException {
-        final Matcher matcher = pattern.matcher(uriString);
+        // This formatting is required since /foo and /foo/ are considered to be equal
+        String formattedURI = uriString.endsWith("/") ?
+                uriString.substring(0, uriString.length() - 1) : uriString;
+        final Matcher matcher = pattern.matcher(formattedURI);
         if (!matcher.matches()) {
             // Unlikely to occur as this pair is already matched within router.
             logger.error("PathTemplate and RawPath is mismatched.");

--- a/enforcer-parent/commons/src/main/java/org/wso2/choreo/connect/enforcer/commons/model/ParameterResolver.java
+++ b/enforcer-parent/commons/src/main/java/org/wso2/choreo/connect/enforcer/commons/model/ParameterResolver.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
 
 class ParameterResolver {
 
-    private static final Pattern PARAMETER_PATTERN = Pattern.compile("(\\{[a-zA-Z]+\\})");
+    private static final Pattern PARAMETER_PATTERN = Pattern.compile("(\\{[a-zA-Z0-9]+[a-z-_A-Z0-9]*\\})");
     private static final Logger logger = LogManager.getLogger(ParameterResolver.class);
     private final List<String> parameterNames = new ArrayList<>();
     private final Pattern pattern;

--- a/enforcer-parent/commons/src/test/java/org/wso2/choreo/connect/enforcer/commons/model/RequestContextTest.java
+++ b/enforcer-parent/commons/src/test/java/org/wso2/choreo/connect/enforcer/commons/model/RequestContextTest.java
@@ -51,6 +51,24 @@ public class RequestContextTest {
     }
 
     @Test
+    public void testPathParametersWithHyphen() {
+        testPathParamValues("/v2/pet/12/status/available", "/v2", "/pet/{pet-Id}/status/{statusType}",
+                "pet-Id", "12");
+    }
+
+    @Test
+    public void testPathParametersWithUnderscore() {
+        testPathParamValues("/v2/pet/12/status/available", "/v2", "/pet/{pet_Id}/status/{statusType}",
+                "pet_Id", "12");
+    }
+
+    @Test
+    public void testPathParametersWithNumbers() {
+        testPathParamValues("/v2/pet/12/status/available", "/v2", "/pet/{petId2}/status/{statusType}",
+                "petId2", "12");
+    }
+
+    @Test
     public void testPathParameterGenerationWithWildcard() {
         testPathParamValues("/v2/pet/12/2/random/random2", "/v2", "/pet/{petId}/{imageId}/*",
                 "petId", "12");

--- a/enforcer-parent/commons/src/test/java/org/wso2/choreo/connect/enforcer/commons/model/RequestContextTest.java
+++ b/enforcer-parent/commons/src/test/java/org/wso2/choreo/connect/enforcer/commons/model/RequestContextTest.java
@@ -39,6 +39,18 @@ public class RequestContextTest {
     }
 
     @Test
+    public void testPathParametersWithTrailingSlashInTemplate() {
+        testPathParamValues("/v2/pet/12/status/available", "/v2", "/pet/{petId}/status/{statusType}/",
+                "petId", "12");
+    }
+
+    @Test
+    public void testPathParametersWithTrailingSlashInRawPath() {
+        testPathParamValues("/v2/pet/12/status/available/", "/v2", "/pet/{petId}/status/{statusType}",
+                "petId", "12");
+    }
+
+    @Test
     public void testPathParameterGenerationWithWildcard() {
         testPathParamValues("/v2/pet/12/2/random/random2", "/v2", "/pet/{petId}/{imageId}/*",
                 "petId", "12");


### PR DESCRIPTION
### Purpose
$subject. 

In addition, allow path parameters to contain hyphen and underscore.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2439 

### Automation tests
 - Unit tests added: Yes
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
