### PR TITLE
Send the same validateInfo used in authContext to jwt generator 

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyAuthenticator.java
@@ -226,10 +226,8 @@ public class APIKeyAuthenticator extends APIKeyHandler {
                 JWTConfigurationDto jwtConfigurationDto = ConfigHolder.getInstance().
                         getConfig().getJwtConfigurationDto();
                 if (jwtConfigurationDto.isEnabled()) {
-                    // TODO: (suksw) Ask if it is okay for this infoDTO to be different from the actual infoDTO
-                    APIKeyValidationInfoDTO infoDtoForBackendJWT = getAPIKeyValidationDTO(requestContext, payload);
                     JWTInfoDto jwtInfoDto = FilterUtils
-                            .generateJWTInfoDto(null, validationInfo, infoDtoForBackendJWT, requestContext);
+                            .generateJWTInfoDto(null, validationInfo, validationInfoDto, requestContext);
                     endUserToken = BackendJwtUtils.generateAndRetrieveJWTToken(jwtGenerator, tokenIdentifier,
                             jwtInfoDto, isGatewayTokenCacheEnabled);
                     // Set generated jwt token as a response header

--- a/resources/k8s-artifacts/choreo-connect/config-toml-configmap.yaml
+++ b/resources/k8s-artifacts/choreo-connect/config-toml-configmap.yaml
@@ -85,6 +85,7 @@ data:
     [[enforcer.security.tokenService]]
       name = "APIM Publisher"
       issuer = "https://apim.wso2.com/publisher"
+      validateSubscription = true
       certificateFilePath = "/home/wso2/security/truststore/wso2carbon.pem"
 
     [enforcer.throttling]


### PR DESCRIPTION
### Purpose
- Send the same validateInfo used in authContext to jwt generator 
- Update k8 artifacts enable sub val for APIM publ

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
