### PR TITLE
[3.2.x] Upgrade ballerina version to 1.2.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -575,7 +575,7 @@
     </build>
 
     <properties>
-        <ballerina.platform.version>1.2.21</ballerina.platform.version>
+        <ballerina.platform.version>1.2.22</ballerina.platform.version>
         <broker.version>0.970.5</broker.version>
         <assembly.plugin.version>3.1.1</assembly.plugin.version>
         <compiler.plugin.version>3.7.0</compiler.plugin.version>


### PR DESCRIPTION
### Purpose
This PR upgrades the ballerina version to 1.2.22.

Fixes: https://github.com/wso2/product-microgateway/issues/2505, https://github.com/wso2/product-microgateway/issues/2456