### PR TITLE
[Bug-fix] Prioritize Swagger definition's vendor extensions over API.yaml for all APIs.

### DIFF
--- a/adapter/internal/discovery/xds/server.go
+++ b/adapter/internal/discovery/xds/server.go
@@ -271,8 +271,13 @@ func UpdateAPI(vHost string, apiProject mgw.ProjectAPI, environments []string) (
 		apiEnvProps = apiEnvPropsV
 	}
 
+	mgwSwagger, err = operator.GetMgwSwaggerFromAPIYaml(apiProject.APIYaml, apiProject.APIType)
+	if err != nil {
+		return nil, err
+	}
+
 	if apiProject.APIType == mgw.HTTP || apiProject.APIType == mgw.WEBHOOK {
-		mgwSwagger, err = operator.GetMgwSwagger(apiProject.OpenAPIJsn)
+		err = mgwSwagger.GetMgwSwagger(apiProject.OpenAPIJsn)
 		if err != nil {
 			return nil, err
 		}
@@ -287,11 +292,6 @@ func UpdateAPI(vHost string, apiProject mgw.ProjectAPI, environments []string) (
 		}
 		mgwSwagger.SetXWso2AuthHeader(apiYaml.AuthorizationHeader)
 
-	} else if apiProject.APIType == mgw.WS {
-		mgwSwagger, err = operator.GetMgwSwaggerWebSocket(apiProject.APIYaml)
-		if err != nil {
-			return nil, err
-		}
 	} else {
 		// Unreachable else condition. Added in case previous apiType check fails due to any modifications.
 		logger.LoggerXds.Error("API type not currently supported by Choreo Connect")

--- a/adapter/internal/discovery/xds/server.go
+++ b/adapter/internal/discovery/xds/server.go
@@ -44,7 +44,6 @@ import (
 	envoyconf "github.com/wso2/product-microgateway/adapter/internal/oasparser/envoyconf"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
 	mgw "github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
-	"github.com/wso2/product-microgateway/adapter/internal/oasparser/operator"
 	"github.com/wso2/product-microgateway/adapter/internal/svcdiscovery"
 	subscription "github.com/wso2/product-microgateway/adapter/pkg/discovery/api/wso2/discovery/subscription"
 	throttle "github.com/wso2/product-microgateway/adapter/pkg/discovery/api/wso2/discovery/throttle"
@@ -271,7 +270,7 @@ func UpdateAPI(vHost string, apiProject mgw.ProjectAPI, environments []string) (
 		apiEnvProps = apiEnvPropsV
 	}
 
-	mgwSwagger, err = operator.GetMgwSwaggerFromAPIYaml(apiProject.APIYaml, apiProject.APIType)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiProject.APIYaml, apiProject.APIType)
 	if err != nil {
 		return nil, err
 	}

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
@@ -75,7 +75,8 @@ func TestCreateRouteswithClustersWebsocketSand(t *testing.T) {
 func commonTestForCreateRoutesWithClusters(t *testing.T, openapiFilePath string, withExtensions bool) {
 	openapiByteArr, err := ioutil.ReadFile(openapiFilePath)
 	assert.Nil(t, err, "Error while reading the openapi file : "+openapiFilePath)
-	mgwSwaggerForOpenapi, err := operator.GetMgwSwagger(openapiByteArr)
+	mgwSwaggerForOpenapi := model.MgwSwagger{}
+	err = mgwSwaggerForOpenapi.GetMgwSwagger(openapiByteArr)
 	assert.Nil(t, err, "Error should not be present when openAPI definition is converted to a MgwSwagger object")
 	routes, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwaggerForOpenapi, nil, nil, "localhost", "carbon.super")
 
@@ -157,7 +158,8 @@ func TestCreateRoutesWithClustersForEndpointRef(t *testing.T) {
 	openapiFilePath := config.GetMgwHome() + "/../adapter/test-resources/envoycodegen/openapi_with_endpoint_ref.yaml"
 	openapiByteArr, err := ioutil.ReadFile(openapiFilePath)
 	assert.Nil(t, err, "Error while reading the openapi file : "+openapiFilePath)
-	mgwSwaggerForOpenapi, err := operator.GetMgwSwagger(openapiByteArr)
+	mgwSwaggerForOpenapi := model.MgwSwagger{}
+	err = mgwSwaggerForOpenapi.GetMgwSwagger(openapiByteArr)
 	assert.Nil(t, err, "Error should not be present when openAPI definition is converted to a MgwSwagger object")
 	routes, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwaggerForOpenapi, nil, nil, "localhost", "carbon.super")
 
@@ -248,7 +250,7 @@ func testCreateRoutesWithClustersWebsocket(t *testing.T, apiYamlFilePath string)
 	err = json.Unmarshal(apiJsn, &apiYaml)
 	apiYaml = model.PopulateEndpointsInfo(apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
-	mgwSwagger, err := operator.GetMgwSwaggerWebSocket(apiYaml)
+	mgwSwagger, err := operator.GetMgwSwaggerFromAPIYaml(apiYaml, model.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	routes, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
 
@@ -332,7 +334,7 @@ func testCreateRoutesWithClustersWebsocketWithEnvProps(t *testing.T, apiYamlFile
 	err = json.Unmarshal(apiJsn, &apiYaml)
 	apiYaml = model.PopulateEndpointsInfo(apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
-	mgwSwagger, err := operator.GetMgwSwaggerWebSocket(apiYaml)
+	mgwSwagger, err := operator.GetMgwSwaggerFromAPIYaml(apiYaml, model.WS)
 	mgwSwagger.SetEnvLabelProperties(envProps)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	routes, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
@@ -455,7 +457,7 @@ func TestCreateRoutesWithClusters(t *testing.T) {
 	err = json.Unmarshal(apiJsn, &apiYaml)
 	apiYaml = model.PopulateEndpointsInfo(apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
-	mgwSwagger, err := operator.GetMgwSwaggerWebSocket(apiYaml)
+	mgwSwagger, err := operator.GetMgwSwaggerFromAPIYaml(apiYaml, model.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	routes, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
 	assert.NotNil(t, routes, "CreateRoutesWithClusters failed: returned routes nil")
@@ -484,7 +486,7 @@ func commonTestForClusterPrioritiesInWebSocketAPI(t *testing.T, apiYamlFilePath 
 	err = json.Unmarshal(apiJsn, &apiYaml)
 	apiYaml = model.PopulateEndpointsInfo(apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
-	mgwSwagger, err := operator.GetMgwSwaggerWebSocket(apiYaml)
+	mgwSwagger, err := operator.GetMgwSwaggerFromAPIYaml(apiYaml, model.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	_, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
 
@@ -550,7 +552,7 @@ func commonTestForClusterPrioritiesInWebSocketAPIWithEnvProps(t *testing.T, apiY
 	err = json.Unmarshal(apiJsn, &apiYaml)
 	apiYaml = model.PopulateEndpointsInfo(apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
-	mgwSwagger, err := operator.GetMgwSwaggerWebSocket(apiYaml)
+	mgwSwagger, err := operator.GetMgwSwaggerFromAPIYaml(apiYaml, model.WS)
 	mgwSwagger.SetEnvLabelProperties(envProps)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	_, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/wso2/product-microgateway/adapter/config"
 	envoy "github.com/wso2/product-microgateway/adapter/internal/oasparser/envoyconf"
-	"github.com/wso2/product-microgateway/adapter/internal/oasparser/operator"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -250,7 +249,8 @@ func testCreateRoutesWithClustersWebsocket(t *testing.T, apiYamlFilePath string)
 	err = json.Unmarshal(apiJsn, &apiYaml)
 	apiYaml = model.PopulateEndpointsInfo(apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
-	mgwSwagger, err := operator.GetMgwSwaggerFromAPIYaml(apiYaml, model.WS)
+	var mgwSwagger model.MgwSwagger
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	routes, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
 
@@ -334,7 +334,8 @@ func testCreateRoutesWithClustersWebsocketWithEnvProps(t *testing.T, apiYamlFile
 	err = json.Unmarshal(apiJsn, &apiYaml)
 	apiYaml = model.PopulateEndpointsInfo(apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
-	mgwSwagger, err := operator.GetMgwSwaggerFromAPIYaml(apiYaml, model.WS)
+	var mgwSwagger model.MgwSwagger
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
 	mgwSwagger.SetEnvLabelProperties(envProps)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	routes, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
@@ -457,7 +458,8 @@ func TestCreateRoutesWithClusters(t *testing.T) {
 	err = json.Unmarshal(apiJsn, &apiYaml)
 	apiYaml = model.PopulateEndpointsInfo(apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
-	mgwSwagger, err := operator.GetMgwSwaggerFromAPIYaml(apiYaml, model.WS)
+	var mgwSwagger model.MgwSwagger
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	routes, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
 	assert.NotNil(t, routes, "CreateRoutesWithClusters failed: returned routes nil")
@@ -486,7 +488,8 @@ func commonTestForClusterPrioritiesInWebSocketAPI(t *testing.T, apiYamlFilePath 
 	err = json.Unmarshal(apiJsn, &apiYaml)
 	apiYaml = model.PopulateEndpointsInfo(apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
-	mgwSwagger, err := operator.GetMgwSwaggerFromAPIYaml(apiYaml, model.WS)
+	var mgwSwagger model.MgwSwagger
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	_, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
 
@@ -552,7 +555,8 @@ func commonTestForClusterPrioritiesInWebSocketAPIWithEnvProps(t *testing.T, apiY
 	err = json.Unmarshal(apiJsn, &apiYaml)
 	apiYaml = model.PopulateEndpointsInfo(apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
-	mgwSwagger, err := operator.GetMgwSwaggerFromAPIYaml(apiYaml, model.WS)
+	var mgwSwagger model.MgwSwagger
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
 	mgwSwagger.SetEnvLabelProperties(envProps)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	_, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")

--- a/adapter/internal/oasparser/model/mgw_swagger.go
+++ b/adapter/internal/oasparser/model/mgw_swagger.go
@@ -994,14 +994,13 @@ func (swagger *MgwSwagger) GetMgwSwagger(apiContent []byte) error {
 	return nil
 }
 
-//SetSwaggerFromAPIYaml populates the mgwSwagger object for APIs using API.yaml
+//PopulateSwaggerFromAPIYaml populates the mgwSwagger object for APIs using API.yaml
 // TODO - (VirajSalaka) read cors config and populate mgwSwagger feild
-func (swagger *MgwSwagger) SetSwaggerFromAPIYaml(apiData APIYaml, apiType string) error {
+func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType string) error {
 
 	data := apiData.Data
 	// UUID in the generated api.yaml file is considerd as swagger.id
 	swagger.id = data.ID
-	// Set apiType as WS for websockets
 	swagger.apiType = apiType
 	// name and version in api.yaml corresponds to title and version respectively.
 	swagger.title = data.Name

--- a/adapter/internal/oasparser/model/mgw_swagger.go
+++ b/adapter/internal/oasparser/model/mgw_swagger.go
@@ -61,6 +61,7 @@ type MgwSwagger struct {
 	xWso2AuthHeader     string
 	disableSecurity     bool
 	OrganizationID      string
+	IsProtoTyped        bool
 }
 
 // EndpointCluster represent an upstream cluster
@@ -146,6 +147,8 @@ type InterceptEndpoint struct {
 	//"invocation_context" }
 	Includes *interceptor.RequestInclusions
 }
+
+const prototypedAPI = "prototyped"
 
 // GetCorsConfig returns the CorsConfiguration Object.
 func (swagger *MgwSwagger) GetCorsConfig() *CorsConfig {
@@ -1010,6 +1013,10 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 
 	// productionURL & sandBoxURL values are extracted from endpointConfig in api.yaml
 	endpointConfig := data.EndpointConfig
+
+	if endpointConfig.ImplementationStatus == prototypedAPI {
+		swagger.IsProtoTyped = true
+	}
 	if len(endpointConfig.SandBoxEndpoints) > 0 {
 		var endpoints []Endpoint
 		endpointType := LoadBalance

--- a/adapter/internal/oasparser/model/mgw_swagger.go
+++ b/adapter/internal/oasparser/model/mgw_swagger.go
@@ -17,6 +17,7 @@
 package model
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -25,10 +26,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/go-openapi/spec"
 	parser "github.com/mitchellh/mapstructure"
 	"github.com/wso2/product-microgateway/adapter/config"
 	"github.com/wso2/product-microgateway/adapter/internal/interceptor"
 	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/utills"
 	"github.com/wso2/product-microgateway/adapter/internal/svcdiscovery"
 	"github.com/wso2/product-microgateway/adapter/pkg/synchronizer"
 )
@@ -941,4 +945,119 @@ func (swagger *MgwSwagger) GetInterceptor(vendorExtensions map[string]interface{
 		return InterceptEndpoint{}, errors.New("error parsing response interceptors values to mgwSwagger")
 	}
 	return InterceptEndpoint{}, nil
+}
+
+// GetMgwSwagger converts the openAPI v3 and v2 content
+// To MgwSwagger objects
+func (swagger *MgwSwagger) GetMgwSwagger(apiContent []byte) error {
+
+	apiJsn, err := utills.ToJSON(apiContent)
+	if err != nil {
+		logger.LoggerOasparser.Error("Error converting api file to json", err)
+		return err
+	}
+	swaggerVerison := utills.FindSwaggerVersion(apiJsn)
+
+	if swaggerVerison == "2" {
+		// map json to struct
+		var apiData2 spec.Swagger
+		err = json.Unmarshal(apiJsn, &apiData2)
+		if err != nil {
+			logger.LoggerOasparser.Error("Error openAPI unmarshalling", err)
+		} else {
+			infoSwaggerErr := swagger.SetInfoSwagger(apiData2)
+			if infoSwaggerErr != nil {
+				return infoSwaggerErr
+			}
+		}
+
+	} else if swaggerVerison == "3" {
+		// map json to struct
+		var apiData3 *openapi3.Swagger
+
+		err = json.Unmarshal(apiJsn, &apiData3)
+		if err != nil {
+			logger.LoggerOasparser.Error("Error openAPI unmarshalling", err)
+		} else {
+			infoOpenAPIErr := swagger.SetInfoOpenAPI(*apiData3)
+			if infoOpenAPIErr != nil {
+				return infoOpenAPIErr
+			}
+		}
+	}
+	err = swagger.SetXWso2Extensions()
+	if err != nil {
+		logger.LoggerOasparser.Error("Error occurred while setting x-wso2 extensions for ",
+			swagger.GetTitle(), " ", err)
+		return err
+	}
+	return nil
+}
+
+//SetSwaggerFromAPIYaml populates the mgwSwagger object for APIs using API.yaml
+// TODO - (VirajSalaka) read cors config and populate mgwSwagger feild
+func (swagger *MgwSwagger) SetSwaggerFromAPIYaml(apiData APIYaml, apiType string) error {
+
+	data := apiData.Data
+	// UUID in the generated api.yaml file is considerd as swagger.id
+	swagger.id = data.ID
+	// Set apiType as WS for websockets
+	swagger.apiType = apiType
+	// name and version in api.yaml corresponds to title and version respectively.
+	swagger.title = data.Name
+	swagger.version = data.Version
+	// context value in api.yaml is assigned as xWso2Basepath
+	swagger.xWso2Basepath = data.Context + "/" + swagger.version
+
+	// productionURL & sandBoxURL values are extracted from endpointConfig in api.yaml
+	endpointConfig := data.EndpointConfig
+	if len(endpointConfig.SandBoxEndpoints) > 0 {
+		var endpoints []Endpoint
+		endpointType := LoadBalance
+		for _, endpointConfig := range endpointConfig.SandBoxEndpoints {
+			sandBoxEndpoint, err := getHostandBasepathandPortWebSocket(endpointConfig.Endpoint)
+			if err == nil {
+				endpoints = append(endpoints, *sandBoxEndpoint)
+			} else {
+				return err
+			}
+		}
+		if len(endpointConfig.SandboxFailoverEndpoints) > 0 {
+			for _, endpointConfig := range endpointConfig.SandboxFailoverEndpoints {
+				failoverEndpoint, err := getHostandBasepathandPortWebSocket(endpointConfig.Endpoint)
+				if err == nil {
+					endpointType = FailOver
+					endpoints = append(endpoints, *failoverEndpoint)
+				} else {
+					return err
+				}
+			}
+		}
+		swagger.sandboxEndpoints = generateEndpointCluster(sandClustersConfigNamePrefix, endpoints, endpointType)
+	}
+	if len(endpointConfig.ProductionEndpoints) > 0 {
+		var endpoints []Endpoint
+		endpointType := LoadBalance
+		for _, endpointConfig := range endpointConfig.ProductionEndpoints {
+			prodEndpoint, err := getHostandBasepathandPortWebSocket(endpointConfig.Endpoint)
+			if err == nil {
+				endpoints = append(endpoints, *prodEndpoint)
+			} else {
+				return err
+			}
+		}
+		if len(endpointConfig.ProductionFailoverEndpoints) > 0 {
+			for _, endpointConfig := range endpointConfig.ProductionFailoverEndpoints {
+				failoverEndpoint, err := getHostandBasepathandPortWebSocket(endpointConfig.Endpoint)
+				if err == nil {
+					endpointType = FailOver
+					endpoints = append(endpoints, *failoverEndpoint)
+				} else {
+					return err
+				}
+			}
+		}
+		swagger.productionEndpoints = generateEndpointCluster(prodClustersConfigNamePrefix, endpoints, endpointType)
+	}
+	return nil
 }

--- a/adapter/internal/oasparser/model/open_api.go
+++ b/adapter/internal/oasparser/model/open_api.go
@@ -77,9 +77,9 @@ func (swagger *MgwSwagger) SetInfoOpenAPI(swagger3 openapi3.Swagger) error {
 
 	swagger.apiType = HTTP
 	var productionUrls []Endpoint
-	// If the productionEndpoints are already assigned from api.Yaml, the servers object will not
-	// be processed.
-	if isServerURLIsAvailable(swagger3.Servers) && swagger.productionEndpoints == nil {
+	// For prototyped APIs, the prototype endpoint is only assinged from api.Yaml. Hence,
+	// an exception is made where servers url is not processed when the API is prototyped.
+	if isServerURLIsAvailable(swagger3.Servers) && !swagger.IsProtoTyped {
 		for _, serverEntry := range swagger3.Servers {
 			if len(serverEntry.URL) == 0 || strings.HasPrefix(serverEntry.URL, "/") {
 				continue

--- a/adapter/internal/oasparser/model/open_api.go
+++ b/adapter/internal/oasparser/model/open_api.go
@@ -77,7 +77,9 @@ func (swagger *MgwSwagger) SetInfoOpenAPI(swagger3 openapi3.Swagger) error {
 
 	swagger.apiType = HTTP
 	var productionUrls []Endpoint
-	if isServerURLIsAvailable(swagger3.Servers) {
+	// If the productionEndpoints are already assigned from api.Yaml, the servers object will not
+	// be processed.
+	if isServerURLIsAvailable(swagger3.Servers) && swagger.productionEndpoints == nil {
 		for _, serverEntry := range swagger3.Servers {
 			if len(serverEntry.URL) == 0 || strings.HasPrefix(serverEntry.URL, "/") {
 				continue
@@ -90,7 +92,7 @@ func (swagger *MgwSwagger) SetInfoOpenAPI(swagger3 openapi3.Swagger) error {
 				logger.LoggerOasparser.Errorf("error encountered when parsing the endpoint under openAPI servers object")
 			}
 		}
-		if productionUrls != nil && len(productionUrls) > 0 {
+		if len(productionUrls) > 0 {
 			swagger.productionEndpoints = generateEndpointCluster(prodClustersConfigNamePrefix, productionUrls, LoadBalance)
 		}
 	}

--- a/adapter/internal/oasparser/model/swagger.go
+++ b/adapter/internal/oasparser/model/swagger.go
@@ -49,7 +49,9 @@ func (swagger *MgwSwagger) SetInfoSwagger(swagger2 spec.Swagger) error {
 	// According to the definition, multiple schemes can be mentioned. Since the microgateway can assign only one scheme
 	// https is prioritized over http. If it is ws or wss, the microgateway will print an error.
 	// If the schemes property is not mentioned at all, http will be assigned. (Only swagger 2 version has this property)
-	if swagger2.Host != "" {
+	// If the productionEndpoints are already assigned from api.Yaml, productionEndpoints should not be
+	// updated with the Host Property.
+	if swagger2.Host != "" && swagger.productionEndpoints == nil {
 		urlScheme := ""
 		for _, scheme := range swagger2.Schemes {
 			//TODO: (VirajSalaka) Introduce Constants
@@ -247,72 +249,4 @@ func setOperationSwagger(path string, methods []Operation, pathItem spec.PathIte
 		vendorExtensions: pathItem.VendorExtensible.Extensions,
 	}
 	return resource
-}
-
-//SetInfoSwaggerWebSocket populates the mgwSwagger object for web sockets
-// TODO - (VirajSalaka) read cors config and populate mgwSwagger feild
-func (swagger *MgwSwagger) SetInfoSwaggerWebSocket(apiData APIYaml) error {
-
-	data := apiData.Data
-	// UUID in the generated api.yaml file is considerd as swagger.id
-	swagger.id = data.ID
-	// Set apiType as WS for websockets
-	swagger.apiType = "WS"
-	// name and version in api.yaml corresponds to title and version respectively.
-	swagger.title = data.Name
-	swagger.version = data.Version
-	// context value in api.yaml is assigned as xWso2Basepath
-	swagger.xWso2Basepath = data.Context + "/" + swagger.version
-
-	// productionURL & sandBoxURL values are extracted from endpointConfig in api.yaml
-	endpointConfig := data.EndpointConfig
-	if len(endpointConfig.SandBoxEndpoints) > 0 {
-		var endpoints []Endpoint
-		endpointType := LoadBalance
-		for _, endpointConfig := range endpointConfig.SandBoxEndpoints {
-			sandBoxEndpoint, err := getHostandBasepathandPortWebSocket(endpointConfig.Endpoint)
-			if err == nil {
-				endpoints = append(endpoints, *sandBoxEndpoint)
-			} else {
-				return err
-			}
-		}
-		if len(endpointConfig.SandboxFailoverEndpoints) > 0 {
-			for _, endpointConfig := range endpointConfig.SandboxFailoverEndpoints {
-				failoverEndpoint, err := getHostandBasepathandPortWebSocket(endpointConfig.Endpoint)
-				if err == nil {
-					endpointType = FailOver
-					endpoints = append(endpoints, *failoverEndpoint)
-				} else {
-					return err
-				}
-			}
-		}
-		swagger.sandboxEndpoints = generateEndpointCluster(sandClustersConfigNamePrefix, endpoints, endpointType)
-	}
-	if len(endpointConfig.ProductionEndpoints) > 0 {
-		var endpoints []Endpoint
-		endpointType := LoadBalance
-		for _, endpointConfig := range endpointConfig.ProductionEndpoints {
-			prodEndpoint, err := getHostandBasepathandPortWebSocket(endpointConfig.Endpoint)
-			if err == nil {
-				endpoints = append(endpoints, *prodEndpoint)
-			} else {
-				return err
-			}
-		}
-		if len(endpointConfig.ProductionFailoverEndpoints) > 0 {
-			for _, endpointConfig := range endpointConfig.ProductionFailoverEndpoints {
-				failoverEndpoint, err := getHostandBasepathandPortWebSocket(endpointConfig.Endpoint)
-				if err == nil {
-					endpointType = FailOver
-					endpoints = append(endpoints, *failoverEndpoint)
-				} else {
-					return err
-				}
-			}
-		}
-		swagger.productionEndpoints = generateEndpointCluster(prodClustersConfigNamePrefix, endpoints, endpointType)
-	}
-	return nil
 }

--- a/adapter/internal/oasparser/model/swagger.go
+++ b/adapter/internal/oasparser/model/swagger.go
@@ -49,9 +49,9 @@ func (swagger *MgwSwagger) SetInfoSwagger(swagger2 spec.Swagger) error {
 	// According to the definition, multiple schemes can be mentioned. Since the microgateway can assign only one scheme
 	// https is prioritized over http. If it is ws or wss, the microgateway will print an error.
 	// If the schemes property is not mentioned at all, http will be assigned. (Only swagger 2 version has this property)
-	// If the productionEndpoints are already assigned from api.Yaml, productionEndpoints should not be
-	// updated with the Host Property.
-	if swagger2.Host != "" && swagger.productionEndpoints == nil {
+	// For prototyped APIs, the prototype endpoint is only assinged from api.Yaml. Hence,
+	// an exception is made where host property is not processed when the API is prototyped.
+	if swagger2.Host != "" && !swagger.IsProtoTyped {
 		urlScheme := ""
 		for _, scheme := range swagger2.Schemes {
 			//TODO: (VirajSalaka) Introduce Constants

--- a/adapter/internal/oasparser/model/swagger_test.go
+++ b/adapter/internal/oasparser/model/swagger_test.go
@@ -44,7 +44,7 @@ func TestSetInfoSwaggerWebSocket(t *testing.T) {
 	var apiYaml model.APIYaml
 	err = json.Unmarshal(apiJsn, &apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
-	mgwSwagger, err := operator.GetMgwSwaggerWebSocket(apiYaml)
+	mgwSwagger, err := operator.GetMgwSwaggerFromAPIYaml(apiYaml, model.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 
 	dataItems := []setInfoSwaggerWebSocketTestItem{
@@ -85,7 +85,8 @@ func TestValidate(t *testing.T) {
 	openapiFilePath := config.GetMgwHome() + "/../adapter/test-resources/envoycodegen/openapi_with_prod_sand_extensions.yaml"
 	openapiByteArr, err := ioutil.ReadFile(openapiFilePath)
 	assert.Nil(t, err, "Error while reading the openapi file : "+openapiFilePath)
-	mgwSwaggerForOpenapi, err := operator.GetMgwSwagger(openapiByteArr)
+	mgwSwaggerForOpenapi := model.MgwSwagger{}
+	err = mgwSwaggerForOpenapi.GetMgwSwagger(openapiByteArr)
 	assert.Nil(t, err, "Error should not be present when openAPI definition is converted to a MgwSwagger object")
 	err = mgwSwaggerForOpenapi.Validate()
 	assert.Nil(t, err, "Validation Error should not be present when servers URL is properly provided.")

--- a/adapter/internal/oasparser/model/swagger_test.go
+++ b/adapter/internal/oasparser/model/swagger_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/wso2/product-microgateway/adapter/config"
 	model "github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
-	"github.com/wso2/product-microgateway/adapter/internal/oasparser/operator"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/utills"
 )
 
@@ -44,7 +43,8 @@ func TestSetInfoSwaggerWebSocket(t *testing.T) {
 	var apiYaml model.APIYaml
 	err = json.Unmarshal(apiJsn, &apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
-	mgwSwagger, err := operator.GetMgwSwaggerFromAPIYaml(apiYaml, model.WS)
+	var mgwSwagger model.MgwSwagger
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 
 	dataItems := []setInfoSwaggerWebSocketTestItem{

--- a/adapter/internal/oasparser/model/types.go
+++ b/adapter/internal/oasparser/model/types.go
@@ -148,6 +148,7 @@ type APIYaml struct {
 			RawSandboxEndpoints          interface{}    `json:"sandbox_endpoints,omitempty"`
 			SandBoxEndpoints             []EndpointInfo
 			SandboxFailoverEndpoints     []EndpointInfo `json:"sandbox_failovers,omitempty"`
+			ImplementationStatus         string         `json:"implementation_status,omitempty"`
 		} `json:"endpointConfig,omitempty"`
 	} `json:"data"`
 }

--- a/adapter/internal/oasparser/operator/operator.go
+++ b/adapter/internal/oasparser/operator/operator.go
@@ -94,16 +94,3 @@ to pass labels. Currently value "DefaultGatewayName" is returned
 func GetXWso2LabelsWebSocket(webSocketAPIDef model.MgwSwagger) []string {
 	return []string{config.DefaultGatewayName}
 }
-
-/*
-GetMgwSwaggerFromAPIYaml returns a MgwSwagger for the APIs using the API.Yaml file.
-*/
-func GetMgwSwaggerFromAPIYaml(apiData model.APIYaml, apiType string) (model.MgwSwagger, error) {
-	var mgwSwagger model.MgwSwagger
-	err := mgwSwagger.SetSwaggerFromAPIYaml(apiData, apiType)
-	if err != nil {
-		return mgwSwagger, err
-	}
-	return mgwSwagger, nil
-
-}

--- a/adapter/internal/oasparser/operator/operator.go
+++ b/adapter/internal/oasparser/operator/operator.go
@@ -31,55 +31,6 @@ import (
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/utills"
 )
 
-// GetMgwSwagger converts the openAPI v3 and v2 content
-// To MgwSwagger objects
-// TODO: (VirajSalaka) return the error and handle
-func GetMgwSwagger(apiContent []byte) (model.MgwSwagger, error) {
-	var mgwSwagger model.MgwSwagger
-
-	apiJsn, err := utills.ToJSON(apiContent)
-	if err != nil {
-		logger.LoggerOasparser.Error("Error converting api file to json", err)
-		return mgwSwagger, err
-	}
-	swaggerVerison := utills.FindSwaggerVersion(apiJsn)
-
-	if swaggerVerison == "2" {
-		// map json to struct
-		var apiData2 spec.Swagger
-		err = json.Unmarshal(apiJsn, &apiData2)
-		if err != nil {
-			logger.LoggerOasparser.Error("Error openAPI unmarshalling", err)
-		} else {
-			infoSwaggerErr := mgwSwagger.SetInfoSwagger(apiData2)
-			if infoSwaggerErr != nil {
-				return mgwSwagger, infoSwaggerErr
-			}
-		}
-
-	} else if swaggerVerison == "3" {
-		// map json to struct
-		var apiData3 *openapi3.Swagger
-
-		err = json.Unmarshal(apiJsn, &apiData3)
-		if err != nil {
-			logger.LoggerOasparser.Error("Error openAPI unmarshalling", err)
-		} else {
-			infoOpenAPIErr := mgwSwagger.SetInfoOpenAPI(*apiData3)
-			if infoOpenAPIErr != nil {
-				return mgwSwagger, infoOpenAPIErr
-			}
-		}
-	}
-	err = mgwSwagger.SetXWso2Extensions()
-	if err != nil {
-		logger.LoggerOasparser.Error("Error occurred while setting x-wso2 extensions for ",
-			mgwSwagger.GetTitle(), " ", err)
-		return mgwSwagger, err
-	}
-	return mgwSwagger, nil
-}
-
 // GetOpenAPIVersionAndJSONContent get the json content and openapi version
 // The input can be either json content or yaml content
 // TODO: (VirajSalaka) Use the MGWSwagger instead of this.
@@ -145,11 +96,11 @@ func GetXWso2LabelsWebSocket(webSocketAPIDef model.MgwSwagger) []string {
 }
 
 /*
-GetMgwSwaggerWebSocket returns a MgwSwagger for the web socket APIs
+GetMgwSwaggerFromAPIYaml returns a MgwSwagger for the APIs using the API.Yaml file.
 */
-func GetMgwSwaggerWebSocket(apiData model.APIYaml) (model.MgwSwagger, error) {
+func GetMgwSwaggerFromAPIYaml(apiData model.APIYaml, apiType string) (model.MgwSwagger, error) {
 	var mgwSwagger model.MgwSwagger
-	err := mgwSwagger.SetInfoSwaggerWebSocket(apiData)
+	err := mgwSwagger.SetSwaggerFromAPIYaml(apiData, apiType)
 	if err != nil {
 		return mgwSwagger, err
 	}

--- a/adapter/internal/oasparser/operator/operator_test.go
+++ b/adapter/internal/oasparser/operator/operator_test.go
@@ -122,7 +122,8 @@ x-wso2-production-endpoints:
 	}
 
 	for _, item := range dataItems {
-		resultMgwSagger, err := operator.GetMgwSwagger([]byte(item.inputSwagger))
+		resultMgwSagger := model.MgwSwagger{}
+		err := resultMgwSagger.GetMgwSwagger([]byte(item.inputSwagger))
 		assert.Nil(t, err, "Error should not be present when openAPI definition is converted to a MgwSwagger object")
 
 		assert.Equal(t, item.resultApiProdEndpoints, resultMgwSagger.GetProdEndpoints().Endpoints, item.message)
@@ -234,7 +235,7 @@ func testGetMgwSwaggerWebSocket(t *testing.T, apiYamlFilePath string) {
 	err = json.Unmarshal(apiJsn, &apiYaml)
 	apiYaml = model.PopulateEndpointsInfo(apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
-	mgwSwagger, err := operator.GetMgwSwaggerWebSocket(apiYaml)
+	mgwSwagger, err := operator.GetMgwSwaggerFromAPIYaml(apiYaml, model.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	if strings.HasSuffix(apiYamlFilePath, "api.yaml") {
 		assert.Equal(t, mgwSwagger.GetAPIType(), "WS", "API type for websocket mismatch")

--- a/adapter/internal/oasparser/operator/operator_test.go
+++ b/adapter/internal/oasparser/operator/operator_test.go
@@ -235,7 +235,8 @@ func testGetMgwSwaggerWebSocket(t *testing.T, apiYamlFilePath string) {
 	err = json.Unmarshal(apiJsn, &apiYaml)
 	apiYaml = model.PopulateEndpointsInfo(apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
-	mgwSwagger, err := operator.GetMgwSwaggerFromAPIYaml(apiYaml, model.WS)
+	var mgwSwagger model.MgwSwagger
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	if strings.HasSuffix(apiYamlFilePath, "api.yaml") {
 		assert.Equal(t, mgwSwagger.GetAPIType(), "WS", "API type for websocket mismatch")

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/AuthFilter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/AuthFilter.java
@@ -134,7 +134,6 @@ public class AuthFilter implements Filter {
 
         boolean canAuthenticated = false;
         for (Authenticator authenticator : authenticators) {
-            log.info("Authenticators " + authenticator.getName());
             if (authenticator.canAuthenticate(requestContext)) {
                 canAuthenticated = true;
                 AuthenticationResponse authenticateResponse = authenticate(authenticator, requestContext);
@@ -186,8 +185,6 @@ public class AuthFilter implements Filter {
      */
     private void updateClusterHeaderAndCheckEnv(RequestContext requestContext, AuthenticationContext authContext)
             throws APISecurityException {
-        log.info("Inside updateCluster env " + requestContext.getProdClusterHeader() + " " +
-                requestContext.getSandClusterHeader());
         String keyType = authContext.getKeyType();
         if (StringUtils.isEmpty(authContext.getKeyType())) {
             keyType = APIConstants.API_KEY_TYPE_PRODUCTION;
@@ -199,14 +196,12 @@ public class AuthFilter implements Filter {
                     requestContext.getProdClusterHeader());
             requestContext.getRemoveHeaders().remove(AdapterConstants.CLUSTER_HEADER);
             addRouterHttpHeaders(requestContext, APIConstants.API_KEY_TYPE_PRODUCTION);
-            log.info("Prod clusterheader is added. " + requestContext.getProdClusterHeader());
         } else if (keyType.equalsIgnoreCase(APIConstants.API_KEY_TYPE_SANDBOX) &&
                 !StringUtils.isEmpty(requestContext.getSandClusterHeader())) {
             requestContext.addOrModifyHeaders(AdapterConstants.CLUSTER_HEADER,
                     requestContext.getSandClusterHeader());
             requestContext.getRemoveHeaders().remove(AdapterConstants.CLUSTER_HEADER);
             addRouterHttpHeaders(requestContext, APIConstants.API_KEY_TYPE_SANDBOX);
-            log.info("Sand clusterheader is added. " + requestContext.getSandClusterHeader());
         } else {
             if (keyType.equalsIgnoreCase(APIConstants.API_KEY_TYPE_PRODUCTION)) {
                 throw new APISecurityException(APIConstants.StatusCodes.UNAUTHENTICATED.getCode(),

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/PrototypedAPITestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/PrototypedAPITestCase.java
@@ -1,0 +1,94 @@
+package org.wso2.choreo.connect.tests.testcases.withapim;
+
+import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus;
+import com.google.gson.Gson;
+import net.minidev.json.JSONObject;
+import net.minidev.json.parser.JSONParser;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.am.integration.clients.publisher.api.v1.dto.APIDTO;
+import org.wso2.am.integration.clients.publisher.api.v1.dto.WorkflowResponseDTO;
+import org.wso2.am.integration.test.utils.bean.APILifeCycleAction;
+import org.wso2.am.integration.test.utils.bean.APIRequest;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+import org.wso2.choreo.connect.tests.apim.ApimBaseTest;
+import org.wso2.choreo.connect.tests.apim.utils.PublisherUtils;
+import org.wso2.choreo.connect.tests.util.HttpsClientRequest;
+import org.wso2.choreo.connect.tests.util.TestConstant;
+import org.wso2.choreo.connect.tests.util.TokenUtil;
+import org.wso2.choreo.connect.tests.util.Utils;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PrototypedAPITestCase extends ApimBaseTest {
+    private static final String SAMPLE_API_NAME = "PrototypedAPI";
+    private static final String SAMPLE_API_CONTEXT = "prototypedApi";
+    private static final String SAMPLE_API_VERSION = "1.0.0";
+    private static final String APP_NAME = "APIKeyTestApp";
+    private String apiId;
+    private String endPoint;
+
+    @BeforeClass(description = "Initialise the setup for API key tests")
+    void start() throws Exception {
+        super.initWithSuperTenant();
+
+        String apiName = "APIMPrototypedEndpointAPI1";
+        String apiContext = "pizzashack-prototype";
+        String apiTags = "pizza, order, pizza-menu";
+        String apiDescription = "Pizza API:Allows to manage pizza orders " +
+                "(create, update, retrieve orders)";
+
+//        apiIdentifier = new APIIdentifier(apiProvider, apiName, apiVersion);
+        String apiEndPointUrl = "http://run.mocky.io/v2/5185415ba171ea3a00704eed";
+        String apiProvider = "admin";
+
+        APIRequest apiRequest = new APIRequest(apiName, apiContext, new URL(apiEndPointUrl));
+        apiRequest.setVersion(SAMPLE_API_VERSION);
+        apiRequest.setDescription(apiDescription);
+        apiRequest.setTags(apiTags);
+        apiRequest.setVisibility(APIDTO.VisibilityEnum.PUBLIC.getValue());
+        apiRequest.setProvider(apiProvider);
+
+        apiId = PublisherUtils.createAPI(apiRequest, publisherRestClient);
+
+        WorkflowResponseDTO lcChangeResponse = publisherRestClient.changeAPILifeCycleStatus(
+                apiId, APILifeCycleAction.DEPLOY_AS_PROTOTYPE.getAction());
+
+        HttpResponse response = publisherRestClient.getAPI(apiId);
+        Gson g = new Gson();
+        APIDTO apiDto = g.fromJson(response.getData(), APIDTO.class);
+        String endPointString = "{\"implementation_status\":\"prototyped\",\"endpoint_type\":\"http\"," +
+                "\"production_endpoints\":{\"config\":null," +
+                "\"url\":\"" + apiEndPointUrl + "\"}," +
+                "\"sandbox_endpoints\":{\"config\":null,\"url\":\"" + apiEndPointUrl + "\"}}";
+
+        JSONParser parser = new JSONParser();
+        JSONObject endpoint = (JSONObject) parser.parse(endPointString);
+        apiDto.setEndpointConfig(endpoint);
+        publisherRestClient.updateAPI(apiDto);
+
+        Assert.assertTrue(lcChangeResponse.getLifecycleState().getState().equals("Prototyped"),
+                apiName + "  status not updated as Prototyped");
+
+        Thread.sleep(10000);
+        PublisherUtils.createAPIRevisionAndDeploy(apiId, publisherRestClient);
+    }
+
+    // When invoke with original token even though the tampered key is in the invalid key cache,
+    // original token should pass.
+    @Test(description = "Test to check the InternalKey is working")
+    public void invokeInternalKeyHeaderSuccessTest() throws Exception {
+        // Set header
+        Map<String, String> headers = new HashMap<>();
+        String internalKey = TokenUtil.getJwtForPetstore(TestConstant.KEY_TYPE_PRODUCTION, null, true);
+        headers.put("Internal-Key", internalKey);
+        org.wso2.choreo.connect.tests.util.HttpResponse response = HttpsClientRequest.doGet(Utils.getServiceURLHttps("/v2/pet/2") , headers);
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK,"Response code mismatched");
+    }
+
+}

--- a/integration/test-integration/src/test/resources/testng-cc-with-apim.xml
+++ b/integration/test-integration/src/test/resources/testng-cc-with-apim.xml
@@ -87,6 +87,7 @@
         <classes>
             <class name="org.wso2.choreo.connect.tests.setup.withapim.CcStartupExecutorTwo"/>
             <class name="org.wso2.choreo.connect.tests.testcases.withapim.APIKeyHeaderTestCase"/>
+            <class name="org.wso2.choreo.connect.tests.testcases.withapim.PrototypedAPITestCase"/>
         </classes>
     </test>
     <test name="cc-shutdown-and-apim-shutdown" parallel="false">


### PR DESCRIPTION
### Purpose

Via this PR, the API.yaml is processed at the earliest. Then the openapi definition is processed and if there are any changes compared to API.yaml (ex. endpoints) those will be overridden by the openAPI. 

So the priority would be,

API.yaml < servers/host property (properties from openapi spec) < x-wso2 extensions

But for the prototyped apis, the endpoints would be determined based on API.yaml (servers/host property is ignored). 


### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1955 

### Automation tests
 - Unit tests added: No
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
