### PR TITLE
[Improvement] [Analytics] Showing application usage when subscription is disabled.

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/APIConstants.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/APIConstants.java
@@ -36,7 +36,7 @@ public class APIConstants {
     public static final String UNLIMITED_TIER = "Unlimited";
     public static final String UNAUTHENTICATED_TIER = "Unauthenticated";
     public static final String END_USER_ANONYMOUS = "anonymous";
-
+    public static final String ANONYMOUS_PREFIX = "anon:";
 
     public static final String GATEWAY_SIGNED_JWT_CACHE = "SignedJWTParseCache";
     public static final String DEFAULT_ISSUER = "Resident Key Manager";

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
@@ -57,11 +57,13 @@ import org.wso2.choreo.connect.enforcer.util.BackendJwtUtils;
 import org.wso2.choreo.connect.enforcer.util.FilterUtils;
 import org.wso2.choreo.connect.enforcer.util.JWTUtils;
 
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 
 /**
@@ -208,6 +210,13 @@ public class JWTAuthenticator implements Authenticator {
                                                     + "API Subscription validation failed.");
                                 }
                             }
+                        } else {
+                            // In this case, the application related properties are populated so that analytics
+                            // could provide much better insights.
+                            // Since application notion becomes less meaningful with subscription validation disabled,
+                            // the application name would be populated under the convention "anon:<KM Reference>"
+                            updateApplicationNameForSubscriptionDisabledKM(apiKeyValidationInfoDTO,
+                                    issuerDto.getName());
                         }
                     } finally {
                         if (Utils.tracingEnabled()) {
@@ -274,6 +283,16 @@ public class JWTAuthenticator implements Authenticator {
             }
         }
 
+    }
+
+    private void updateApplicationNameForSubscriptionDisabledKM(APIKeyValidationInfoDTO apiKeyValidationInfoDTO,
+                                                                String kmReference) {
+        String applicationRef = APIConstants.ANONYMOUS_PREFIX + kmReference;
+        apiKeyValidationInfoDTO.setApplicationName(applicationRef);
+        apiKeyValidationInfoDTO.setApplicationId(
+                UUID.nameUUIDFromBytes(
+                        applicationRef.getBytes(StandardCharsets.UTF_8)).toString());
+        apiKeyValidationInfoDTO.setApplicationTier(APIConstants.UNLIMITED_TIER);
     }
 
     @Override


### PR DESCRIPTION


### Purpose
When subscription validation is disabled, provide a meaningful application reference for analytics. The convention used here would be anon:<KM Ref>

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2356

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
