### PR TITLE
bug-fix [TokenRevocation] Revoked Tokens are not properly updated when enforcer restarts.

### DIFF
--- a/adapter/pkg/discovery/protocol/cache/v3/resource.go
+++ b/adapter/pkg/discovery/protocol/cache/v3/resource.go
@@ -87,6 +87,8 @@ func GetResourceName(res envoy_types.Resource) string {
 		return "ThrottleData"
 	case *ga.Api:
 		return fmt.Sprint(v.ApiUUID)
+	case *keymgt.RevokedToken:
+		return fmt.Sprint(v.Jti)
 	default:
 		return ""
 	}


### PR DESCRIPTION


### Purpose
when there are multiple revoked tokens, only one of them is passed to enforcer via XDS communication. The reason for this behavior is that, in XDS cache these resources are maintained in a map. Hence, it is required to provide a key to maintain them as unique records. 

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2447

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
