### PR TITLE
Fix path param population error in Websocket APIs

### DIFF
--- a/enforcer-parent/commons/src/main/java/org/wso2/choreo/connect/enforcer/commons/model/RequestContext.java
+++ b/enforcer-parent/commons/src/main/java/org/wso2/choreo/connect/enforcer/commons/model/RequestContext.java
@@ -20,6 +20,8 @@ package org.wso2.choreo.connect.enforcer.commons.model;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -33,6 +35,7 @@ import java.util.TreeMap;
  * through out the complete request flow through the gateway enforcer.
  */
 public class RequestContext {
+    private static final Logger logger = LogManager.getLogger(RequestContext.class);
 
     //constants
     public static final String CLUSTER_HEADER = "x-wso2-cluster-header";
@@ -447,6 +450,11 @@ public class RequestContext {
          */
         private Map<String, String> populatePathParameters(String basePath, String resourceTemplate,
                                                            String rawPath) {
+            if (resourceTemplate == null || rawPath == null) {
+                logger.debug("Skip populating the path parameters. template: {}, rawPath: {}", resourceTemplate,
+                        rawPath);
+                return null;
+            }
             // Format the basePath and resourcePath to maintain consistency
             String formattedBasePath = basePath.startsWith("/") ? basePath : "/" + basePath;
             formattedBasePath = formattedBasePath.endsWith("/") ?
@@ -457,8 +465,7 @@ public class RequestContext {
             String formattedRawPath = rawPath.split("\\?")[0];
             final ParameterResolver parameterResolver = new ParameterResolver
                     (formattedBasePath + formattedResourcePathTemplate);
-            final Map<String, String> resultMap = parameterResolver.parametersByName(formattedRawPath);
-            return resultMap;
+            return parameterResolver.parametersByName(formattedRawPath);
         }
     }
 }


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
When path temaplate is missing in scenarios like websocket API invocations, we should avoid trying to build path param map.
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2537

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
