### PR TITLE
[Bug-Fix] Unlimited API Level Tier is not applied after resource level tier applied for once

### DIFF
--- a/enforcer-parent/commons/src/main/java/org/wso2/choreo/connect/enforcer/commons/model/APIConfig.java
+++ b/enforcer-parent/commons/src/main/java/org/wso2/choreo/connect/enforcer/commons/model/APIConfig.java
@@ -40,7 +40,7 @@ public class APIConfig {
     private String uuid;
 
     private Map<String, List<String>> apiSecurity = new HashMap<>();
-    private String tier = "Unlimited";
+    private String tier;
     private boolean disableSecurity = false;
     private List<ResourceConfig> resources = new ArrayList<>();
 
@@ -203,7 +203,7 @@ public class APIConfig {
         private String uuid;
         private Map<String, SecuritySchemaConfig> securitySchemeDefinitions;
         private Map<String, List<String>> apiSecurity = new HashMap<>();
-        private String tier = "Unlimited";
+        private String tier;
         private boolean disableSecurity = false;
         private List<ResourceConfig> resources = new ArrayList<>();
 

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
@@ -228,7 +228,6 @@ public class InternalAPIKeyAuthenticator extends APIKeyHandler {
                     }
 
                     return FilterUtils.generateAuthenticationContext(tokenIdentifier, payload, api,
-                            requestContext.getMatchedAPI().getTier(),
                             requestContext.getMatchedAPI().getUuid(), internalKey);
                 } else {
                     log.error("Internal Key authentication failed. " + FilterUtils.getMaskedToken(splitToken[0]));

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/throttle/ThrottleFilter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/throttle/ThrottleFilter.java
@@ -135,7 +135,7 @@ public class ThrottleFilter implements Filter {
                 String authorizedUser = FilterUtils.buildUsernameWithTenant(authContext.getUsername(), appTenant);
                 boolean isApiLevelTriggered = false;
 
-                if (!StringUtils.isEmpty(apiTier) && !ThrottleConstants.UNLIMITED_TIER.equalsIgnoreCase(apiTier)) {
+                if (!StringUtils.isEmpty(api.getTier())) {
                     resourceThrottleKey = apiThrottleKey;
                     resourceTier = apiTier;
                     isApiLevelTriggered = true;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/throttle/ThrottleFilter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/throttle/ThrottleFilter.java
@@ -298,7 +298,9 @@ public class ThrottleFilter implements Filter {
             tenantDomain = APIConstants.SUPER_TENANT_DOMAIN_NAME;
         }
 
-        if (!StringUtils.isEmpty(apiTier) && !ThrottleConstants.UNLIMITED_TIER.equals(apiTier)) {
+        // apiConfig instance will have the tier assigned only if openapi definition contains the
+        // extension
+        if (!StringUtils.isEmpty(api.getTier())) {
             resourceTier = apiTier;
             resourceKey = apiContext;
         } else {
@@ -362,7 +364,7 @@ public class ThrottleFilter implements Filter {
     }
 
     private String getApiTier(APIConfig apiConfig) {
-        if (!apiConfig.getTier().isBlank()) {
+        if (!StringUtils.isEmpty(apiConfig.getTier())) {
             return apiConfig.getTier();
         }
         return ThrottleConstants.UNLIMITED_TIER;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/util/FilterUtils.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/util/FilterUtils.java
@@ -300,13 +300,12 @@ public class FilterUtils {
      * @param tokenIdentifier
      * @param payload
      * @param api
-     * @param apiLevelPolicy
      * @param rawToken Raw token used to authenticate the request
      * @return
      * @throws java.text.ParseException
      */
     public static AuthenticationContext generateAuthenticationContext(String tokenIdentifier, JWTClaimsSet payload,
-                                                                      JSONObject api, String apiLevelPolicy,
+                                                                      JSONObject api,
                                                                       String apiUUID, String rawToken)
             throws java.text.ParseException {
 

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/websocket/WebSocketMetaDataFilter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/websocket/WebSocketMetaDataFilter.java
@@ -27,6 +27,7 @@ import org.wso2.choreo.connect.enforcer.commons.model.APIConfig;
 import org.wso2.choreo.connect.enforcer.commons.model.AuthenticationContext;
 import org.wso2.choreo.connect.enforcer.commons.model.RequestContext;
 import org.wso2.choreo.connect.enforcer.constants.APIConstants;
+import org.wso2.choreo.connect.enforcer.throttle.ThrottleConstants;
 import org.wso2.choreo.connect.enforcer.tracing.TracingConstants;
 import org.wso2.choreo.connect.enforcer.tracing.TracingSpan;
 import org.wso2.choreo.connect.enforcer.tracing.TracingTracer;
@@ -63,6 +64,8 @@ public class WebSocketMetaDataFilter implements Filter {
                         ThreadContext.get(APIConstants.LOG_TRACE_ID));
 
             }
+            String apiTier = !requestContext.getMatchedAPI().getTier().isBlank()
+                    ? requestContext.getMatchedAPI().getTier() : ThrottleConstants.UNLIMITED_TIER;
             AuthenticationContext authenticationContext = requestContext.getAuthenticationContext();
             requestContext.addMetadataToMap(MetadataConstants.GRPC_STREAM_ID, UUID.randomUUID().toString());
             requestContext.addMetadataToMap(MetadataConstants.REQUEST_ID,
@@ -74,7 +77,7 @@ public class WebSocketMetaDataFilter implements Filter {
             requestContext.addMetadataToMap(MetadataConstants.TIER,
                     getNullableStringValue(authenticationContext.getTier()));
             requestContext.addMetadataToMap(MetadataConstants.API_TIER,
-                    getNullableStringValue(requestContext.getMatchedAPI().getTier()));
+                    getNullableStringValue(apiTier));
             requestContext.addMetadataToMap(MetadataConstants.CONTENT_AWARE_TIER_PRESENT,
                     getNullableStringValue(String.valueOf(authenticationContext.isContentAwareTierPresent())));
             requestContext.addMetadataToMap(MetadataConstants.API_KEY,


### PR DESCRIPTION
bug fix: If the openAPI's throttling is set to some operation level, and then revert back to API Level with Unlimited Tier, the resource level throttling still enforced instead on Unlimited Tier.

### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2561 

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
