### PR TITLE
[Bug-Fix] userId based deny policies not working 

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/throttle/ThrottleFilter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/throttle/ThrottleFilter.java
@@ -132,7 +132,10 @@ public class ThrottleFilter implements Filter {
                 String appTenant = authContext.getSubscriberTenantDomain();
                 String clientIp = reqContext.getClientIp();
                 String apiTenantDomain = FilterUtils.getTenantDomainFromRequestURL(apiContext);
-                String authorizedUser = FilterUtils.buildUsernameWithTenant(authContext.getUsername(), appTenant);
+                // API Tenant Domain is required to be taken in order to support internal Key scenario.
+                // Using apiTenant is valid as the choreo connect does not work in multi-tenant mode.
+                String authorizedUser = FilterUtils.buildUsernameWithTenant(authContext.getUsername(),
+                        apiTenantDomain);
                 boolean isApiLevelTriggered = false;
 
                 if (!StringUtils.isEmpty(api.getTier())) {
@@ -290,7 +293,9 @@ public class ThrottleFilter implements Filter {
         String apiTier = getApiTier(api);
         String tenantDomain = FilterUtils.getTenantDomainFromRequestURL(apiContext);
         String appTenant = authContext.getSubscriberTenantDomain();
-        String authorizedUser = FilterUtils.buildUsernameWithTenant(authContext.getUsername(), appTenant);
+        // API Tenant Domain is required to be taken in order to support internal Key scenario.
+        // Using apiTenant is valid as the choreo connect does not work in multi-tenant mode.
+        String authorizedUser = FilterUtils.buildUsernameWithTenant(authContext.getUsername(), tenantDomain);
         String resourceTier;
         String resourceKey;
 


### PR DESCRIPTION
### Purpose

UserId based deny policies not working as it is not populated correctly, when the InternalKey credential is used. The reason was that when InternalKey is used, there is no appTenant.  Hence the userID is populated in some incorrect manner. To fix, we have used APITenant instead. This will not cause any issue because apiTenant and appTenant remains same when oauth2 token or apiKey is used as cross tenant support is not available in the choreo connect,


### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2578 

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
