### PR TITLE
bug-fix: subscription throttling does not work for self contained access token

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
@@ -435,6 +435,15 @@ public class JWTAuthenticator implements Authenticator {
                     String subTenant = subApi.getAsString(APIConstants.JwtTokenConstants.SUBSCRIBER_TENANT_DOMAIN);
                     if (subTier != null) {
                         validationInfo.setTier(subTier);
+                        if (payload.getClaim(APIConstants.JwtTokenConstants.TIER_INFO) != null) {
+                            JSONObject tierInfo = (JSONObject) payload.getClaim(
+                                    APIConstants.JwtTokenConstants.TIER_INFO);
+                            if (tierInfo.get(subTier) != null) {
+                                JSONObject subTierInfo = (JSONObject) tierInfo.get(subTier);
+                                validationInfo.setStopOnQuotaReach((Boolean)
+                                        subTierInfo.get(APIConstants.JwtTokenConstants.STOP_ON_QUOTA_REACH));
+                            }
+                        }
                     }
                     if (subPublisher != null) {
                         validationInfo.setApiPublisher(subPublisher);

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/throttle/SubscriptionThrottlingTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/throttle/SubscriptionThrottlingTestCase.java
@@ -31,7 +31,10 @@ import org.wso2.am.integration.clients.admin.api.dto.ThrottleLimitDTO;
 import org.wso2.am.integration.test.impl.DtoFactory;
 import org.wso2.choreo.connect.tests.apim.ApimResourceProcessor;
 import org.wso2.choreo.connect.tests.apim.utils.StoreUtils;
+import org.wso2.choreo.connect.tests.common.model.API;
+import org.wso2.choreo.connect.tests.common.model.ApplicationDTO;
 import org.wso2.choreo.connect.tests.util.TestConstant;
+import org.wso2.choreo.connect.tests.util.TokenUtil;
 import org.wso2.choreo.connect.tests.util.Utils;
 
 import java.util.ArrayList;
@@ -97,6 +100,29 @@ public class SubscriptionThrottlingTestCase extends ThrottlingBaseTestCase {
 
     @Test(description = "Test Subscription throttling")
     public void testSubscriptionLevelThrottling() throws Exception {
+        Assert.assertTrue(isThrottled(endpointURL, requestHeaders, null, requestCount),
+                "Request not throttled by request count condition in subscription tier");
+    }
+
+    @Test(description = "Test Subscription throttling for self-contained token")
+    public void testSubscriptionLevelThrottlingSelfContainedToken() throws Exception {
+        API api = new API();
+        api.setName(super.SAMPLE_API_NAME);
+        api.setContext("/" + super.SAMPLE_API_CONTEXT + "/" + super.SAMPLE_API_VERSION);
+
+        api.setVersion(super.SAMPLE_API_VERSION);
+        api.setProvider("admin");
+
+        //Define application info
+        ApplicationDTO application = new ApplicationDTO();
+        application.setName("jwtApp");
+        application.setTier("Unlimited");
+        application.setId((int) (Math.random() * 1000));
+        String jwtToken = TokenUtil.getJWT(api, application, "15PerMin", TestConstant.KEY_TYPE_PRODUCTION,
+                3600, "write:pets", false);
+
+        Map<String, String> requestHeaders = new HashMap<>();
+        requestHeaders.put(TestConstant.AUTHORIZATION_HEADER, "Bearer " + jwtToken);
         Assert.assertTrue(isThrottled(endpointURL, requestHeaders, null, requestCount),
                 "Request not throttled by request count condition in subscription tier");
     }

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/TokenUtil.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/TokenUtil.java
@@ -174,7 +174,15 @@ public class TokenUtil {
         subscribedApiDTO.setSubscriberTenantDomain("carbon.super");
 
         JSONObject jwtTokenInfo = new JSONObject();
+
+        JSONObject tierDTO = new JSONObject();
+        tierDTO.put("stopOnQuotaReach", true);
+        JSONObject tierInfoDTO = new JSONObject();
+        tierInfoDTO.put(tier, tierDTO);
+
         jwtTokenInfo.put("subscribedAPIs", new JSONArray(Arrays.asList(subscribedApiDTO)));
+        jwtTokenInfo.put("tierInfo", tierInfoDTO);
+
         if (isInternalKey) {
             return TokenUtil.getInternalKey(jwtTokenInfo, keyType, validityPeriod);
         }

--- a/integration/test-integration/src/test/resources/configs/controlplane-enabled-config.toml
+++ b/integration/test-integration/src/test/resources/configs/controlplane-enabled-config.toml
@@ -13,6 +13,22 @@
     enableJwtClaimConditions = true
     jmsConnectionProviderUrl = "amqp://admin:admin@carbon/carbon?brokerlist='tcp://apim:5672'"
 
+[[enforcer.security.tokenService]]
+  # Provide unique name for the JWT issuer
+  name = "Resident Key Manager"
+  issuer = "https://localhost:9443/oauth2/token"
+  # Alias name given in Enforcer truststore for the public certificate of the JWT issuer
+  certificateAlias = "wso2carbon"
+  # URL of the JWKs endpoint
+  jwksURL = ""
+  # Validate subscribed APIs
+  validateSubscription = true
+  # The claim in which the consumer key of the application is coming
+  consumerKeyClaim = "azp"
+  # Certificate Filepath within Enforcer
+  certificateFilePath = "/home/wso2/security/truststore/wso2carbon.pem"
+
+
 [controlPlane]
     enabled = true
     skipSSLVerification=true

--- a/integration/test-integration/src/test/resources/configs/controlplane-enabled-config.toml
+++ b/integration/test-integration/src/test/resources/configs/controlplane-enabled-config.toml
@@ -28,6 +28,31 @@
   # Certificate Filepath within Enforcer
   certificateFilePath = "/home/wso2/security/truststore/wso2carbon.pem"
 
+# Issuer 2
+[[enforcer.security.tokenService]]
+  # Provide unique name for the JWT issuer
+  name = "MGW"
+  issuer = "https://localhost:9095/testkey"
+  # Alias name given in Enforcer truststore for the public certificate of the JWT issuer
+  certificateAlias = "mgw"
+  # URL of the JWKs endpoint
+  jwksURL = ""
+  # Validate subscribed APIs
+  validateSubscription = false
+  # The claim in which the consumer key of the application is coming
+  consumerKeyClaim = ""
+  # Certificate Filepath within Enforcer
+  certificateFilePath = "/home/wso2/security/truststore/mg.pem"
+
+# Issuer 3
+[[enforcer.security.tokenService]]
+  # Provide unique name for the JWT issuer
+  name = "APIM Publisher"
+  issuer = "https://localhost:9443/publisher"
+  # Alias name given in Enforcer truststore for the public certificate of the JWT issuer
+  certificateAlias = ""
+  # Certificate Filepath within Enforcer
+  certificateFilePath = "/home/wso2/security/truststore/wso2carbon.pem"
 
 [controlPlane]
     enabled = true


### PR DESCRIPTION

### Purpose

StopOnQuotaReach is properly populated as that was the root cause for subscription throttling failure.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2368

### Automation tests
 - Unit tests added: No
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
