### PR TITLE
Bug fix: [ Websocket] APIs with no endpointBasepath results in XDS update failure

### DIFF
--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -647,13 +647,13 @@ func createRoute(params *routeCreateParams) *routev3.Route {
 			Value: true,
 		},
 	}
-	if apiType == model.WS {
+	// route path could be empty only if there is no basePath for API or the endpoint available,
+	// and resourcePath is also an empty string.
+	// Empty check is added to run the gateway in failsafe mode, as if the decorator string is
+	// empty, the route configuration does not apply.
+	if strings.TrimSpace(routePath) != "" {
 		decorator = &routev3.Decorator{
-			Operation: endpointBasepath,
-		}
-	} else if apiType == model.HTTP || apiType == model.WEBHOOK {
-		decorator = &routev3.Decorator{
-			Operation: resourcePath,
+			Operation: vHost + ":" + routePath,
 		}
 	}
 


### PR DESCRIPTION
### Purpose

The decorator field is used for tracing purposes. Hence rather than attaching resource path or endpoint basePath, it sounds correct to assign it with the complete routePath as routerPath remains unique across the router.
https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto.html?highlight=decorator#envoy-v3-api-msg-config-route-v3-decorator

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2445 

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
