### PR TITLE
[Bug-Fix] Avoid Unwanted headers/query parameters being forwarded to the backend

### DIFF
--- a/enforcer-parent/commons/src/main/java/org/wso2/choreo/connect/enforcer/commons/model/RequestContext.java
+++ b/enforcer-parent/commons/src/main/java/org/wso2/choreo/connect/enforcer/commons/model/RequestContext.java
@@ -62,6 +62,7 @@ public class RequestContext {
     private WebSocketFrameContext webSocketFrameContext;
     private Map<String, String> queryParameters;
     private Map<String, String> pathParameters;
+    private ArrayList<String> queryParamsToRemove;
 
     // Request Timestamp is required for analytics
     private long requestTimeStamp;
@@ -313,6 +314,16 @@ public class RequestContext {
     }
 
     /**
+     * If there is a set of query parameters needs to be removed from the request path, those parameters should
+     * be added to the arrayList here.
+     *
+     * @return query parameters which are supposed to be removed.
+     */
+    public ArrayList<String> getQueryParamsToRemove() {
+        return queryParamsToRemove;
+    }
+
+    /**
      * Implements builder pattern to build an {@link RequestContext} object.
      */
     public static class Builder {
@@ -412,6 +423,7 @@ public class RequestContext {
             requestContext.clientIp = this.clientIp;
             requestContext.addHeaders = new HashMap<>();
             requestContext.removeHeaders = new ArrayList<>();
+            requestContext.queryParamsToRemove = new ArrayList<>();
             String[] queryParts = this.requestPath.split("\\?");
             String queryPrams = queryParts.length > 1 ? queryParts[1] : "";
 

--- a/enforcer-parent/commons/src/main/java/org/wso2/choreo/connect/enforcer/commons/model/RequestContext.java
+++ b/enforcer-parent/commons/src/main/java/org/wso2/choreo/connect/enforcer/commons/model/RequestContext.java
@@ -317,7 +317,7 @@ public class RequestContext {
     }
 
     /**
-     * If there is a set of query parameters needs to be removed from the request path, those parameters should
+     * If there is a set of query parameters needs to be removed from the outbound request, those parameters should
      * be added to the arrayList here.
      *
      * @return query parameters which are supposed to be removed.

--- a/enforcer-parent/commons/src/main/java/org/wso2/choreo/connect/enforcer/commons/model/RequestContext.java
+++ b/enforcer-parent/commons/src/main/java/org/wso2/choreo/connect/enforcer/commons/model/RequestContext.java
@@ -63,6 +63,9 @@ public class RequestContext {
     private Map<String, String> queryParameters;
     private Map<String, String> pathParameters;
     private ArrayList<String> queryParamsToRemove;
+    // This is used to keep protected headers like authorization header. The protected headers will not be
+    // sent to the Traffic Manager when header based rate limiting is enabled.
+    private ArrayList<String> protectedHeaders;
 
     // Request Timestamp is required for analytics
     private long requestTimeStamp;
@@ -324,6 +327,18 @@ public class RequestContext {
     }
 
     /**
+     * If there is a set of headers needs to be removed from the throttle publishing event, those headers should
+     * be added to the arrayList here.
+     *
+     * Ex. Authorization Header
+     *
+     * @return header names which are not supposed to be published to the traffic manager.
+     */
+    public ArrayList<String> getProtectedHeaders() {
+        return protectedHeaders;
+    }
+
+    /**
      * Implements builder pattern to build an {@link RequestContext} object.
      */
     public static class Builder {
@@ -424,6 +439,7 @@ public class RequestContext {
             requestContext.addHeaders = new HashMap<>();
             requestContext.removeHeaders = new ArrayList<>();
             requestContext.queryParamsToRemove = new ArrayList<>();
+            requestContext.protectedHeaders = new ArrayList<>();
             String[] queryParts = this.requestPath.split("\\?");
             String queryPrams = queryParts.length > 1 ? queryParts[1] : "";
 

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/ResponseObject.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/ResponseObject.java
@@ -123,11 +123,11 @@ public class ResponseObject {
     }
 
     public Map<String, String> getQueryParamMap() {
-        return queryParamMap;
+        return queryParams;
     }
 
-    public void setQueryParamMap(Map<String, String> queryParamMap) {
-        this.queryParamMap = queryParamMap;
+    public void setQueryParamMap(Map<String, String> queryParams) {
+        this.queryParams = queryParams;
     }
 
     public String getRequestPath() {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/ResponseObject.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/ResponseObject.java
@@ -35,7 +35,7 @@ public class ResponseObject {
     private Map<String, String> metaDataMap;
     private boolean isDirectResponse = false;
     private ArrayList<String> queryParamsToRemove = new ArrayList<>();
-    private Map<String, String> queryParamMap;
+    private Map<String, String> queryParams;
     private String requestPath;
 
     public ArrayList<String> getRemoveHeaderMap() {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/ResponseObject.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/ResponseObject.java
@@ -34,6 +34,9 @@ public class ResponseObject {
     private ArrayList<String> removeHeaderMap = new ArrayList<>();
     private Map<String, String> metaDataMap;
     private boolean isDirectResponse = false;
+    private ArrayList<String> queryParamsToRemove = new ArrayList<>();
+    private Map<String, String> queryParamMap;
+    private String requestPath;
 
     public ArrayList<String> getRemoveHeaderMap() {
         return removeHeaderMap;
@@ -109,5 +112,29 @@ public class ResponseObject {
 
     public void setMetaDataMap(Map<String, String> metaDataMap) {
         this.metaDataMap = metaDataMap;
+    }
+
+    public ArrayList<String> getQueryParamsToRemove() {
+        return queryParamsToRemove;
+    }
+
+    public void setQueryParamsToRemove(ArrayList<String> queryParamsToRemove) {
+        this.queryParamsToRemove = queryParamsToRemove;
+    }
+
+    public Map<String, String> getQueryParamMap() {
+        return queryParamMap;
+    }
+
+    public void setQueryParamMap(Map<String, String> queryParamMap) {
+        this.queryParamMap = queryParamMap;
+    }
+
+    public String getRequestPath() {
+        return requestPath;
+    }
+
+    public void setRequestPath(String requestPath) {
+        this.requestPath = requestPath;
     }
 }

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/RestAPI.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/RestAPI.java
@@ -302,7 +302,7 @@ public class RestAPI implements API {
                     requestContext.getRemoveHeaders().add(schema.getName());
                     continue;
                 }
-                if ("query".equals(schema.getIn())) {
+                if (APIConstants.SWAGGER_API_KEY_IN_QUERY.equals(schema.getIn())) {
                     requestContext.getQueryParamsToRemove().add(schema.getName());
                 }
             }

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/RestAPI.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/RestAPI.java
@@ -296,7 +296,7 @@ public class RestAPI implements API {
         // credentials.
         for (Map.Entry<String, SecuritySchemaConfig> entry : securitySchemeDefinitions.entrySet()) {
             SecuritySchemaConfig schema = entry.getValue();
-            if ("apiKey".equalsIgnoreCase(schema.getType())) {
+            if (APIConstants.SWAGGER_API_KEY_AUTH_TYPE_NAME.equalsIgnoreCase(schema.getType())) {
                 if (APIConstants.SWAGGER_API_KEY_IN_HEADER.equals(schema.getIn())) {
                     requestContext.getProtectedHeaders().add(schema.getName());
                     requestContext.getRemoveHeaders().add(schema.getName());

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/RestAPI.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/RestAPI.java
@@ -157,6 +157,7 @@ public class RestAPI implements API {
     @Override
     public ResponseObject process(RequestContext requestContext) {
         ResponseObject responseObject = new ResponseObject(requestContext.getRequestID());
+        responseObject.setRequestPath(requestContext.getRequestPath());
         boolean analyticsEnabled = ConfigHolder.getInstance().getConfig().getAnalyticsConfig().isEnabled();
 
         // Process to-be-removed headers
@@ -168,6 +169,8 @@ public class RestAPI implements API {
 
         if (executeFilterChain(requestContext)) {
             responseObject.setRemoveHeaderMap(requestContext.getRemoveHeaders());
+            responseObject.setQueryParamsToRemove(requestContext.getQueryParamsToRemove());
+            responseObject.setQueryParamMap(requestContext.getQueryParameters());
             responseObject.setStatusCode(APIConstants.StatusCodes.OK.getCode());
             if (requestContext.getAddHeaders() != null && requestContext.getAddHeaders().size() > 0) {
                 responseObject.setHeaderMap(requestContext.getAddHeaders());

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/RestAPI.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/RestAPI.java
@@ -308,7 +308,7 @@ public class RestAPI implements API {
             }
         }
 
-        //Internal-Key credential is considered to be protected headers, such that the header would not be sent
+        // Internal-Key credential is considered to be protected headers, such that the header would not be sent
         // to backend and traffic manager.
         String internalKeyHeader = ConfigHolder.getInstance().getConfig().getAuthHeader()
                 .getTestConsoleHeaderName().toLowerCase();

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/RestAPI.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/RestAPI.java
@@ -297,7 +297,7 @@ public class RestAPI implements API {
         for (Map.Entry<String, SecuritySchemaConfig> entry : securitySchemeDefinitions.entrySet()) {
             SecuritySchemaConfig schema = entry.getValue();
             if ("apiKey".equalsIgnoreCase(schema.getType())) {
-                if ("header".equals(schema.getIn())) {
+                if (APIConstants.SWAGGER_API_KEY_IN_HEADER.equals(schema.getIn())) {
                     requestContext.getProtectedHeaders().add(schema.getName());
                     requestContext.getRemoveHeaders().add(schema.getName());
                     continue;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/RestAPI.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/RestAPI.java
@@ -166,6 +166,8 @@ public class RestAPI implements API {
             String authHeaderName = FilterUtils.getAuthHeaderName(requestContext);
             requestContext.getRemoveHeaders().add(authHeaderName);
         }
+        // Authorization Header should not be included in the throttle publishing event.
+        requestContext.getProtectedHeaders().add(FilterUtils.getAuthHeaderName(requestContext));
 
         if (executeFilterChain(requestContext)) {
             responseObject.setRemoveHeaderMap(requestContext.getRemoveHeaders());

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/APIConstants.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/APIConstants.java
@@ -86,6 +86,7 @@ public class APIConstants {
     public static final String APPLICATION_JSON = "application/json";
     public static final String API_TRACE_KEY = "X-TRACE-KEY";
     public static final String X_FORWARDED_FOR = "x-forwarded-for";
+    public static final String PATH_HEADER = ":path";
 
     public static final String LOG_TRACE_ID = "traceId";
 

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/grpc/ExtAuthService.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/grpc/ExtAuthService.java
@@ -144,6 +144,10 @@ public class ExtAuthService extends AuthorizationGrpc.AuthorizationImplBase {
         } else {
             OkHttpResponse.Builder okResponseBuilder = OkHttpResponse.newBuilder();
 
+            // If the user is sending the APIKey credentials within query parameters, those query parameters should
+            // not be sent to the backend. Hence, the :path header needs to be constructed again removing the apiKey
+            // query parameter. In this scenario, apiKey query parameter is sent within the property called
+            // 'queryParamsToRemove' so that the custom filters also can utilize the method.
             if (responseObject.getQueryParamsToRemove().size() > 0) {
                 String constructedPath = constructQueryParamString(responseObject.getRequestPath(),
                         responseObject.getQueryParamMap(), responseObject.getQueryParamsToRemove());
@@ -195,7 +199,7 @@ public class ExtAuthService extends AuthorizationGrpc.AuthorizationImplBase {
         return Code.INTERNAL_VALUE;
     }
 
-    private String constructQueryParamString(String requestPath, Map<String, String> queryParams,
+    private String constructQueryParamString(String requestPath, Map<String, String> queryParamMap,
                                              List<String> queryParamsToRemove) {
         // If no query parameters needs to be removed, then the request path can be applied as it is.
         if (queryParamsToRemove.size() == 0) {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/grpc/ExtAuthService.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/grpc/ExtAuthService.java
@@ -195,7 +195,7 @@ public class ExtAuthService extends AuthorizationGrpc.AuthorizationImplBase {
         return Code.INTERNAL_VALUE;
     }
 
-    private String constructQueryParamString(String requestPath, Map<String, String> queryParamMap,
+    private String constructQueryParamString(String requestPath, Map<String, String> queryParams,
                                              List<String> queryParamsToRemove) {
         // If no query parameters needs to be removed, then the request path can be applied as it is.
         if (queryParamsToRemove.size() == 0) {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyAuthenticator.java
@@ -104,16 +104,11 @@ public class APIKeyAuthenticator extends APIKeyHandler {
                     // key must exist in specified location
                     if (APIConstants.SWAGGER_API_KEY_IN_HEADER.equalsIgnoreCase(securitySchemaDefinition.getIn())) {
                         if (requestContext.getHeaders().containsKey(securitySchemaDefinition.getName())) {
-                            // Remove the apiKey header being forwarded to the backend.
-                            requestContext.getRemoveHeaders().add(securitySchemaDefinition.getName());
-                            // avoid the apiKey header being published within the throttle event.
-                            requestContext.getProtectedHeaders().add(securitySchemaDefinition.getName());
                             return requestContext.getHeaders().get(securitySchemaDefinition.getName());
                         }
                     }
                     if (APIConstants.SWAGGER_API_KEY_IN_QUERY.equalsIgnoreCase(securitySchemaDefinition.getIn())) {
                         if (requestContext.getQueryParameters().containsKey(securitySchemaDefinition.getName())) {
-                            requestContext.getQueryParamsToRemove().add(securitySchemaDefinition.getName());
                             return requestContext.getQueryParameters().get(securitySchemaDefinition.getName());
                         }
                     }

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyAuthenticator.java
@@ -106,6 +106,8 @@ public class APIKeyAuthenticator extends APIKeyHandler {
                         if (requestContext.getHeaders().containsKey(securitySchemaDefinition.getName())) {
                             // Remove the apiKey header being forwarded to the backend.
                             requestContext.getRemoveHeaders().add(securitySchemaDefinition.getName());
+                            // avoid the apiKey header being published within the throttle event.
+                            requestContext.getProtectedHeaders().add(securitySchemaDefinition.getName());
                             return requestContext.getHeaders().get(securitySchemaDefinition.getName());
                         }
                     }

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyAuthenticator.java
@@ -104,11 +104,14 @@ public class APIKeyAuthenticator extends APIKeyHandler {
                     // key must exist in specified location
                     if (APIConstants.SWAGGER_API_KEY_IN_HEADER.equalsIgnoreCase(securitySchemaDefinition.getIn())) {
                         if (requestContext.getHeaders().containsKey(securitySchemaDefinition.getName())) {
+                            // Remove the apiKey header being forwarded to the backend.
+                            requestContext.getRemoveHeaders().add(securitySchemaDefinition.getName());
                             return requestContext.getHeaders().get(securitySchemaDefinition.getName());
                         }
                     }
                     if (APIConstants.SWAGGER_API_KEY_IN_QUERY.equalsIgnoreCase(securitySchemaDefinition.getIn())) {
                         if (requestContext.getQueryParameters().containsKey(securitySchemaDefinition.getName())) {
+                            requestContext.getQueryParamsToRemove().add(securitySchemaDefinition.getName());
                             return requestContext.getQueryParameters().get(securitySchemaDefinition.getName());
                         }
                     }

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
@@ -98,6 +98,8 @@ public class InternalAPIKeyAuthenticator extends APIKeyHandler {
                 String internalKey = extractInternalKey(requestContext);
                 // Remove internal key from outbound request
                 requestContext.getRemoveHeaders().add(securityParam);
+                // Avoid internal key being published to the Traffic Manager
+                requestContext.getProtectedHeaders().add(securityParam);
 
                 String[] splitToken = internalKey.split("\\.");
                 SignedJWT signedJWT = SignedJWT.parse(internalKey);

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
@@ -96,10 +96,6 @@ public class InternalAPIKeyAuthenticator extends APIKeyHandler {
                 }
                 // Extract internal from the request while removing it from the msg context.
                 String internalKey = extractInternalKey(requestContext);
-                // Remove internal key from outbound request
-                requestContext.getRemoveHeaders().add(securityParam);
-                // Avoid internal key being published to the Traffic Manager
-                requestContext.getProtectedHeaders().add(securityParam);
 
                 String[] splitToken = internalKey.split("\\.");
                 SignedJWT signedJWT = SignedJWT.parse(internalKey);

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/throttle/ThrottleFilter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/throttle/ThrottleFilter.java
@@ -395,7 +395,7 @@ public class ThrottleFilter implements Filter {
             Map<String, String> headers = requestContext.getHeaders();
             for (String name : headers.keySet()) {
                 // To avoid publishing user token to the traffic manager.
-                if (requestContext.getRemoveHeaders().contains(name)) {
+                if (requestContext.getProtectedHeaders().contains(name)) {
                     continue;
                 }
                 // Sending path header is stopped as it could contain query parameters which are used

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/throttle/ThrottleFilter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/throttle/ThrottleFilter.java
@@ -394,6 +394,15 @@ public class ThrottleFilter implements Filter {
         if (config.isHeaderConditionsEnabled()) {
             Map<String, String> headers = requestContext.getHeaders();
             for (String name : headers.keySet()) {
+                // To avoid publishing user token to the traffic manager.
+                if (requestContext.getRemoveHeaders().contains(name)) {
+                    continue;
+                }
+                // Sending path header is stopped as it could contain query parameters which are used
+                // to secure APIs.
+                if (name.equals(":path")) {
+                    continue;
+                }
                 jsonObMap.put(name, headers.get(name));
             }
         }
@@ -401,6 +410,10 @@ public class ThrottleFilter implements Filter {
         if (config.isQueryConditionsEnabled()) {
             Map<String, String> params = requestContext.getQueryParameters();
             for (String name : params.keySet()) {
+                // To avoid publishing apiKey to the traffic manager.
+                if (requestContext.getQueryParamsToRemove().contains(name)) {
+                    continue;
+                }
                 jsonObMap.put(name, params.get(name));
             }
         }

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/throttle/ThrottleFilter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/throttle/ThrottleFilter.java
@@ -400,7 +400,7 @@ public class ThrottleFilter implements Filter {
                 }
                 // Sending path header is stopped as it could contain query parameters which are used
                 // to secure APIs.
-                if (name.equals(":path")) {
+                if (name.equals(APIConstants.PATH_HEADER)) {
                     continue;
                 }
                 jsonObMap.put(name, headers.get(name));


### PR DESCRIPTION
### Purpose
bug fix: 
1. Stop sending the apiKey to backend (as a header and as a queryParam)

2. Stop sending authentication token/ apikey value within the throttle event

With this fix, users may be able to remove, modify query parameters using custom filters as well.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2572 

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
