### PR TITLE
Only depend on tier in APIConfig which represents apiTier

### DIFF
--- a/enforcer-parent/commons/src/main/java/org/wso2/choreo/connect/enforcer/commons/model/AuthenticationContext.java
+++ b/enforcer-parent/commons/src/main/java/org/wso2/choreo/connect/enforcer/commons/model/AuthenticationContext.java
@@ -27,7 +27,6 @@ public class AuthenticationContext {
     private String username;
     private String applicationTier;
     private String tier;
-    private String apiTier;
     private boolean isContentAwareTierPresent;
     private String apiKey;
     private String keyType;
@@ -54,7 +53,6 @@ public class AuthenticationContext {
     public AuthenticationContext() {
         this.applicationId = UNKNOWN_VALUE;
         this.apiPublisher = UNKNOWN_VALUE;
-        this.apiTier = "";
         this.applicationId = UNKNOWN_VALUE;
         this.applicationName = UNKNOWN_VALUE;
         this.applicationTier = "Unlimited";
@@ -85,20 +83,6 @@ public class AuthenticationContext {
 
     public void setIsContentAware(boolean isContentAware) {
         this.isContentAwareTierPresent = isContentAware;
-    }
-
-    /**
-     * API Level throttling tier.
-     *
-     * @return API Level Throttling Tier.
-     */
-    public String getApiTier() {
-        return apiTier;
-    }
-
-
-    public void setApiTier(String apiTier) {
-        this.apiTier = apiTier;
     }
 
     /**

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/dto/APIKeyValidationInfoDTO.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/dto/APIKeyValidationInfoDTO.java
@@ -38,8 +38,6 @@ public class APIKeyValidationInfoDTO implements Serializable {
     //If this property is true then throttle handler should build message or get content length and pass it to
     //throttle server.
     private boolean contentAware;
-    //Form API Manager 2.0 onward API specific tiers can define and this property is here to pass it.
-    private String apiTier;
     //JWT or SAML token containing details of API invoker
     private String userType;
     private String endUserToken;
@@ -76,14 +74,6 @@ public class APIKeyValidationInfoDTO implements Serializable {
 
     public void setThrottlingDataList(List<String> throttlingDataList) {
         this.throttlingDataList = throttlingDataList;
-    }
-
-    public String getApiTier() {
-        return apiTier;
-    }
-
-    public void setApiTier(String apiTier) {
-        this.apiTier = apiTier;
     }
 
     public boolean isContentAware() {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/KeyValidator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/KeyValidator.java
@@ -262,9 +262,6 @@ public class KeyValidator {
         infoDTO.setStopOnQuotaReach(stopOnQuotaReach);
         infoDTO.setGraphQLMaxDepth(graphQLMaxDepth);
         infoDTO.setGraphQLMaxComplexity(graphQLMaxComplexity);
-        if (apiTier != null && apiTier.trim().length() > 0) {
-            infoDTO.setApiTier(apiTier);
-        }
         // We also need to set throttling data list associated with given API. This need to have
         // policy id and
         // condition id list for all throttling tiers associated with this API.

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyAuthenticator.java
@@ -303,7 +303,6 @@ public class APIKeyAuthenticator extends APIKeyHandler {
         String version = requestContext.getMatchedAPI().getVersion();
         JSONObject api = null;
 
-        validationInfoDTO.setApiTier(requestContext.getMatchedAPI().getTier());
         if (payload.getClaim(APIConstants.JwtTokenConstants.KEY_TYPE) != null) {
             validationInfoDTO.setType(payload.getStringClaim(APIConstants.JwtTokenConstants.KEY_TYPE));
         } else {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
@@ -259,7 +259,6 @@ public class InternalAPIKeyAuthenticator extends APIKeyHandler {
             throws ParseException {
 
         APIKeyValidationInfoDTO validationInfoDTO = new APIKeyValidationInfoDTO();
-        validationInfoDTO.setApiTier(requestContext.getMatchedAPI().getTier());
         if (payload.getClaim(APIConstants.JwtTokenConstants.KEY_TYPE) != null) {
             validationInfoDTO.setType(payload.getStringClaim(APIConstants.JwtTokenConstants.KEY_TYPE));
         } else {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/server/WebSocketHandler.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/server/WebSocketHandler.java
@@ -100,7 +100,6 @@ public class WebSocketHandler implements RequestHandler<WebSocketFrameRequest, W
         String username = extAuthMetadata.get(MetadataConstants.USERNAME);
         String appTier = extAuthMetadata.get(MetadataConstants.APP_TIER);
         String tier = extAuthMetadata.get(MetadataConstants.TIER);
-        String apiTier = extAuthMetadata.get(MetadataConstants.API_TIER);
         boolean isContentAwareTierPresent = Boolean.parseBoolean(extAuthMetadata
                 .get(MetadataConstants.CONTENT_AWARE_TIER_PRESENT));
         String apiKey = extAuthMetadata.get(MetadataConstants.API_KEY);
@@ -132,7 +131,6 @@ public class WebSocketHandler implements RequestHandler<WebSocketFrameRequest, W
         authenticationContext.setUsername(username);
         authenticationContext.setApplicationTier(appTier);
         authenticationContext.setTier(tier);
-        authenticationContext.setApiTier(apiTier);
         authenticationContext.setIsContentAware(isContentAwareTierPresent);
         authenticationContext.setApiKey(apiKey);
         authenticationContext.setKeyType(keyType);

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/util/FilterUtils.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/util/FilterUtils.java
@@ -200,7 +200,6 @@ public class FilterUtils {
         }
         // Setting end user as anonymous
         authContext.setUsername(APIConstants.END_USER_ANONYMOUS);
-        authContext.setApiTier(getAPILevelTier(requestContext));
         authContext.setApplicationId(clientIP);
         authContext.setApplicationName(null);
         authContext.setApplicationTier(APIConstants.UNLIMITED_TIER);
@@ -228,7 +227,6 @@ public class FilterUtils {
         authContext.setUsername(jwtValidationInfo.getUser());
 
         if (apiKeyValidationInfoDTO != null) {
-            authContext.setApiTier(apiKeyValidationInfoDTO.getApiTier());
             authContext.setKeyType(apiKeyValidationInfoDTO.getType());
             authContext.setApplicationId(apiKeyValidationInfoDTO.getApplicationId());
             authContext.setApplicationName(apiKeyValidationInfoDTO.getApplicationName());
@@ -320,7 +318,6 @@ public class FilterUtils {
         } else {
             authContext.setKeyType(APIConstants.API_KEY_TYPE_PRODUCTION);
         }
-        authContext.setApiTier(apiLevelPolicy);
         if (api != null) {
             authContext.setTier(APIConstants.UNLIMITED_TIER);
             authContext.setApiName(api.getAsString(APIConstants.JwtTokenConstants.API_NAME));
@@ -514,26 +511,6 @@ public class FilterUtils {
             return username + '@' + tenantDomain;
         }
         return username;
-    }
-
-    /**
-     * Get the API related throttling tier for auth context.
-     * If API level present, it will be returned. If not resource level
-     * would be returned. If both not present, UNLIMITED tier would be returned.
-     * @param requestContext Request context
-     * @return string format API tier.
-     */
-    public static String getAPILevelTier(RequestContext requestContext) {
-        String apiTier = requestContext.getMatchedAPI().getTier();
-        String resourceTier = requestContext.getMatchedResourcePath().getTier();
-
-        if (!apiTier.isEmpty() && !ThrottleConstants.UNLIMITED_TIER.equalsIgnoreCase(apiTier)) {
-            return apiTier;
-        }
-        if (!resourceTier.isBlank()) {
-            return resourceTier;
-        }
-        return ThrottleConstants.UNLIMITED_TIER;
     }
 
     public static String getClientIp(Map<String, String> headers, String knownIp) {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/websocket/WebSocketMetaDataFilter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/websocket/WebSocketMetaDataFilter.java
@@ -74,8 +74,6 @@ public class WebSocketMetaDataFilter implements Filter {
                     getNullableStringValue(authenticationContext.getApplicationTier()));
             requestContext.addMetadataToMap(MetadataConstants.TIER,
                     getNullableStringValue(authenticationContext.getTier()));
-            requestContext.addMetadataToMap(MetadataConstants.API_TIER,
-                    getNullableStringValue(authenticationContext.getApiTier()));
             requestContext.addMetadataToMap(MetadataConstants.CONTENT_AWARE_TIER_PRESENT,
                     getNullableStringValue(String.valueOf(authenticationContext.isContentAwareTierPresent())));
             requestContext.addMetadataToMap(MetadataConstants.API_KEY,

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/websocket/WebSocketMetaDataFilter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/websocket/WebSocketMetaDataFilter.java
@@ -45,7 +45,6 @@ public class WebSocketMetaDataFilter implements Filter {
     private static final Logger logger = LogManager.getLogger(WebSocketAPI.class);
 
     private APIConfig apiConfig;
-    private AuthenticationContext authenticationContext;
 
     @Override
     public void init(APIConfig apiConfig, Map<String, String> configProperties) {
@@ -64,7 +63,7 @@ public class WebSocketMetaDataFilter implements Filter {
                         ThreadContext.get(APIConstants.LOG_TRACE_ID));
 
             }
-            this.authenticationContext = requestContext.getAuthenticationContext();
+            AuthenticationContext authenticationContext = requestContext.getAuthenticationContext();
             requestContext.addMetadataToMap(MetadataConstants.GRPC_STREAM_ID, UUID.randomUUID().toString());
             requestContext.addMetadataToMap(MetadataConstants.REQUEST_ID,
                     getNullableStringValue(requestContext.getRequestID()));
@@ -74,6 +73,8 @@ public class WebSocketMetaDataFilter implements Filter {
                     getNullableStringValue(authenticationContext.getApplicationTier()));
             requestContext.addMetadataToMap(MetadataConstants.TIER,
                     getNullableStringValue(authenticationContext.getTier()));
+            requestContext.addMetadataToMap(MetadataConstants.API_TIER,
+                    getNullableStringValue(requestContext.getMatchedAPI().getTier()));
             requestContext.addMetadataToMap(MetadataConstants.CONTENT_AWARE_TIER_PRESENT,
                     getNullableStringValue(String.valueOf(authenticationContext.isContentAwareTierPresent())));
             requestContext.addMetadataToMap(MetadataConstants.API_KEY,


### PR DESCRIPTION
### Purpose
Remove apitier field from AuthenticationContext and APIKeyValidationInfoDTO and only depend on tier field in APIConfig.

### Issues
Fixes https://github.com/wso2/product-microgateway/issues/2264

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
