### PR TITLE
Run tests if the workflow is manually triggered

### DIFF
--- a/.github/workflows/nightly-integration-test.yml
+++ b/.github/workflows/nightly-integration-test.yml
@@ -33,7 +33,7 @@ jobs:
 
   build:
     needs: check_continue
-    if: ${{ needs.check_continue.outputs.should_run == 'true' }}
+    if: ${{ needs.check_continue.outputs.should_run != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### Purpose
Run tests if the workflow is manually triggered
The check job only runs, if the workflow triggered by the cron

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/2487

### Automation tests
 - Unit tests added: N/A
 - Integration tests added:  N/A

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Ubuntu ARM Images are tested in an Mac M1 chip lap - QSG

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
