### PR TITLE
Adapter side AsyncAPI impl and file processing refactored

### DIFF
--- a/adapter/go.mod
+++ b/adapter/go.mod
@@ -26,8 +26,9 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/streadway/amqp v1.0.0
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d
-	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e // indirect
+	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f
+	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
+	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20201201144952-b05cb90ed32e
 	google.golang.org/grpc v1.36.0
 	google.golang.org/protobuf v1.27.1

--- a/adapter/go.sum
+++ b/adapter/go.sum
@@ -398,6 +398,7 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -418,8 +419,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d h1:20cMwl2fHAzkJMEA+8J4JgqBQcQGzbisXo31MIeenXI=
-golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f h1:OfiFi4JbukWwe3lzw+xunroH1mnC1e2Gy5cxNJApiSY=
+golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -449,8 +450,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e h1:WUoyKPm6nCo1BnNUvPGnFG3T5DUVem42yDJZZ4CNxMA=
-golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -459,6 +460,8 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -479,6 +482,7 @@ golang.org/x/tools v0.0.0-20200522201501-cb1345f3a375/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200918232735-d647fc253266/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20210114065538-d78b04bdf963 h1:K+NlvTLy0oONtRtkl1jRD9xIhnItbG2PiE7YOdjPb+k=
 golang.org/x/tools v0.0.0-20210114065538-d78b04bdf963/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/adapter/internal/api/deployer/apis_eventhub.go
+++ b/adapter/internal/api/deployer/apis_eventhub.go
@@ -81,7 +81,7 @@ func ApplyAPIProjectFromAPIM(
 		loggers.LoggerAPI.Debugf("Update all environments (%v) of API %v %v:%v with UUID \"%v\".",
 			allEnvironments, vhost, apiYaml.Name, apiYaml.Version, apiYaml.ID)
 		// first update the API for vhost
-		deployedRevision, err := xds.UpdateAPI(vhost, apiProject, allEnvironments)
+		deployedRevision, err := xds.UpdateAPI(vhost, *apiProject, allEnvironments)
 		if err != nil {
 			return deployedRevisionList, fmt.Errorf("%v:%v with UUID \"%v\"", apiYaml.Name, apiYaml.Version, apiYaml.ID)
 		}

--- a/adapter/internal/api/deployer/apis_eventhub.go
+++ b/adapter/internal/api/deployer/apis_eventhub.go
@@ -1,0 +1,104 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package deployer
+
+import (
+	"fmt"
+
+	"github.com/wso2/product-microgateway/adapter/config"
+	"github.com/wso2/product-microgateway/adapter/pkg/synchronizer"
+
+	xds "github.com/wso2/product-microgateway/adapter/internal/discovery/xds"
+	"github.com/wso2/product-microgateway/adapter/internal/loggers"
+	"github.com/wso2/product-microgateway/adapter/internal/notifier"
+)
+
+// ApplyAPIProjectFromAPIM accepts an apictl project (as a byte array), list of vhosts with respective environments
+// and updates the xds servers based upon the content.
+func ApplyAPIProjectFromAPIM(
+	payload []byte,
+	vhostToEnvsMap map[string][]string,
+	apiEnvs map[string]map[string]synchronizer.APIEnvProps,
+) (deployedRevisionList []*notifier.DeployedAPIRevision, err error) {
+	apiProject, err := extractAPIProject(payload)
+	if err != nil {
+		return nil, err
+	}
+	apiYaml := apiProject.APIYaml.Data
+	if apiEnvProps, found := apiEnvs[apiProject.APIYaml.Data.ID]; found {
+		loggers.LoggerAPI.Infof("Environment specific values found for the API %v ", apiProject.APIYaml.Data.ID)
+		apiProject.APIEnvProps = apiEnvProps
+	}
+
+	// handle panic
+	defer func() {
+		if r := recover(); r != nil {
+			loggers.LoggerAPI.Error("Recovered from panic. ", r)
+			err = fmt.Errorf("%v:%v with UUID \"%v\"", apiYaml.Name, apiYaml.Version, apiYaml.ID)
+		}
+	}()
+
+	if apiProject.OrganizationID == "" {
+		apiProject.OrganizationID = config.GetControlPlaneConnectedTenantDomain()
+	}
+	loggers.LoggerAPI.Infof("Deploying api %s:%s in Organization %s", apiYaml.Name, apiYaml.Version, apiProject.OrganizationID)
+
+	// vhostsToRemove contains vhosts and environments to undeploy
+	vhostsToRemove := make(map[string][]string)
+
+	// TODO: (renuka) optimize to update cache only once when all internal memory maps are updated
+	for vhost, environments := range vhostToEnvsMap {
+		// search for vhosts in the given environments
+		for _, env := range environments {
+			if existingVhost, exists := xds.GetVhostOfAPI(apiYaml.ID, env); exists {
+				loggers.LoggerAPI.Infof("API %v:%v with UUID \"%v\" already deployed to vhost: %v",
+					apiYaml.Name, apiYaml.Version, apiYaml.ID, existingVhost)
+				if vhost != existingVhost {
+					loggers.LoggerAPI.Infof("Un-deploying API %v:%v with UUID \"%v\" which is already deployed to vhost: %v",
+						apiYaml.Name, apiYaml.Version, apiYaml.ID, existingVhost)
+					vhostsToRemove[existingVhost] = append(vhostsToRemove[existingVhost], env)
+				}
+			}
+		}
+
+		// allEnvironments represent all the environments the API should be deployed
+		allEnvironments := xds.GetAllEnvironments(apiYaml.ID, vhost, environments)
+		loggers.LoggerAPI.Debugf("Update all environments (%v) of API %v %v:%v with UUID \"%v\".",
+			allEnvironments, vhost, apiYaml.Name, apiYaml.Version, apiYaml.ID)
+		// first update the API for vhost
+		deployedRevision, err := xds.UpdateAPI(vhost, apiProject, allEnvironments)
+		if err != nil {
+			return deployedRevisionList, fmt.Errorf("%v:%v with UUID \"%v\"", apiYaml.Name, apiYaml.Version, apiYaml.ID)
+		}
+		if deployedRevision != nil {
+			deployedRevisionList = append(deployedRevisionList, deployedRevision)
+		}
+	}
+
+	// undeploy APIs with other vhosts in the same gateway environment
+	for vhost, environments := range vhostsToRemove {
+		if vhost == "" {
+			// ignore if vhost is empty, since it deletes all vhosts of API
+			continue
+		}
+		if err := xds.DeleteAPIsWithUUID(vhost, apiYaml.ID, environments, apiProject.OrganizationID); err != nil {
+			return deployedRevisionList, err
+		}
+	}
+	return deployedRevisionList, nil
+}

--- a/adapter/internal/api/deployer/apis_eventhub.go
+++ b/adapter/internal/api/deployer/apis_eventhub.go
@@ -53,10 +53,10 @@ func ApplyAPIProjectFromAPIM(
 		}
 	}()
 
-	if apiProject.OrganizationID == "" {
-		apiProject.OrganizationID = config.GetControlPlaneConnectedTenantDomain()
+	if apiYaml.OrganizationID == "" {
+		apiYaml.OrganizationID = config.GetControlPlaneConnectedTenantDomain()
 	}
-	loggers.LoggerAPI.Infof("Deploying api %s:%s in Organization %s", apiYaml.Name, apiYaml.Version, apiProject.OrganizationID)
+	loggers.LoggerAPI.Infof("Deploying api %s:%s in Organization %s", apiYaml.Name, apiYaml.Version, apiYaml.OrganizationID)
 
 	// vhostsToRemove contains vhosts and environments to undeploy
 	vhostsToRemove := make(map[string][]string)
@@ -96,7 +96,7 @@ func ApplyAPIProjectFromAPIM(
 			// ignore if vhost is empty, since it deletes all vhosts of API
 			continue
 		}
-		if err := xds.DeleteAPIsWithUUID(vhost, apiYaml.ID, environments, apiProject.OrganizationID); err != nil {
+		if err := xds.DeleteAPIsWithUUID(vhost, apiYaml.ID, environments, apiYaml.OrganizationID); err != nil {
 			return deployedRevisionList, err
 		}
 	}

--- a/adapter/internal/api/deployer/apis_process.go
+++ b/adapter/internal/api/deployer/apis_process.go
@@ -61,12 +61,15 @@ const (
 // extractAPIProject accepts the API project as a zip file and returns the extracted content.
 // The API project must be in zipped format.
 // API type is decided by the type field in the api.yaml file.
-func extractAPIProject(payload []byte) (apiProject model.ProjectAPI, err error) {
+func extractAPIProject(payload []byte) (*model.ProjectAPI, error) {
+	var apiProject model.ProjectAPI
+	apiProject.UpstreamCerts = make(map[string][]byte)
+	apiProject.EndpointCerts = make(map[string]string)
 	zipReader, err := zip.NewReader(bytes.NewReader(payload), int64(len(payload)))
 
 	if err != nil {
 		loggers.LoggerAPI.Errorf("Error occurred while unzipping the apictl project. Error: %v", err.Error())
-		return apiProject, err
+		return nil, err
 	}
 	// TODO: (VirajSalaka) this won't support for distributed openAPI definition
 	for _, file := range zipReader.File {
@@ -74,18 +77,18 @@ func extractAPIProject(payload []byte) (apiProject model.ProjectAPI, err error) 
 		unzippedFileBytes, err := readZipFile(file)
 		if err != nil {
 			loggers.LoggerAPI.Errorf("Error occurred while reading the file : %v %v", file.Name, err.Error())
-			return apiProject, err
+			return nil, err
 		}
-		apiProject, err = ProcessFilesInsideProject(unzippedFileBytes, file.Name)
+		err = ProcessFileInsideProject(&apiProject, unzippedFileBytes, file.Name)
 		if err != nil {
-			return apiProject, err
+			return nil, err
 		}
 	}
 	err = ValidateAPIType(&apiProject)
 	if err != nil {
-		return apiProject, err
+		return nil, err
 	}
-	return apiProject, nil
+	return &apiProject, nil
 }
 
 func readZipFile(zf *zip.File) ([]byte, error) {
@@ -97,12 +100,11 @@ func readZipFile(zf *zip.File) ([]byte, error) {
 	return ioutil.ReadAll(f)
 }
 
-// ProcessFilesInsideProject process single file inside API Project and update the apiProject instance appropriately.
-func ProcessFilesInsideProject(fileContent []byte, fileName string) (apiProject model.ProjectAPI, err error) {
-	apiProject.UpstreamCerts = make(map[string][]byte)
-	apiProject.EndpointCerts = make(map[string]string)
+// ProcessFileInsideProject method process one file at a time and
+// update the apiProject instance appropriately. Files could be: /petstore,
+// /petstore/Definition, /petstore/Definition/swagger.yaml, /petstore/api.yaml, etc.
+func ProcessFileInsideProject(apiProject *model.ProjectAPI, fileContent []byte, fileName string) error {
 	newLineByteArray := []byte("\n")
-
 	// Deployment file
 	if strings.Contains(fileName, deploymentsYAMLFile) {
 		loggers.LoggerAPI.Debug("Setting deployments of API")
@@ -121,7 +123,7 @@ func ProcessFilesInsideProject(fileContent []byte, fileName string) (apiProject 
 		swaggerJsn, conversionErr := utills.ToJSON(fileContent)
 		if conversionErr != nil {
 			loggers.LoggerAPI.Errorf("Error converting api file to json: %v", conversionErr.Error())
-			return apiProject, conversionErr
+			return conversionErr
 		}
 		apiProject.APIDefinition = swaggerJsn
 
@@ -131,7 +133,7 @@ func ProcessFilesInsideProject(fileContent []byte, fileName string) (apiProject 
 
 		if !tlsutils.IsPublicCertificate(fileContent) {
 			loggers.LoggerAPI.Errorf("Provided interceptor certificate: %v is not in the PEM file format. ", fileName)
-			return apiProject, errors.New("interceptor certificate Validation Error")
+			return errors.New("interceptor certificate Validation Error")
 		}
 		apiProject.InterceptorCerts = append(apiProject.InterceptorCerts, fileContent...)
 		apiProject.InterceptorCerts = append(apiProject.InterceptorCerts, newLineByteArray...)
@@ -143,7 +145,7 @@ func ProcessFilesInsideProject(fileContent []byte, fileName string) (apiProject 
 			epCertJSON, conversionErr := utills.ToJSON(fileContent)
 			if conversionErr != nil {
 				loggers.LoggerAPI.Errorf("Error converting %v file to json: %v", fileName, conversionErr.Error())
-				return apiProject, conversionErr
+				return conversionErr
 			}
 			endpointCertificates := &model.EndpointCertificatesDetails{}
 			err := json.Unmarshal(epCertJSON, endpointCertificates)
@@ -158,7 +160,7 @@ func ProcessFilesInsideProject(fileContent []byte, fileName string) (apiProject 
 			if !tlsutils.IsPublicCertificate(fileContent) {
 				loggers.LoggerAPI.Errorf("Provided certificate: %v is not in the PEM file format. ", fileName)
 				// TODO: (VirajSalaka) Create standard error handling mechanism
-				return apiProject, errors.New("certificate Validation Error")
+				return errors.New("certificate Validation Error")
 			}
 
 			if fileNameArray := strings.Split(fileName, string(os.PathSeparator)); len(fileNameArray) > 0 {
@@ -170,15 +172,14 @@ func ProcessFilesInsideProject(fileContent []byte, fileName string) (apiProject 
 		// api.yaml or api.json
 	} else if (strings.Contains(fileName, apiYAMLFile) || strings.Contains(fileName, apiJSONFile)) &&
 		!strings.Contains(fileName, openAPIDir) {
-
 		apiYaml, err := ExtractAPIYaml(fileContent)
 		if err != nil {
 			loggers.LoggerAPI.Errorf("Error while reading %v", fileName)
-			return apiProject, errors.New("Error while reading api.yaml or api.json")
+			return errors.New("Error while reading api.yaml or api.json")
 		}
 		apiProject.APIYaml = apiYaml
 	}
-	return apiProject, nil
+	return nil
 }
 
 // ExtractAPIYaml returns an APIYaml struct after reading and validating api.yaml or api.json
@@ -244,7 +245,7 @@ func parseDeployments(data []byte) ([]model.Deployment, error) {
 
 // ValidateAPIType checks if the apiProject is properly assigned with the type.
 func ValidateAPIType(apiProject *model.ProjectAPI) (err error) {
-	apiType := strings.ToUpper(apiProject.APIYaml.Type)
+	apiType := strings.ToUpper(apiProject.APIYaml.Data.APIType)
 	if apiType == "" {
 		// If no api.yaml file is included in the zip folder, return with error.
 		err = errors.New("could not find api.yaml or api.json")

--- a/adapter/internal/api/deployer/apis_standalone.go
+++ b/adapter/internal/api/deployer/apis_standalone.go
@@ -106,7 +106,7 @@ func ProcessMountedAPIProjects() error {
 
 func validateAndUpdateXds(apiProject model.ProjectAPI, override *bool) (err error) {
 	apiYaml := apiProject.APIYaml.Data
-	apiProject.OrganizationID = config.GetControlPlaneConnectedTenantDomain()
+	organizationID := config.GetControlPlaneConnectedTenantDomain()
 
 	// handle panic
 	defer func() {
@@ -140,7 +140,7 @@ func validateAndUpdateXds(apiProject model.ProjectAPI, override *bool) (err erro
 		// if the API already exists in the one of vhost, break deployment of the API
 		exists := false
 		for _, deployment := range apiProject.Deployments {
-			if xds.IsAPIExist(deployment.DeploymentVhost, apiYaml.ID, apiProject.OrganizationID) {
+			if xds.IsAPIExist(deployment.DeploymentVhost, apiYaml.ID, organizationID) {
 				exists = true
 				break
 			}

--- a/adapter/internal/api/deployer/apis_standalone.go
+++ b/adapter/internal/api/deployer/apis_standalone.go
@@ -54,6 +54,8 @@ func ProcessMountedAPIProjects() error {
 	for _, apiProjectFile := range files {
 		if apiProjectFile.IsDir() {
 			var apiProject model.ProjectAPI
+			apiProject.UpstreamCerts = make(map[string][]byte)
+			apiProject.EndpointCerts = make(map[string]string)
 			err = filepath.Walk(filepath.FromSlash(apisDirName+"/"+apiProjectFile.Name()), func(path string, info os.FileInfo, err error) error {
 
 				if !info.IsDir() {
@@ -61,7 +63,7 @@ func ProcessMountedAPIProjects() error {
 					if err != nil {
 						return err
 					}
-					apiProject, err = ProcessFilesInsideProject(fileContent, path)
+					err = ProcessFileInsideProject(&apiProject, fileContent, path)
 					return err
 				}
 				return nil
@@ -172,10 +174,11 @@ func validateAndUpdateXds(apiProject model.ProjectAPI, override *bool) (err erro
 // between create and update using the override param
 func ApplyAPIProjectInStandaloneMode(payload []byte, override *bool) (err error) {
 	apiProject, err := extractAPIProject(payload)
+
 	if err != nil {
 		return err
 	}
-	return validateAndUpdateXds(apiProject, override)
+	return validateAndUpdateXds(*apiProject, override)
 }
 
 // ListApis calls the ListApis method in xds_server.go

--- a/adapter/internal/api/restserver/config_restapi.go
+++ b/adapter/internal/api/restserver/config_restapi.go
@@ -35,7 +35,7 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 
 	"github.com/wso2/product-microgateway/adapter/config"
-	apiServer "github.com/wso2/product-microgateway/adapter/internal/api"
+	"github.com/wso2/product-microgateway/adapter/internal/api/deployer"
 	"github.com/wso2/product-microgateway/adapter/internal/api/models"
 	"github.com/wso2/product-microgateway/adapter/internal/api/restserver/operations"
 	"github.com/wso2/product-microgateway/adapter/internal/api/restserver/operations/api_collection"
@@ -145,12 +145,12 @@ func configureAPI(api *operations.RestapiAPI) http.Handler {
 	api.APICollectionGetApisHandler = api_collection.GetApisHandlerFunc(func(
 		params api_collection.GetApisParams, principal *models.Principal) middleware.Responder {
 
-		return api_collection.NewGetApisOK().WithPayload(apiServer.ListApis(params.Query, params.Limit, tenantDomain))
+		return api_collection.NewGetApisOK().WithPayload(deployer.ListApis(params.Query, params.Limit, tenantDomain))
 	})
 	api.APIIndividualPostApisHandler = api_individual.PostApisHandlerFunc(func(
 		params api_individual.PostApisParams, principal *models.Principal) middleware.Responder {
 		jsonByteArray, _ := ioutil.ReadAll(params.File)
-		err := apiServer.ApplyAPIProjectInStandaloneMode(jsonByteArray, params.Override)
+		err := deployer.ApplyAPIProjectInStandaloneMode(jsonByteArray, params.Override)
 		if err != nil {
 			if err.Error() == constants.AlreadyExists {
 				return api_individual.NewPostApisConflict()

--- a/adapter/internal/api/restserver/config_restapi.go
+++ b/adapter/internal/api/restserver/config_restapi.go
@@ -152,6 +152,7 @@ func configureAPI(api *operations.RestapiAPI) http.Handler {
 		jsonByteArray, _ := ioutil.ReadAll(params.File)
 		err := deployer.ApplyAPIProjectInStandaloneMode(jsonByteArray, params.Override)
 		if err != nil {
+			logger.LoggerAPI.Error("Error while deploying API: ", err.Error())
 			if err.Error() == constants.AlreadyExists {
 				return api_individual.NewPostApisConflict()
 			} else if strings.HasPrefix(err.Error(), "An API exists with the same basepath") {

--- a/adapter/internal/api/restserver/config_restapi.go
+++ b/adapter/internal/api/restserver/config_restapi.go
@@ -43,7 +43,7 @@ import (
 	"github.com/wso2/product-microgateway/adapter/internal/api/restserver/operations/authorization"
 	"github.com/wso2/product-microgateway/adapter/internal/auth"
 	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
-	constants "github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 	"github.com/wso2/product-microgateway/adapter/pkg/health"
 	"github.com/wso2/product-microgateway/adapter/pkg/tlsutils"
 )

--- a/adapter/internal/discovery/xds/server.go
+++ b/adapter/internal/discovery/xds/server.go
@@ -282,6 +282,9 @@ func UpdateAPI(vHost string, apiProject model.ProjectAPI, environments []string)
 	if apiType == constants.HTTP || apiType == constants.WS || apiType == constants.WEBHOOK || apiType == constants.SSE {
 
 		err = mgwSwagger.GetMgwSwagger(apiProject.APIDefinition)
+		mgwSwagger.SetID(apiYaml.ID)
+		mgwSwagger.SetName(apiYaml.Name)
+		mgwSwagger.SetVersion(apiYaml.Version)
 		if err != nil {
 			return nil, err
 		}
@@ -302,7 +305,8 @@ func UpdateAPI(vHost string, apiProject model.ProjectAPI, environments []string)
 		mgwSwagger.SetXWso2AuthHeader(apiYaml.AuthorizationHeader)
 	} else {
 		// Unreachable else condition. Added in case previous apiType check fails due to any modifications.
-		logger.LoggerXds.Error("API type not currently supported by Choreo Connect")
+		errMsg := fmt.Sprintf("API type %v currently supported by Choreo Connect", apiType)
+		return nil, errors.New(errMsg)
 	}
 	mgwSwagger.SetEnvLabelProperties(apiEnvProps)
 	organizationID := mgwSwagger.OrganizationID

--- a/adapter/internal/discovery/xds/server.go
+++ b/adapter/internal/discovery/xds/server.go
@@ -34,23 +34,24 @@ import (
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	envoy_cachev3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
-	"github.com/wso2/product-microgateway/adapter/config"
-	apiModel "github.com/wso2/product-microgateway/adapter/internal/api/models"
-	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
-	"github.com/wso2/product-microgateway/adapter/internal/notifier"
-	oasParser "github.com/wso2/product-microgateway/adapter/internal/oasparser"
-	envoyconf "github.com/wso2/product-microgateway/adapter/internal/oasparser/envoyconf"
-	"github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
-	mgw "github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
-	"github.com/wso2/product-microgateway/adapter/internal/svcdiscovery"
+
 	subscription "github.com/wso2/product-microgateway/adapter/pkg/discovery/api/wso2/discovery/subscription"
 	throttle "github.com/wso2/product-microgateway/adapter/pkg/discovery/api/wso2/discovery/throttle"
 	wso2_cache "github.com/wso2/product-microgateway/adapter/pkg/discovery/protocol/cache/v3"
 	wso2_resource "github.com/wso2/product-microgateway/adapter/pkg/discovery/protocol/resource/v3"
 	eventhubTypes "github.com/wso2/product-microgateway/adapter/pkg/eventhub/types"
 	"github.com/wso2/product-microgateway/adapter/pkg/synchronizer"
+
+	"github.com/wso2/product-microgateway/adapter/config"
+	apiModel "github.com/wso2/product-microgateway/adapter/internal/api/models"
+	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
+	"github.com/wso2/product-microgateway/adapter/internal/notifier"
+	oasParser "github.com/wso2/product-microgateway/adapter/internal/oasparser"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/envoyconf"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
+	"github.com/wso2/product-microgateway/adapter/internal/svcdiscovery"
 )
 
 var (
@@ -78,7 +79,7 @@ var (
 	apiUUIDToGatewayToVhosts map[string]map[string]string   // API_UUID -> gateway-env -> vhost (for un-deploying APIs from APIM or Choreo)
 	apiToVhostsMap           map[string]map[string]struct{} // API_UUID -> VHosts set (for un-deploying APIs from API-CTL)
 
-	orgIDAPIMgwSwaggerMap       map[string]map[string]mgw.MgwSwagger       // organizationID -> Vhost:API_UUID -> MgwSwagger struct map
+	orgIDAPIMgwSwaggerMap       map[string]map[string]model.MgwSwagger     // organizationID -> Vhost:API_UUID -> MgwSwagger struct map
 	orgIDOpenAPIEnvoyMap        map[string]map[string][]string             // organizationID -> Vhost:API_UUID -> Envoy Label Array map
 	orgIDOpenAPIRoutesMap       map[string]map[string][]*routev3.Route     // organizationID -> Vhost:API_UUID -> Envoy Routes map
 	orgIDOpenAPIClustersMap     map[string]map[string][]*clusterv3.Cluster // organizationID -> Vhost:API_UUID -> Envoy Clusters map
@@ -156,7 +157,7 @@ func init() {
 	envoyClusterConfigMap = make(map[string][]*clusterv3.Cluster)
 	envoyEndpointConfigMap = make(map[string][]*corev3.Address)
 
-	orgIDAPIMgwSwaggerMap = make(map[string]map[string]mgw.MgwSwagger)         // organizationID -> Vhost:API_UUID -> MgwSwagger struct map
+	orgIDAPIMgwSwaggerMap = make(map[string]map[string]model.MgwSwagger)       // organizationID -> Vhost:API_UUID -> MgwSwagger struct map
 	orgIDOpenAPIEnvoyMap = make(map[string]map[string][]string)                // organizationID -> Vhost:API_UUID -> Envoy Label Array map
 	orgIDOpenAPIRoutesMap = make(map[string]map[string][]*routev3.Route)       // organizationID -> Vhost:API_UUID -> Envoy Routes map
 	orgIDOpenAPIClustersMap = make(map[string]map[string][]*clusterv3.Cluster) // organizationID -> Vhost:API_UUID -> Envoy Clusters map
@@ -247,8 +248,8 @@ func DeployReadinessAPI(envs []string) {
 }
 
 // UpdateAPI updates the Xds Cache when OpenAPI Json content is provided
-func UpdateAPI(vHost string, apiProject mgw.ProjectAPI, environments []string) (*notifier.DeployedAPIRevision, error) {
-	var mgwSwagger mgw.MgwSwagger
+func UpdateAPI(vHost string, apiProject model.ProjectAPI, environments []string) (*notifier.DeployedAPIRevision, error) {
+	var mgwSwagger model.MgwSwagger
 	var deployedRevision *notifier.DeployedAPIRevision
 	var err error
 	var newLabels []string
@@ -277,7 +278,7 @@ func UpdateAPI(vHost string, apiProject mgw.ProjectAPI, environments []string) (
 		return nil, err
 	}
 
-	if apiProject.APIType == mgw.HTTP || apiProject.APIType == mgw.WEBHOOK {
+	if apiProject.APIType == constants.HTTP || apiProject.APIType == constants.WEBHOOK {
 		err = mgwSwagger.GetMgwSwagger(apiProject.OpenAPIJsn)
 		if err != nil {
 			return nil, err
@@ -287,17 +288,17 @@ func UpdateAPI(vHost string, apiProject mgw.ProjectAPI, environments []string) (
 		isYamlAPIKey := false
 		isYamlOauth := false
 		for _, value := range apiYaml.SecurityScheme {
-			if value == model.APIMAPIKeyType {
+			if value == constants.APIMAPIKeyType {
 				logger.LoggerXds.Debugf("API key is enabled in api.yaml for API %v:%v", apiYaml.Name, apiYaml.Version)
 				isYamlAPIKey = true
-			} else if value == model.APIMOauth2Type {
+			} else if value == constants.APIMOauth2Type {
 				logger.LoggerXds.Debugf("Oauth2 is enabled in api.yaml for API %v:%v", apiYaml.Name, apiYaml.Version)
 				isYamlOauth = true
 			}
 		}
 		mgwSwagger.SanitizeAPISecurity(isYamlAPIKey, isYamlOauth)
 		mgwSwagger.SetXWso2AuthHeader(apiYaml.AuthorizationHeader)
-	} else if apiProject.APIType != mgw.WS {
+	} else if apiProject.APIType != constants.WS {
 		// Unreachable else condition. Added in case previous apiType check fails due to any modifications.
 		logger.LoggerXds.Error("API type not currently supported by Choreo Connect")
 	}
@@ -357,7 +358,7 @@ func UpdateAPI(vHost string, apiProject mgw.ProjectAPI, environments []string) (
 	if _, ok := orgIDAPIMgwSwaggerMap[organizationID]; ok {
 		orgIDAPIMgwSwaggerMap[organizationID][apiIdentifier] = mgwSwagger
 	} else {
-		mgwSwaggerMap := make(map[string]mgw.MgwSwagger)
+		mgwSwaggerMap := make(map[string]model.MgwSwagger)
 		mgwSwaggerMap[apiIdentifier] = mgwSwagger
 		orgIDAPIMgwSwaggerMap[organizationID] = mgwSwaggerMap
 	}
@@ -478,7 +479,7 @@ func GetVhostOfAPI(apiUUID, environment string) (vhost string, exists bool) {
 	return "", false
 }
 
-func addBasepathToMap(mgwSwagger mgw.MgwSwagger, organizationID, vHost, apiIdentifier string) error {
+func addBasepathToMap(mgwSwagger model.MgwSwagger, organizationID, vHost, apiIdentifier string) error {
 	newBasepath := mgwSwagger.GetXWso2Basepath()
 
 	// Check if the basepath exists
@@ -521,7 +522,7 @@ func DeleteAPIs(vhost, apiName, version string, environments []string, organizat
 	vhosts, found := apiToVhostsMap[apiNameVersionHashedID]
 	if !found {
 		logger.LoggerXds.Infof("Unable to delete API %v from Organization %v. API does not exist.", apiNameVersionID, organizationID)
-		return errors.New(mgw.NotFound)
+		return errors.New(constants.NotFound)
 	}
 
 	if vhost == "" {
@@ -585,7 +586,7 @@ func DeleteAPIsWithUUID(vhost, uuid string, environments []string, organizationI
 	vhosts, found := apiToVhostsMap[uuid]
 	if !found {
 		logger.LoggerXds.Infof("Unable to delete API with UUID %v from Organization %v. API does not exist.", uuid, organizationID)
-		return errors.New(mgw.NotFound)
+		return errors.New(constants.NotFound)
 	}
 
 	if vhost == "" {
@@ -667,7 +668,7 @@ func deleteAPI(apiIdentifier string, environments []string, organizationID strin
 	_, exists := orgIDAPIMgwSwaggerMap[organizationID][apiIdentifier]
 	if !exists {
 		logger.LoggerXds.Infof("Unable to delete API: %v from Organization: %v. API Does not exist.", apiIdentifier, organizationID)
-		return errors.New(mgw.NotFound)
+		return errors.New(constants.NotFound)
 	}
 
 	existingLabels := orgIDOpenAPIEnvoyMap[organizationID][apiIdentifier]

--- a/adapter/internal/oasparser/constants/constants.go
+++ b/adapter/internal/oasparser/constants/constants.go
@@ -17,7 +17,7 @@
 
 package constants
 
-// sub-property keys mentioned under x-wso2-production-endpoints
+// sub-property keys and values mentioned in API definitions
 const (
 	Urls                  string = "urls"
 	Type                  string = "type"
@@ -25,6 +25,15 @@ const (
 	FailOver              string = "failover"
 	AdvanceEndpointConfig string = "advanceEndpointConfig"
 	SecurityConfig        string = "securityConfig"
+	None                  string = "None"
+	DefaultSecurity       string = "default"
+
+	HTTP    string = "HTTP"
+	WS      string = "WS"
+	WEBHOOK string = "WEBHOOK"
+	SSE     string = "SSE"
+
+	InlineEndpointType string = "INLINE"
 )
 
 // Constants for OpenAPI vendor extension keys
@@ -40,8 +49,6 @@ const (
 	XAuthHeader          string = "x-wso2-auth-header"
 	XAuthType            string = "x-auth-type"
 	XWso2DisableSecurity string = "x-wso2-disable-security"
-	None                 string = "None"
-	DefaultSecurity      string = "default"
 )
 
 // cluster name prefixes
@@ -72,15 +79,20 @@ const (
 	Includes       string = "includes"
 )
 
-// API type constants
-const (
-	HTTP    string = "HTTP"
-	WS      string = "WS"
-	WEBHOOK string = "WEBHOOK"
-)
-
 // Constants to represent errors
 const (
 	AlreadyExists string = "ALREADY_EXISTS"
 	NotFound      string = "NOT_FOUND"
+)
+
+// Constants used for version identification of API definitions
+const (
+	Swagger       string = "swagger"
+	OpenAPI       string = "openapi"
+	AsyncAPI      string = "asyncapi"
+	Swagger2      string = "swagger_2"
+	OpenAPI3      string = "openapi_3"
+	AsyncAPI2_0_0 string = "asyncapi_2.0.0"
+	NotDefined    string = "not_defined"
+	NotSupported  string = "not_supported"
 )

--- a/adapter/internal/oasparser/constants/constants.go
+++ b/adapter/internal/oasparser/constants/constants.go
@@ -15,12 +15,12 @@
  *
  */
 
-package model
+package constants
 
 // sub-property keys mentioned under x-wso2-production-endpoints
 const (
-	urls                  string = "urls"
-	typeConst             string = "type"
+	Urls                  string = "urls"
+	Type                  string = "type"
 	LoadBalance           string = "loadbalance"
 	FailOver              string = "failover"
 	AdvanceEndpointConfig string = "advanceEndpointConfig"
@@ -29,26 +29,26 @@ const (
 
 // Constants for OpenAPI vendor extension keys
 const (
-	xWso2ProdEndpoints   string = "x-wso2-production-endpoints"
-	xWso2SandbxEndpoints string = "x-wso2-sandbox-endpoints"
-	xWso2endpoints       string = "x-wso2-endpoints"
-	xWso2BasePath        string = "x-wso2-basePath"
-	xWso2Label           string = "x-wso2-label"
-	xWso2Cors            string = "x-wso2-cors"
-	xThrottlingTier      string = "x-throttling-tier"
-	xWso2ThrottlingTier  string = "x-wso2-throttling-tier"
-	xAuthHeader          string = "x-wso2-auth-header"
-	xAuthType            string = "x-auth-type"
-	xWso2DisableSecurity string = "x-wso2-disable-security"
+	XWso2ProdEndpoints   string = "x-wso2-production-endpoints"
+	XWso2SandbxEndpoints string = "x-wso2-sandbox-endpoints"
+	XWso2endpoints       string = "x-wso2-endpoints"
+	XWso2BasePath        string = "x-wso2-basePath"
+	XWso2Label           string = "x-wso2-label"
+	XWso2Cors            string = "x-wso2-cors"
+	XThrottlingTier      string = "x-throttling-tier"
+	XWso2ThrottlingTier  string = "x-wso2-throttling-tier"
+	XAuthHeader          string = "x-wso2-auth-header"
+	XAuthType            string = "x-auth-type"
+	XWso2DisableSecurity string = "x-wso2-disable-security"
 	None                 string = "None"
 	DefaultSecurity      string = "default"
 )
 
 // cluster name prefixes
 const (
-	sandClustersConfigNamePrefix    string = "clusterSand"
-	prodClustersConfigNamePrefix    string = "clusterProd"
-	xWso2EPClustersConfigNamePrefix string = "xwso2cluster"
+	SandClustersConfigNamePrefix    string = "clusterSand"
+	ProdClustersConfigNamePrefix    string = "clusterProd"
+	XWso2EPClustersConfigNamePrefix string = "xwso2cluster"
 )
 
 // sub-property values and keys relevant for x-wso2-application security extension
@@ -66,18 +66,16 @@ const (
 
 // sub-property keys mentioned under x-wso2-request-interceptor and x-wso2-response-interceptor
 const (
-	serviceURL     string = "serviceURL"
-	clusterTimeout string = "clusterTimeout"
-	requestTimeout string = "requestTimeout"
-	includes       string = "includes"
+	ServiceURL     string = "serviceURL"
+	ClusterTimeout string = "clusterTimeout"
+	RequestTimeout string = "requestTimeout"
+	Includes       string = "includes"
 )
 
+// API type constants
 const (
-	// HTTP - API type for http/https APIs
-	HTTP string = "HTTP"
-	// WS - API type for websocket APIs
-	WS string = "WS"
-	// WEBHOOK - API type for WEBHOOK APIs
+	HTTP    string = "HTTP"
+	WS      string = "WS"
 	WEBHOOK string = "WEBHOOK"
 )
 

--- a/adapter/internal/oasparser/constants/constants.go
+++ b/adapter/internal/oasparser/constants/constants.go
@@ -21,7 +21,7 @@ package constants
 const (
 	Urls                  string = "urls"
 	Type                  string = "type"
-	LoadBalance           string = "loadbalance"
+	LoadBalance           string = "load_balance"
 	FailOver              string = "failover"
 	AdvanceEndpointConfig string = "advanceEndpointConfig"
 	SecurityConfig        string = "securityConfig"

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -39,6 +39,7 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/wso2/product-microgateway/adapter/config"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -304,7 +305,7 @@ func CreateRoutesWithClusters(mgwSwagger model.MgwSwagger, upstreamCerts map[str
 			clusterNameSand, resourceRequestInterceptor, resourceResponseInterceptor, organizationID))
 		routes = append(routes, routeP)
 	}
-	if mgwSwagger.GetAPIType() == model.WS {
+	if mgwSwagger.GetAPIType() == constants.WS {
 		routesP := createRoute(genRouteCreateParams(&mgwSwagger, nil, vHost, apiLevelbasePath, apiLevelClusterNameProd,
 			apiLevelClusterNameSand, apiRequestInterceptor, apiResponseInterceptor, organizationID))
 		routes = append(routes, routesP)
@@ -1110,7 +1111,7 @@ func generateRegex(fullpath string) string {
 
 func getUpgradeConfig(apiType string) []*routev3.RouteAction_UpgradeConfig {
 	var upgradeConfig []*routev3.RouteAction_UpgradeConfig
-	if apiType == model.WS {
+	if apiType == constants.WS {
 		upgradeConfig = []*routev3.RouteAction_UpgradeConfig{{
 			UpgradeType: "websocket",
 			Enabled:     &wrappers.BoolValue{Value: true},
@@ -1221,7 +1222,7 @@ func createAddress(remoteHost string, port uint32) *corev3.Address {
 // getMaxStreamDuration configures a maximum duration for a websocket route.
 func getMaxStreamDuration(apiType string) *routev3.RouteAction_MaxStreamDuration {
 	var maxStreamDuration *routev3.RouteAction_MaxStreamDuration = nil
-	if apiType == model.WS {
+	if apiType == constants.WS {
 		maxStreamDuration = &routev3.RouteAction_MaxStreamDuration{
 			MaxStreamDuration: &durationpb.Duration{
 				Seconds: 60 * 60 * 24,
@@ -1233,7 +1234,7 @@ func getMaxStreamDuration(apiType string) *routev3.RouteAction_MaxStreamDuration
 
 func getDefaultResourceMethods(apiType string) []string {
 	var defaultResourceMethods []string = nil
-	if apiType == model.WS {
+	if apiType == constants.WS {
 		defaultResourceMethods = []string{"GET"}
 	}
 	return defaultResourceMethods

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/utills"
 	"github.com/wso2/product-microgateway/adapter/pkg/synchronizer"
@@ -247,10 +248,10 @@ func testCreateRoutesWithClustersWebsocket(t *testing.T, apiYamlFilePath string)
 
 	var apiYaml model.APIYaml
 	err = json.Unmarshal(apiJsn, &apiYaml)
-	apiYaml = model.PopulateEndpointsInfo(apiYaml)
+	apiYaml.PopulateEndpointsInfo()
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	routes, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
 
@@ -332,10 +333,10 @@ func testCreateRoutesWithClustersWebsocketWithEnvProps(t *testing.T, apiYamlFile
 
 	var apiYaml model.APIYaml
 	err = json.Unmarshal(apiJsn, &apiYaml)
-	apiYaml = model.PopulateEndpointsInfo(apiYaml)
+	apiYaml.PopulateEndpointsInfo()
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
 	mgwSwagger.SetEnvLabelProperties(envProps)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	routes, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
@@ -456,10 +457,10 @@ func TestCreateRoutesWithClusters(t *testing.T) {
 
 	var apiYaml model.APIYaml
 	err = json.Unmarshal(apiJsn, &apiYaml)
-	apiYaml = model.PopulateEndpointsInfo(apiYaml)
+	apiYaml.PopulateEndpointsInfo()
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	routes, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
 	assert.NotNil(t, routes, "CreateRoutesWithClusters failed: returned routes nil")
@@ -486,10 +487,10 @@ func commonTestForClusterPrioritiesInWebSocketAPI(t *testing.T, apiYamlFilePath 
 
 	var apiYaml model.APIYaml
 	err = json.Unmarshal(apiJsn, &apiYaml)
-	apiYaml = model.PopulateEndpointsInfo(apiYaml)
+	apiYaml.PopulateEndpointsInfo()
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	_, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
 
@@ -553,10 +554,10 @@ func commonTestForClusterPrioritiesInWebSocketAPIWithEnvProps(t *testing.T, apiY
 
 	var apiYaml model.APIYaml
 	err = json.Unmarshal(apiJsn, &apiYaml)
-	apiYaml = model.PopulateEndpointsInfo(apiYaml)
+	apiYaml.PopulateEndpointsInfo()
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
 	mgwSwagger.SetEnvLabelProperties(envProps)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	_, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
@@ -17,14 +17,12 @@
 package envoyconf_test
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"strings"
 	"testing"
 
-	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
+	"github.com/wso2/product-microgateway/adapter/internal/api/deployer"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
-	"github.com/wso2/product-microgateway/adapter/internal/oasparser/utills"
 	"github.com/wso2/product-microgateway/adapter/pkg/synchronizer"
 
 	"github.com/stretchr/testify/assert"
@@ -243,15 +241,11 @@ func TestCreateRoutesWithClustersForEndpointRef(t *testing.T) {
 func testCreateRoutesWithClustersWebsocket(t *testing.T, apiYamlFilePath string) {
 	apiYamlByteArr, err := ioutil.ReadFile(apiYamlFilePath)
 	assert.Nil(t, err, "Error while reading the api.yaml file : %v"+apiYamlFilePath)
-	apiJsn, conversionErr := utills.ToJSON(apiYamlByteArr)
-	assert.Nil(t, conversionErr, "YAML to JSON conversion error : %v"+apiYamlFilePath)
 
-	var apiYaml model.APIYaml
-	err = json.Unmarshal(apiJsn, &apiYaml)
-	apiYaml.PopulateEndpointsInfo()
-	assert.Nil(t, err, "Error occured while parsing api.yaml")
+	apiYaml, err := deployer.ExtractAPIYaml(apiYamlByteArr)
+	assert.Nil(t, err, "Error occurred while processing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	routes, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
 
@@ -328,15 +322,10 @@ func testCreateRoutesWithClustersWebsocketWithEnvProps(t *testing.T, apiYamlFile
 
 	apiYamlByteArr, err := ioutil.ReadFile(apiYamlFilePath)
 	assert.Nil(t, err, "Error while reading the api.yaml file : %v", apiYamlFilePath)
-	apiJsn, conversionErr := utills.ToJSON(apiYamlByteArr)
-	assert.Nil(t, conversionErr, "YAML to JSON conversion error : %v", apiYamlFilePath)
-
-	var apiYaml model.APIYaml
-	err = json.Unmarshal(apiJsn, &apiYaml)
-	apiYaml.PopulateEndpointsInfo()
-	assert.Nil(t, err, "Error occured while parsing api.yaml")
+	apiYaml, err := deployer.ExtractAPIYaml(apiYamlByteArr)
+	assert.Nil(t, err, "Error occurred while parsing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml)
 	mgwSwagger.SetEnvLabelProperties(envProps)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	routes, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
@@ -452,15 +441,10 @@ func TestCreateRoutesWithClusters(t *testing.T) {
 	apiYamlFilePath := config.GetMgwHome() + "/../adapter/test-resources/envoycodegen/api.yaml"
 	apiYamlByteArr, err := ioutil.ReadFile(apiYamlFilePath)
 	assert.Nil(t, err, "Error while reading the api.yaml file : %v"+apiYamlFilePath)
-	apiJsn, conversionErr := utills.ToJSON(apiYamlByteArr)
-	assert.Nil(t, conversionErr, "YAML to JSON conversion error : %v"+apiYamlFilePath)
-
-	var apiYaml model.APIYaml
-	err = json.Unmarshal(apiJsn, &apiYaml)
-	apiYaml.PopulateEndpointsInfo()
-	assert.Nil(t, err, "Error occured while parsing api.yaml")
+	apiYaml, err := deployer.ExtractAPIYaml(apiYamlByteArr)
+	assert.Nil(t, err, "Error occurred while processing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	routes, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
 	assert.NotNil(t, routes, "CreateRoutesWithClusters failed: returned routes nil")
@@ -482,15 +466,10 @@ func TestFailoverCluster(t *testing.T) {
 func commonTestForClusterPrioritiesInWebSocketAPI(t *testing.T, apiYamlFilePath string) {
 	apiYamlByteArr, err := ioutil.ReadFile(apiYamlFilePath)
 	assert.Nil(t, err, "Error while reading the api.yaml file : %v"+apiYamlFilePath)
-	apiJsn, conversionErr := utills.ToJSON(apiYamlByteArr)
-	assert.Nil(t, conversionErr, "YAML to JSON conversion error : %v"+apiYamlFilePath)
-
-	var apiYaml model.APIYaml
-	err = json.Unmarshal(apiJsn, &apiYaml)
-	apiYaml.PopulateEndpointsInfo()
-	assert.Nil(t, err, "Error occured while parsing api.yaml")
+	apiYaml, err := deployer.ExtractAPIYaml(apiYamlByteArr)
+	assert.Nil(t, err, "Error occurred while processing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	_, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
 
@@ -549,15 +528,10 @@ func commonTestForClusterPrioritiesInWebSocketAPIWithEnvProps(t *testing.T, apiY
 
 	apiYamlByteArr, err := ioutil.ReadFile(apiYamlFilePath)
 	assert.Nil(t, err, "Error while reading the api.yaml file : %v", apiYamlFilePath)
-	apiJsn, conversionErr := utills.ToJSON(apiYamlByteArr)
-	assert.Nil(t, conversionErr, "YAML to JSON conversion error : %v", apiYamlFilePath)
-
-	var apiYaml model.APIYaml
-	err = json.Unmarshal(apiJsn, &apiYaml)
-	apiYaml.PopulateEndpointsInfo()
-	assert.Nil(t, err, "Error occured while parsing api.yaml")
+	apiYaml, err := deployer.ExtractAPIYaml(apiYamlByteArr)
+	assert.Nil(t, err, "Error occurred while processing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml)
 	mgwSwagger.SetEnvLabelProperties(envProps)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	_, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")

--- a/adapter/internal/oasparser/model/api_env.go
+++ b/adapter/internal/oasparser/model/api_env.go
@@ -35,7 +35,7 @@ func retrieveEndpointsFromEnv(apiHashValue string) ([]Endpoint, []Endpoint) {
 			break
 		}
 
-		productionEndpoint, err := getHostandBasepathandPort(productionEndpointURL)
+		productionEndpoint, err := getHTTPEndpoint(productionEndpointURL)
 		if err != nil {
 			loggers.LoggerAPI.Errorf("error while reading production endpoint : %v in env variables, %v", productionEndpointURL, err.Error())
 		} else if productionEndpoint != nil {
@@ -52,7 +52,7 @@ func retrieveEndpointsFromEnv(apiHashValue string) ([]Endpoint, []Endpoint) {
 			break
 		}
 
-		sandboxEndpoint, err := getHostandBasepathandPort(sandboxEndpointURL)
+		sandboxEndpoint, err := getHTTPEndpoint(sandboxEndpointURL)
 		if err != nil {
 			loggers.LoggerAPI.Errorf("error while reading sandbox endpoint : %v in env variables, %v", sandboxEndpointURL, err.Error())
 		} else if sandboxEndpoint != nil {

--- a/adapter/internal/oasparser/model/api_yaml.go
+++ b/adapter/internal/oasparser/model/api_yaml.go
@@ -29,8 +29,9 @@ import (
 // To support both api.json and api.yaml we convert yaml to json and then use json.Unmarshal()
 // Therefore, the params are defined to support json.Unmarshal()
 type APIYaml struct {
-	ApimMeta
-	Data struct {
+	Type    string `yaml:"type" json:"type"`
+	Version string `yaml:"version" json:"version"`
+	Data    struct {
 		ID                         string   `json:"Id,omitempty"`
 		Name                       string   `json:"name,omitempty"`
 		Context                    string   `json:"context,omitempty"`
@@ -63,6 +64,15 @@ type APIYaml struct {
 type APIEndpointSecurity struct {
 	Production EndpointSecurity `json:"production,omitempty"`
 	Sandbox    EndpointSecurity `json:"sandbox,omitempty"`
+}
+
+// EndpointSecurity contains parameters of endpoint security at api.json
+type EndpointSecurity struct {
+	Password         string            `json:"password,omitempty" mapstructure:"password"`
+	Type             string            `json:"type,omitempty" mapstructure:"type"`
+	Enabled          bool              `json:"enabled,omitempty" mapstructure:"enabled"`
+	Username         string            `json:"username,omitempty" mapstructure:"username"`
+	CustomParameters map[string]string `json:"customparameters,omitempty" mapstructure:"customparameters"`
 }
 
 // EndpointInfo holds config values regards to the endpoint

--- a/adapter/internal/oasparser/model/api_yaml.go
+++ b/adapter/internal/oasparser/model/api_yaml.go
@@ -68,8 +68,8 @@ func VerifyMandatoryFields(apiYaml APIYaml) error {
 	return nil
 }
 
-// ExtractAPIInformation reads the values in api.yaml/api.json and populates ProjectAPI struct
-func ExtractAPIInformation(apiProject *ProjectAPI, apiYaml APIYaml) {
+// PopulateAPIInfo reads the values in api.yaml/api.json and populates ProjectAPI struct
+func (apiProject *ProjectAPI) PopulateAPIInfo(apiYaml APIYaml) {
 	apiProject.APIType = strings.ToUpper(apiYaml.Data.APIType)
 	apiProject.APILifeCycleStatus = strings.ToUpper(apiYaml.Data.LifeCycleStatus)
 	// organization ID would remain empty string if unassigned
@@ -78,7 +78,7 @@ func ExtractAPIInformation(apiProject *ProjectAPI, apiYaml APIYaml) {
 
 // PopulateEndpointsInfo this will map sandbox and prod endpoint
 // This is done to fix the issue https://github.com/wso2/product-microgateway/issues/2288
-func PopulateEndpointsInfo(apiYaml APIYaml) APIYaml {
+func (apiYaml *APIYaml) PopulateEndpointsInfo() {
 	rawProdEndpoints := apiYaml.Data.EndpointConfig.RawProdEndpoints
 	if rawProdEndpoints != nil {
 		if val, ok := rawProdEndpoints.(map[string]interface{}); ok {
@@ -112,5 +112,4 @@ func PopulateEndpointsInfo(apiYaml APIYaml) APIYaml {
 			loggers.LoggerAPI.Warn("No sandbox endpoints provided")
 		}
 	}
-	return apiYaml
 }

--- a/adapter/internal/oasparser/model/async_api.go
+++ b/adapter/internal/oasparser/model/async_api.go
@@ -1,0 +1,164 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package model
+
+import (
+	"errors"
+
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
+)
+
+// AsyncAPI is the struct for the AsyncAPI 2.0.0 definition
+type AsyncAPI struct {
+	SpecVersion string `json:"asyncapi,omitempty"`
+	ID          string `json:"id,omitempty"`
+	Info        struct {
+		Title   string `json:"title,omitempty"`
+		Version string `json:"version,omitempty"`
+	} `json:"info,omitempty"`
+	Servers struct {
+		Production Server `json:"production,omitempty"`
+		Sandbox    Server `json:"sandbox,omitempty"`
+	} `json:"servers,omitempty"`
+	Channels   map[string]ChannelItem `json:"channels,omitempty"`
+	Components struct {
+		Schemas         map[string]interface{}    `json:"schemas,omitempty"`
+		Messages        map[string]interface{}    `json:"messages,omitempty"`
+		SecuritySchemes map[string]SecurityScheme `json:"securitySchemes,omitempty"`
+	} `json:"components,omitempty"`
+	VendorExtensions map[string]interface{} `json:"-"`
+}
+
+// Server object in AsyncAPI
+type Server struct {
+	URL             string                 `json:"url,omitempty"`
+	Protocol        string                 `json:"protocol,omitempty"`
+	ProtocolVersion string                 `json:"protocolVersion,omitempty"`
+	Variables       map[string]interface{} `json:"variables,omitempty"`
+	Security        []map[string][]string  `json:"security,omitempty"`
+	Bindings        map[string]interface{} `json:"bindings,omitempty"`
+}
+
+// ChannelItem in AsyncAPI channels
+type ChannelItem struct {
+	Ref              string                 `json:"$ref,omitempty"`
+	Subscribe        interface{}            `json:"subscribe,omitempty"` // TODO: (suksw) OperationAsync or $ref
+	Publish          interface{}            `json:"publish,omitempty"`   // TODO: (suksw) OperationAsync or $ref
+	Parameters       map[string]interface{} `json:"parameters,omitempty"`
+	Bindings         map[string]interface{} `json:"bindings,omitempty"`
+	VendorExtensions map[string]interface{} `json:"-"`
+}
+
+// OperationAsync is the Operation object that includes the message object
+type OperationAsync struct {
+	OperationID string `json:"operationId,omitempty"`
+	Message     struct {
+		Headers       string `json:"headers,omitempty"`
+		Payload       string `json:"payload,omitempty"`
+		CorrelationID string `json:"correlationId,omitempty"`
+		SchemaFormat  string `json:"schemaFormat,omitempty"`
+		ContentType   string `json:"contentType,omitempty"`
+		Name          string `json:"name,omitempty"`
+		Title         string `json:"title,omitempty"`
+	}
+}
+
+// SetInfoAsyncAPI populates the MgwSwagger object with information in asyncapi.yaml.
+func (swagger *MgwSwagger) SetInfoAsyncAPI(asyncAPI AsyncAPI) error {
+	swagger.vendorExtensions = asyncAPI.VendorExtensions
+	swagger.securityScheme = asyncAPI.getSecuritySchemes()
+	swagger.resources = asyncAPI.getResourcesSwagger()
+	swagger.apiType = constants.HTTP
+
+	if !swagger.IsProtoTyped {
+		if asyncAPI.Servers.Production.URL != "" {
+			endpoint, err := getWebSocketEndpoint(asyncAPI.Servers.Production.URL)
+			if err == nil {
+				productionEndpoints := append([]Endpoint{}, *endpoint)
+				swagger.productionEndpoints = generateEndpointCluster(constants.ProdClustersConfigNamePrefix,
+					productionEndpoints, constants.LoadBalance)
+			} else {
+				return errors.New("error encountered when parsing the production endpoint for AsyncAPI")
+			}
+		}
+		if asyncAPI.Servers.Sandbox.URL != "" {
+			endpoint, err := getWebSocketEndpoint(asyncAPI.Servers.Sandbox.URL)
+			if err == nil {
+				productionEndpoints := append([]Endpoint{}, *endpoint)
+				swagger.productionEndpoints = generateEndpointCluster(constants.SandClustersConfigNamePrefix,
+					productionEndpoints, constants.LoadBalance)
+			} else {
+				return errors.New("error encountered when parsing the production endpoint for AsyncAPI")
+			}
+		}
+	}
+	return nil
+}
+
+func (asyncAPI AsyncAPI) getSecuritySchemes() []SecurityScheme {
+	securitySchemes := []SecurityScheme{}
+	for key, securityScheme := range asyncAPI.Components.SecuritySchemes {
+		securityScheme.DefinitionName = key
+		securitySchemes = append(securitySchemes, securityScheme)
+	}
+	return securitySchemes
+}
+
+func (asyncAPI AsyncAPI) getResourcesSwagger() []*Resource {
+	resources := []*Resource{}
+	for channel, channelItem := range asyncAPI.Channels {
+		var methodsArray []*Operation
+		methodFound := false
+		if channelItem.Publish != nil {
+			vendorExtensions := channelItem.Publish.(map[string]interface{})
+			security := getSecurityArray(vendorExtensions)
+			// relevant security schemes are added by default by the mgwSwagger.SanitizeAPISecurity at server.go
+
+			methodsArray = append(methodsArray, NewOperation("GET", security, vendorExtensions))
+			methodFound = true
+		}
+		if channelItem.Subscribe != nil {
+			vendorExtensions := channelItem.Subscribe.(map[string]interface{})
+			security := getSecurityArray(vendorExtensions)
+			// relevant security schemes are added by default by the mgwSwagger.SanitizeAPISecurity at server.go
+
+			methodsArray = append(methodsArray, NewOperation("GET", security, vendorExtensions))
+			methodFound = true
+		}
+		if methodFound {
+			resource := generateResource(channel, methodsArray, channelItem.VendorExtensions)
+			resources = append(resources, &resource)
+		}
+	}
+
+	return SortResources(resources)
+}
+
+func getSecurityArray(vendorExtensions map[string]interface{}) (security []map[string][]string) {
+	if vendorExtensions["x-scopes"] != nil {
+		securityItem := make(map[string][]string)
+		rawScopes := vendorExtensions["x-scopes"].([]interface{})
+		var scopes []string
+
+		for _, rawScope := range rawScopes {
+			scopes = append(scopes, rawScope.(string))
+		}
+		securityItem[constants.APIMOauth2Type] = scopes
+		security = append(security, securityItem)
+	}
+	return security
+}

--- a/adapter/internal/oasparser/model/async_api_test.go
+++ b/adapter/internal/oasparser/model/async_api_test.go
@@ -1,0 +1,118 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package model
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wso2/product-microgateway/adapter/config"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/utills"
+)
+
+// TestSetInfoAsyncAPI for mgwSwagger.SetInfoAsyncAPI(asyncapi)
+func TestSetInfoAsyncAPI(t *testing.T) {
+
+	type setInfoAsyncAPITestItem struct {
+		actual   MgwSwagger
+		expected MgwSwagger
+	}
+
+	asyncapiFilePath := config.GetMgwHome() + "/../adapter/test-resources/envoycodegen/asyncapi_websocket.yaml"
+	asyncapiByteArr, err := ioutil.ReadFile(asyncapiFilePath)
+	assert.Nil(t, err, "Error while reading file : %v"+asyncapiFilePath)
+	apiJsn, conversionErr := utills.ToJSON(asyncapiByteArr)
+	assert.Nil(t, conversionErr, "YAML to JSON conversion error : %v"+asyncapiFilePath)
+
+	var asyncapi AsyncAPI
+	err = json.Unmarshal(apiJsn, &asyncapi)
+	assert.Nil(t, err, "Error occurred while parsing api.yaml")
+	var mgwSwagger MgwSwagger
+	err = mgwSwagger.SetInfoAsyncAPI(asyncapi)
+	assert.Nil(t, err, "Error while populating the MgwSwagger object for websocket APIs")
+
+	dataItem := setInfoAsyncAPITestItem{
+		actual: mgwSwagger,
+		expected: MgwSwagger{
+			title:   "WebSocket",
+			version: "1",
+			productionEndpoints: &EndpointCluster{
+				EndpointPrefix: "clusterProd",
+				Endpoints: []Endpoint{
+					{
+						Host:     "ws.ifelse.io",
+						Port:     443,
+						URLType:  "wss",
+						Basepath: "",
+						RawURL:   "wss://ws.ifelse.io:443",
+					},
+				},
+				EndpointType: "load_balance",
+			},
+			resources: []*Resource{
+				{
+					path: "/notifications",
+					methods: []*Operation{
+						{
+							method: "GET",
+						},
+						{
+							method: "GET",
+							security: []map[string][]string{
+								{
+									"oauth2": {"abc"},
+								},
+							},
+						},
+					},
+				},
+				{
+					path: "/rooms/{roomID}",
+					methods: []*Operation{
+						{
+							method: "GET",
+						},
+						{
+							method: "GET",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assert.Nil(t, err, "Error while populating the mgwSwagger object for asyncAPIs")
+
+	assert.Equal(t, dataItem.expected.productionEndpoints.Endpoints[0],
+		dataItem.actual.productionEndpoints.Endpoints[0], "AsyncAPI MgwSwagger productionEndpoints mismatch")
+	assert.Nil(t, dataItem.actual.sandboxEndpoints, "AsyncAPI MgwSwagger sandboxEndpoints not nil")
+
+	assert.Equal(t, dataItem.expected.resources[0].path,
+		dataItem.actual.resources[0].path, "AsyncAPI MgwSwagger /notifications path mismatch")
+	assert.Equal(t, dataItem.expected.resources[1].path,
+		dataItem.actual.resources[1].path, "AsyncAPI MgwSwagger /rooms/{roomID} path mismatch")
+
+	assert.Equal(t, dataItem.expected.resources[0].methods[0].method,
+		dataItem.actual.resources[0].methods[0].method,
+		"AsyncAPI MgwSwagger resource method mismatch")
+
+	assert.Equal(t, dataItem.expected.resources[0].methods[1].security[0]["oauth2"],
+		dataItem.actual.resources[0].methods[1].security[0]["oauth2"],
+		"AsyncAPI MgwSwagger subscribe security scope mismatch")
+}

--- a/adapter/internal/oasparser/model/mgw_common.go
+++ b/adapter/internal/oasparser/model/mgw_common.go
@@ -1,0 +1,196 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+// This file contains util methods either common for operation/resource/base levels
+// Or common to swagger/OpenAPI/AsyncAPI when populating the mgwSwagger object
+
+package model
+
+import (
+	"errors"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
+)
+
+func arrayContains(a []string, x string) bool {
+	for _, n := range a {
+		if x == n {
+			return true
+		}
+	}
+	return false
+}
+
+// getXWso2AuthHeader extracts the value of xWso2AuthHeader extension.
+// if the property is not available, an empty string is returned.
+func getXWso2AuthHeader(vendorExtensions map[string]interface{}) string {
+	xWso2AuthHeader := ""
+	if y, found := vendorExtensions[constants.XAuthHeader]; found {
+		if val, ok := y.(string); ok {
+			xWso2AuthHeader = val
+		}
+	}
+	return xWso2AuthHeader
+}
+
+// getXWso2Basepath extracts the value of xWso2BasePath extension.
+// if the property is not available, an empty string is returned.
+func getXWso2Basepath(vendorExtensions map[string]interface{}) string {
+	xWso2basepath := ""
+	if y, found := vendorExtensions[constants.XWso2BasePath]; found {
+		if val, ok := y.(string); ok {
+			xWso2basepath = val
+		}
+	}
+	return xWso2basepath
+}
+
+// ResolveThrottlingTier extracts the value of x-wso2-throttling-tier and
+// x-throttling-tier extension. if x-wso2-throttling-tier is available it
+// will be prioritized.
+// if both the properties are not available, an empty string is returned.
+func ResolveThrottlingTier(vendorExtensions map[string]interface{}) string {
+	xTier := ""
+	if x, found := vendorExtensions[constants.XWso2ThrottlingTier]; found {
+		if val, ok := x.(string); ok {
+			xTier = val
+		}
+	} else if y, found := vendorExtensions[constants.XThrottlingTier]; found {
+		if val, ok := y.(string); ok {
+			xTier = val
+		}
+	}
+	return xTier
+}
+
+// ResolveDisableSecurity extracts the value of x-auth-type extension.
+// if the property is not available, false is returned.
+// If the API definition is fed from API manager, then API definition contains
+// x-auth-type as "None" for non secured APIs. Then the return value would be true.
+// If the API definition is fed through apictl, the users can use either
+// x-wso2-disable-security : true/false to enable and disable security.
+func ResolveDisableSecurity(vendorExtensions map[string]interface{}) bool {
+	disableSecurity := false
+	y, vExtAuthType := vendorExtensions[constants.XAuthType]
+	z, vExtDisableSecurity := vendorExtensions[constants.XWso2DisableSecurity]
+	if vExtDisableSecurity {
+		// If x-wso2-disable-security is present, then disableSecurity = val
+		if val, ok := z.(bool); ok {
+			disableSecurity = val
+		}
+	}
+	if vExtAuthType && !disableSecurity {
+		// If APIs are published through APIM, all resource levels contains x-auth-type
+		// vendor extension.
+		if val, ok := y.(string); ok {
+			// If the x-auth-type vendor ext is None, then the API/resource is considerd
+			// to be non secure
+			if val == constants.None {
+				disableSecurity = true
+			}
+		}
+	}
+	return disableSecurity
+}
+
+func getHTTPEndpoint(rawURL string) (*Endpoint, error) {
+	return getHostandBasepathandPort(constants.HTTP, rawURL)
+}
+
+func getWebSocketEndpoint(rawURL string) (*Endpoint, error) {
+	return getHostandBasepathandPort(constants.WS, rawURL)
+}
+
+func getHostandBasepathandPort(apiType string, rawURL string) (*Endpoint, error) {
+	var (
+		basepath string
+		host     string
+		port     uint32
+		urlType  string
+	)
+
+	if !strings.Contains(rawURL, "://") {
+		if apiType == constants.HTTP {
+			rawURL = "http://" + rawURL
+		} else if apiType == constants.WS {
+			rawURL = "ws://" + rawURL
+		}
+	}
+
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		logger.LoggerOasparser.Errorf("Failed to parse the malformed endpoint %v. Error message: %v", rawURL, err)
+		return nil, err
+	}
+
+	// Hostname validation
+	if err == nil && !regexp.MustCompile(hostNameValidator).MatchString(parsedURL.Hostname()) {
+		logger.LoggerOasparser.Error("Malformed endpoint detected (Invalid host name) : ", rawURL)
+		return nil, errors.New("malformed endpoint detected (Invalid host name) : " + rawURL)
+	}
+
+	host = parsedURL.Hostname()
+	basepath = parsedURL.Path
+	if parsedURL.Port() != "" {
+		u32, err := strconv.ParseUint(parsedURL.Port(), 10, 32)
+		if err != nil {
+			logger.LoggerOasparser.Error("Error passing port value to mgwSwagger", err)
+		}
+		port = uint32(u32)
+	} else {
+		if strings.HasPrefix(rawURL, "https://") || strings.HasPrefix(rawURL, "wss://") {
+			port = uint32(443)
+		} else {
+			port = uint32(80)
+		}
+	}
+
+	if strings.HasPrefix(rawURL, "https://") {
+		urlType = "https"
+	} else if strings.HasPrefix(rawURL, "http://") {
+		urlType = "http"
+	} else if strings.HasPrefix(rawURL, "wss://") {
+		urlType = "wss"
+	} else if strings.HasPrefix(rawURL, "ws://") {
+		urlType = "ws"
+	}
+
+	return &Endpoint{Host: host, Basepath: basepath, Port: port, URLType: urlType, RawURL: rawURL}, nil
+}
+
+// generateResource used to populate mgwSwagger for both OpenAPI and AsyncAPI
+func generateResource(path string, methods []*Operation, vendorExtensions map[string]interface{}) Resource {
+	return Resource{
+		path:    path,
+		methods: methods,
+		// TODO: (VirajSalaka) This will not solve the actual problem when incremental Xds is introduced (used for cluster names)
+		iD: uuid.New().String(),
+		// PathItem object in swagger 2 specification does not contain summary and description properties
+		summary:     "",
+		description: "",
+		//schemes:          operation.Schemes,
+		//tags:             operation.Tags,
+		//security:         operation.Security,
+		vendorExtensions: vendorExtensions,
+	}
+}

--- a/adapter/internal/oasparser/model/mgw_swagger.go
+++ b/adapter/internal/oasparser/model/mgw_swagger.go
@@ -32,6 +32,7 @@ import (
 	"github.com/wso2/product-microgateway/adapter/config"
 	"github.com/wso2/product-microgateway/adapter/internal/interceptor"
 	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/utills"
 	"github.com/wso2/product-microgateway/adapter/internal/svcdiscovery"
 	"github.com/wso2/product-microgateway/adapter/pkg/synchronizer"
@@ -287,17 +288,17 @@ func (swagger *MgwSwagger) SanitizeAPISecurity(isYamlAPIKey bool, isYamlOauth bo
 	if isYamlAPIKey {
 		//creating security definition for apikey in header in behalf of apim yaml security
 		overridenAPISecurityDefinitions = append(overridenAPISecurityDefinitions,
-			SecurityScheme{DefinitionName: APIMAPIKeyInHeader,
-				Type: APIKeyTypeInOAS, Name: APIKeyNameWithApim, In: APIKeyInHeaderOAS})
+			SecurityScheme{DefinitionName: constants.APIMAPIKeyInHeader,
+				Type: constants.APIKeyTypeInOAS, Name: constants.APIKeyNameWithApim, In: constants.APIKeyInHeaderOAS})
 
 		//creating security definition for apikey in query in behalf of apim yaml security
 		overridenAPISecurityDefinitions = append(overridenAPISecurityDefinitions,
-			SecurityScheme{DefinitionName: APIMAPIKeyInQuery, Type: APIKeyTypeInOAS,
-				Name: APIKeyNameWithApim, In: APIKeyInQueryOAS})
+			SecurityScheme{DefinitionName: constants.APIMAPIKeyInQuery, Type: constants.APIKeyTypeInOAS,
+				Name: constants.APIKeyNameWithApim, In: constants.APIKeyInQueryOAS})
 	}
 	for _, securityDef := range swagger.securityScheme {
 		//read default oauth2 security with scopes when oauth2 enabled
-		if isYamlOauth && securityDef.DefinitionName == APIMDefaultOauth2Security {
+		if isYamlOauth && securityDef.DefinitionName == constants.APIMDefaultOauth2Security {
 			overridenAPISecurityDefinitions = append(overridenAPISecurityDefinitions, securityDef)
 			apiSecurityDefinitionNames = append(apiSecurityDefinitionNames, securityDef.DefinitionName)
 		} else if !isOverrideSecurityByYaml {
@@ -326,8 +327,8 @@ func (swagger *MgwSwagger) SanitizeAPISecurity(isYamlAPIKey bool, isYamlOauth bo
 	}
 	// Adding api level security when api.yaml apikey security is provided
 	if isYamlAPIKey {
-		sanitizedAPISecurity = append(sanitizedAPISecurity, map[string][]string{APIMAPIKeyInHeader: {}})
-		sanitizedAPISecurity = append(sanitizedAPISecurity, map[string][]string{APIMAPIKeyInQuery: {}})
+		sanitizedAPISecurity = append(sanitizedAPISecurity, map[string][]string{constants.APIMAPIKeyInHeader: {}})
+		sanitizedAPISecurity = append(sanitizedAPISecurity, map[string][]string{constants.APIMAPIKeyInQuery: {}})
 	}
 	swagger.security = sanitizedAPISecurity
 
@@ -347,8 +348,8 @@ func (swagger *MgwSwagger) SanitizeAPISecurity(isYamlAPIKey bool, isYamlOauth bo
 			}
 			// has do the following to enable apikey as well when default oauth2 security is in operation level
 			if isOverrideSecurityByYaml && isYamlOauth && isYamlAPIKey {
-				sanitizedOperationSecurity = append(sanitizedOperationSecurity, map[string][]string{APIMAPIKeyInHeader: {}})
-				sanitizedOperationSecurity = append(sanitizedOperationSecurity, map[string][]string{APIMAPIKeyInQuery: {}})
+				sanitizedOperationSecurity = append(sanitizedOperationSecurity, map[string][]string{constants.APIMAPIKeyInHeader: {}})
+				sanitizedOperationSecurity = append(sanitizedOperationSecurity, map[string][]string{constants.APIMAPIKeyInQuery: {}})
 			}
 			operation.SetSecurity(sanitizedOperationSecurity)
 		}
@@ -426,7 +427,8 @@ func (swagger *MgwSwagger) SetEnvLabelProperties(envProps synchronizer.APIEnvPro
 
 	if len(productionUrls) > 0 {
 		logger.LoggerOasparser.Infof("Production endpoints is overridden by env properties %v : %v", swagger.title, swagger.version)
-		swagger.productionEndpoints = generateEndpointCluster(prodClustersConfigNamePrefix, productionUrls, LoadBalance)
+		swagger.productionEndpoints = generateEndpointCluster(constants.ProdClustersConfigNamePrefix,
+			productionUrls, constants.LoadBalance)
 	}
 
 	if envProps.APIConfigs.SandBoxEndpoint != "" {
@@ -442,7 +444,7 @@ func (swagger *MgwSwagger) SetEnvLabelProperties(envProps synchronizer.APIEnvPro
 
 	if len(sandboxUrls) > 0 {
 		logger.LoggerOasparser.Infof("Sandbox endpoints is overridden by env properties %v : %v", swagger.title, swagger.version)
-		swagger.sandboxEndpoints = generateEndpointCluster(sandClustersConfigNamePrefix, sandboxUrls, LoadBalance)
+		swagger.sandboxEndpoints = generateEndpointCluster(constants.SandClustersConfigNamePrefix, sandboxUrls, constants.LoadBalance)
 	}
 }
 
@@ -451,16 +453,16 @@ func (swagger *MgwSwagger) SetEnvVariables(apiHashValue string) {
 	productionEndpoints, sandboxEndpoints := retrieveEndpointsFromEnv(apiHashValue)
 	if len(productionEndpoints) > 0 {
 		logger.LoggerOasparser.Infof("Applying production endpoints provided in env variables for API %v : %v", swagger.title, swagger.version)
-		swagger.productionEndpoints.EndpointPrefix = prodClustersConfigNamePrefix
+		swagger.productionEndpoints.EndpointPrefix = constants.ProdClustersConfigNamePrefix
 		swagger.productionEndpoints.Endpoints = productionEndpoints
-		swagger.productionEndpoints.EndpointType = LoadBalance
+		swagger.productionEndpoints.EndpointType = constants.LoadBalance
 
 	}
 	if len(sandboxEndpoints) > 0 {
 		logger.LoggerOasparser.Infof("Applying sandbox endpoints provided in env variables for API %v : %v", swagger.title, swagger.version)
-		swagger.sandboxEndpoints.EndpointPrefix = sandClustersConfigNamePrefix
+		swagger.sandboxEndpoints.EndpointPrefix = constants.SandClustersConfigNamePrefix
 		swagger.sandboxEndpoints.Endpoints = sandboxEndpoints
-		swagger.sandboxEndpoints.EndpointType = LoadBalance
+		swagger.sandboxEndpoints.EndpointType = constants.LoadBalance
 	}
 
 	// retrieving security credentials from environment variables
@@ -477,18 +479,20 @@ func (swagger *MgwSwagger) SetEnvVariables(apiHashValue string) {
 // SetSandboxEndpoints set the MgwSwagger object with the SandboxEndpoint when
 // it is not populated by SetXWso2Extensions
 func (swagger *MgwSwagger) SetSandboxEndpoints(sandboxEndpoints []Endpoint) {
-	swagger.sandboxEndpoints = generateEndpointCluster(sandClustersConfigNamePrefix, sandboxEndpoints, LoadBalance)
+	swagger.sandboxEndpoints = generateEndpointCluster(constants.SandClustersConfigNamePrefix,
+		sandboxEndpoints, constants.LoadBalance)
 }
 
 // SetProductionEndpoints set the MgwSwagger object with the productionEndpoint when
 // it is not populated by SetXWso2Extensions
 func (swagger *MgwSwagger) SetProductionEndpoints(productionEndpoints []Endpoint) {
-	swagger.productionEndpoints = generateEndpointCluster(prodClustersConfigNamePrefix, productionEndpoints, LoadBalance)
+	swagger.productionEndpoints = generateEndpointCluster(constants.ProdClustersConfigNamePrefix,
+		productionEndpoints, constants.LoadBalance)
 }
 
 func (swagger *MgwSwagger) setXWso2ProductionEndpoint() (bool, error) {
 	apiLevelEPFound := false
-	xWso2APIEndpoints, err := swagger.getEndpoints(swagger.vendorExtensions, xWso2ProdEndpoints)
+	xWso2APIEndpoints, err := swagger.getEndpoints(swagger.vendorExtensions, constants.XWso2ProdEndpoints)
 	if xWso2APIEndpoints != nil {
 		swagger.productionEndpoints = xWso2APIEndpoints
 		apiLevelEPFound = true
@@ -498,7 +502,7 @@ func (swagger *MgwSwagger) setXWso2ProductionEndpoint() (bool, error) {
 
 	//resources
 	for i, resource := range swagger.resources {
-		xwso2ResourceEndpoints, err := swagger.getEndpoints(resource.vendorExtensions, xWso2ProdEndpoints)
+		xwso2ResourceEndpoints, err := swagger.getEndpoints(resource.vendorExtensions, constants.XWso2ProdEndpoints)
 		if err != nil {
 			return apiLevelEPFound, errors.New("error encountered when extracting resource endpoints for API with basepath: " +
 				swagger.xWso2Basepath + ". " + err.Error())
@@ -512,7 +516,7 @@ func (swagger *MgwSwagger) setXWso2ProductionEndpoint() (bool, error) {
 
 func (swagger *MgwSwagger) setXWso2SandboxEndpoint() (bool, error) {
 	apiLevelEPFound := false
-	xWso2APIEndpoints, err := swagger.getEndpoints(swagger.vendorExtensions, xWso2SandbxEndpoints)
+	xWso2APIEndpoints, err := swagger.getEndpoints(swagger.vendorExtensions, constants.XWso2SandbxEndpoints)
 	if xWso2APIEndpoints != nil {
 		swagger.sandboxEndpoints = xWso2APIEndpoints
 		apiLevelEPFound = true
@@ -522,7 +526,7 @@ func (swagger *MgwSwagger) setXWso2SandboxEndpoint() (bool, error) {
 
 	// resources
 	for i, resource := range swagger.resources {
-		xwso2ResourceEndpoints, err := swagger.getEndpoints(resource.vendorExtensions, xWso2SandbxEndpoints)
+		xwso2ResourceEndpoints, err := swagger.getEndpoints(resource.vendorExtensions, constants.XWso2SandbxEndpoints)
 		if err != nil {
 			return apiLevelEPFound, errors.New("error encountered when extracting resource endpoints for API with basepath: " +
 				swagger.xWso2Basepath + ". " + err.Error())
@@ -536,7 +540,7 @@ func (swagger *MgwSwagger) setXWso2SandboxEndpoint() (bool, error) {
 // GetXWso2Endpoints get x-wso2-endpoints
 func (swagger *MgwSwagger) setXWso2Endpoints() error {
 	endpointClusters := make(map[string]*EndpointCluster)
-	if val, found := swagger.vendorExtensions[xWso2endpoints]; found {
+	if val, found := swagger.vendorExtensions[constants.XWso2endpoints]; found {
 		if val1, ok := val.([]interface{}); ok {
 			for _, val2 := range val1 { // loop thorough multiple endpoints
 				if eps, ok := val2.(map[string]interface{}); ok {
@@ -608,7 +612,7 @@ func (swagger *MgwSwagger) setXWso2ThrottlingTier() {
 // if the property is not available, an empty string is returned.
 func getXWso2AuthHeader(vendorExtensions map[string]interface{}) string {
 	xWso2AuthHeader := ""
-	if y, found := vendorExtensions[xAuthHeader]; found {
+	if y, found := vendorExtensions[constants.XAuthHeader]; found {
 		if val, ok := y.(string); ok {
 			xWso2AuthHeader = val
 		}
@@ -765,24 +769,24 @@ func (swagger *MgwSwagger) getEndpoints(vendorExtensions map[string]interface{},
 	// TODO: (VirajSalaka) x-wso2-production-endpoint 's type does not represent http/https, instead it indicates loadbalance and failover
 	if endpointClusterYaml, found := vendorExtensions[endpointName]; found {
 		if endpointClusterMap, ok := endpointClusterYaml.(map[string]interface{}); ok {
-			endpointPrefix := endpointName + "_" + xWso2EPClustersConfigNamePrefix
-			if strings.EqualFold(endpointName, xWso2ProdEndpoints) {
-				endpointPrefix = prodClustersConfigNamePrefix
-			} else if strings.EqualFold(endpointName, xWso2SandbxEndpoints) {
-				endpointPrefix = sandClustersConfigNamePrefix
+			endpointPrefix := endpointName + "_" + constants.XWso2EPClustersConfigNamePrefix
+			if strings.EqualFold(endpointName, constants.XWso2ProdEndpoints) {
+				endpointPrefix = constants.ProdClustersConfigNamePrefix
+			} else if strings.EqualFold(endpointName, constants.XWso2SandbxEndpoints) {
+				endpointPrefix = constants.SandClustersConfigNamePrefix
 			}
 			endpointCluster := EndpointCluster{
 				EndpointPrefix: endpointPrefix,
 			}
 			// Set URLs
-			if urlsProperty, found := endpointClusterMap[urls]; found {
+			if urlsProperty, found := endpointClusterMap[constants.Urls]; found {
 				if urlsArray, ok := urlsProperty.([]interface{}); ok {
 					endpoints, err := processEndpointUrls(urlsArray)
 					if err != nil {
 						return nil, err
 					}
 					endpointCluster.Endpoints = endpoints
-					endpointCluster.EndpointType = LoadBalance
+					endpointCluster.EndpointType = constants.LoadBalance
 				} else {
 					return nil, errors.New("Error while parsing array of urls in " + endpointName)
 				}
@@ -794,13 +798,13 @@ func (swagger *MgwSwagger) getEndpoints(vendorExtensions map[string]interface{},
 			}
 
 			// Update Endpoint Cluster type
-			if epType, found := endpointClusterMap[typeConst]; found {
+			if epType, found := endpointClusterMap[constants.Type]; found {
 				if endpointType, ok := epType.(string); ok {
 					endpointCluster.EndpointType = endpointType
 				}
 			}
 			// Set Endpoint Config
-			if advanceEndpointConfig, found := endpointClusterMap[AdvanceEndpointConfig]; found {
+			if advanceEndpointConfig, found := endpointClusterMap[constants.AdvanceEndpointConfig]; found {
 				if configMap, ok := advanceEndpointConfig.(map[string]interface{}); ok {
 					var endpointConfig EndpointConfig
 					err := parser.Decode(configMap, &endpointConfig)
@@ -813,7 +817,7 @@ func (swagger *MgwSwagger) getEndpoints(vendorExtensions map[string]interface{},
 				}
 			}
 			// Set Endpoint Config
-			if securityConfig, found := endpointClusterMap[SecurityConfig]; found {
+			if securityConfig, found := endpointClusterMap[constants.SecurityConfig]; found {
 				if configMap, ok := securityConfig.(map[string]interface{}); ok {
 					var epSecurity EndpointSecurity
 					err := parser.Decode(configMap, &epSecurity)
@@ -831,8 +835,9 @@ func (swagger *MgwSwagger) getEndpoints(vendorExtensions map[string]interface{},
 			}
 			return &endpointCluster, nil
 		} else if endpointRef, ok := endpointClusterYaml.(string); ok &&
-			(strings.EqualFold(endpointName, xWso2ProdEndpoints) || strings.EqualFold(endpointName, xWso2SandbxEndpoints)) {
-			refPrefix := "#/" + xWso2endpoints + "/"
+			(strings.EqualFold(endpointName, constants.XWso2ProdEndpoints) ||
+				strings.EqualFold(endpointName, constants.XWso2SandbxEndpoints)) {
+			refPrefix := "#/" + constants.XWso2endpoints + "/"
 			if strings.HasPrefix(endpointRef, refPrefix) {
 				epName := strings.TrimPrefix(endpointRef, refPrefix)
 				if _, found := swagger.xWso2Endpoints[epName]; found {
@@ -881,7 +886,7 @@ func processEndpointUrls(urlsArray []interface{}) ([]Endpoint, error) {
 // if the property is not available, an empty string is returned.
 func getXWso2Basepath(vendorExtensions map[string]interface{}) string {
 	xWso2basepath := ""
-	if y, found := vendorExtensions[xWso2BasePath]; found {
+	if y, found := vendorExtensions[constants.XWso2BasePath]; found {
 		if val, ok := y.(string); ok {
 			xWso2basepath = val
 		}
@@ -897,8 +902,8 @@ func (swagger *MgwSwagger) setXWso2Basepath() {
 }
 
 func (swagger *MgwSwagger) setXWso2Cors() {
-	if cors, corsFound := swagger.vendorExtensions[xWso2Cors]; corsFound {
-		logger.LoggerOasparser.Debugf("%v configuration is available", xWso2Cors)
+	if cors, corsFound := swagger.vendorExtensions[constants.XWso2Cors]; corsFound {
+		logger.LoggerOasparser.Debugf("%v configuration is available", constants.XWso2Cors)
 		if parsedCors, parsedCorsOk := cors.(map[string]interface{}); parsedCorsOk {
 			//Default CorsConfiguration
 			corsConfig := &CorsConfig{
@@ -906,7 +911,7 @@ func (swagger *MgwSwagger) setXWso2Cors() {
 			}
 			err := parser.Decode(parsedCors, &corsConfig)
 			if err != nil {
-				logger.LoggerOasparser.Errorf("Error while parsing %v: "+err.Error(), xWso2Cors)
+				logger.LoggerOasparser.Errorf("Error while parsing %v: "+err.Error(), constants.XWso2Cors)
 				return
 			}
 			if corsConfig.Enabled {
@@ -917,7 +922,7 @@ func (swagger *MgwSwagger) setXWso2Cors() {
 			swagger.xWso2Cors = generateGlobalCors()
 			return
 		}
-		logger.LoggerOasparser.Errorf("Error while parsing %v .", xWso2Cors)
+		logger.LoggerOasparser.Errorf("Error while parsing %v .", constants.XWso2Cors)
 	} else {
 		swagger.xWso2Cors = generateGlobalCors()
 	}
@@ -954,11 +959,11 @@ func generateGlobalCors() *CorsConfig {
 // if both the properties are not available, an empty string is returned.
 func ResolveThrottlingTier(vendorExtensions map[string]interface{}) string {
 	xTier := ""
-	if x, found := vendorExtensions[xWso2ThrottlingTier]; found {
+	if x, found := vendorExtensions[constants.XWso2ThrottlingTier]; found {
 		if val, ok := x.(string); ok {
 			xTier = val
 		}
-	} else if y, found := vendorExtensions[xThrottlingTier]; found {
+	} else if y, found := vendorExtensions[constants.XThrottlingTier]; found {
 		if val, ok := y.(string); ok {
 			xTier = val
 		}
@@ -974,8 +979,8 @@ func ResolveThrottlingTier(vendorExtensions map[string]interface{}) string {
 // x-wso2-disable-security : true/false to enable and disable security.
 func ResolveDisableSecurity(vendorExtensions map[string]interface{}) bool {
 	disableSecurity := false
-	y, vExtAuthType := vendorExtensions[xAuthType]
-	z, vExtDisableSecurity := vendorExtensions[xWso2DisableSecurity]
+	y, vExtAuthType := vendorExtensions[constants.XAuthType]
+	z, vExtDisableSecurity := vendorExtensions[constants.XWso2DisableSecurity]
 	if vExtDisableSecurity {
 		// If x-wso2-disable-security is present, then disableSecurity = val
 		if val, ok := z.(bool); ok {
@@ -988,7 +993,7 @@ func ResolveDisableSecurity(vendorExtensions map[string]interface{}) bool {
 		if val, ok := y.(string); ok {
 			// If the x-auth-type vendor ext is None, then the API/resource is considerd
 			// to be non secure
-			if val == None {
+			if val == constants.None {
 				disableSecurity = true
 			}
 		}
@@ -1007,7 +1012,7 @@ func (swagger *MgwSwagger) GetInterceptor(vendorExtensions map[string]interface{
 	if x, found := vendorExtensions[extensionName]; found {
 		if val, ok := x.(map[string]interface{}); ok {
 			//serviceURL mandatory
-			if v, found := val[serviceURL]; found {
+			if v, found := val[constants.ServiceURL]; found {
 				serviceURLV := v.(string)
 				endpoint, err := getHostandBasepathandPort(serviceURLV)
 				if err != nil {
@@ -1025,25 +1030,25 @@ func (swagger *MgwSwagger) GetInterceptor(vendorExtensions map[string]interface{
 				return InterceptEndpoint{}, errors.New("error reading interceptors service url value")
 			}
 			//clusterTimeout optional
-			if v, found := val[clusterTimeout]; found {
+			if v, found := val[constants.ClusterTimeout]; found {
 				p, err := strconv.ParseInt(fmt.Sprint(v), 0, 0)
 				if err == nil {
 					clusterTimeoutV = time.Duration(p)
 				} else {
-					logger.LoggerOasparser.Errorf("Error reading interceptors %v value : %v", clusterTimeout, err.Error())
+					logger.LoggerOasparser.Errorf("Error reading interceptors %v value : %v", constants.ClusterTimeout, err.Error())
 				}
 			}
 			//requestTimeout optional
-			if v, found := val[requestTimeout]; found {
+			if v, found := val[constants.RequestTimeout]; found {
 				p, err := strconv.ParseInt(fmt.Sprint(v), 0, 0)
 				if err == nil {
 					requestTimeoutV = time.Duration(p)
 				} else {
-					logger.LoggerOasparser.Errorf("Error reading interceptors %v value : %v", requestTimeout, err.Error())
+					logger.LoggerOasparser.Errorf("Error reading interceptors %v value : %v", constants.RequestTimeout, err.Error())
 				}
 			}
 			//includes optional
-			if v, found := val[includes]; found {
+			if v, found := val[constants.Includes]; found {
 				includes := v.([]interface{})
 				if len(includes) > 0 {
 					for _, include := range includes {
@@ -1150,10 +1155,10 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 
 	if len(endpointConfig.ProductionEndpoints) > 0 {
 		var endpoints []Endpoint
-		endpointType := LoadBalance
+		endpointType := constants.LoadBalance
 		var unProcessedURLs []interface{}
 		for _, endpointConfig := range endpointConfig.ProductionEndpoints {
-			if apiType == WS {
+			if apiType == constants.WS {
 				prodEndpoint, err := getEndpointForWebsocketURL(endpointConfig.Endpoint)
 				if err == nil {
 					endpoints = append(endpoints, *prodEndpoint)
@@ -1165,9 +1170,9 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 			}
 		}
 		if len(endpointConfig.ProductionFailoverEndpoints) > 0 {
-			endpointType = FailOver
+			endpointType = constants.FailOver
 			for _, endpointConfig := range endpointConfig.ProductionFailoverEndpoints {
-				if apiType == WS {
+				if apiType == constants.WS {
 					failoverEndpoint, err := getEndpointForWebsocketURL(endpointConfig.Endpoint)
 					if err == nil {
 						endpoints = append(endpoints, *failoverEndpoint)
@@ -1179,7 +1184,7 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 				}
 			}
 		}
-		if apiType != WS {
+		if apiType != constants.WS {
 			productionEndpoints, err := processEndpointUrls(unProcessedURLs)
 			if err == nil {
 				endpoints = append(endpoints, productionEndpoints...)
@@ -1187,15 +1192,15 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 				return err
 			}
 		}
-		swagger.productionEndpoints = generateEndpointCluster(prodClustersConfigNamePrefix, endpoints, endpointType)
+		swagger.productionEndpoints = generateEndpointCluster(constants.ProdClustersConfigNamePrefix, endpoints, endpointType)
 	}
 
 	if len(endpointConfig.SandBoxEndpoints) > 0 {
 		var endpoints []Endpoint
-		endpointType := LoadBalance
+		endpointType := constants.LoadBalance
 		var unProcessedURLs []interface{}
 		for _, endpointConfig := range endpointConfig.SandBoxEndpoints {
-			if apiType == WS {
+			if apiType == constants.WS {
 				sandBoxEndpoint, err := getEndpointForWebsocketURL(endpointConfig.Endpoint)
 				if err == nil {
 					endpoints = append(endpoints, *sandBoxEndpoint)
@@ -1207,9 +1212,9 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 			}
 		}
 		if len(endpointConfig.SandboxFailoverEndpoints) > 0 {
-			endpointType = FailOver
+			endpointType = constants.FailOver
 			for _, endpointConfig := range endpointConfig.SandboxFailoverEndpoints {
-				if apiType == WS {
+				if apiType == constants.WS {
 					failoverEndpoint, err := getEndpointForWebsocketURL(endpointConfig.Endpoint)
 					if err == nil {
 						endpoints = append(endpoints, *failoverEndpoint)
@@ -1221,7 +1226,7 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 				}
 			}
 		}
-		if apiType != WS {
+		if apiType != constants.WS {
 			sandboxEndpoints, err := processEndpointUrls(unProcessedURLs)
 			if err == nil {
 				endpoints = append(endpoints, sandboxEndpoints...)
@@ -1229,7 +1234,7 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 				return err
 			}
 		}
-		swagger.sandboxEndpoints = generateEndpointCluster(sandClustersConfigNamePrefix, endpoints, endpointType)
+		swagger.sandboxEndpoints = generateEndpointCluster(constants.SandClustersConfigNamePrefix, endpoints, endpointType)
 	}
 
 	// if yaml has production security, setting it

--- a/adapter/internal/oasparser/model/mgw_swagger.go
+++ b/adapter/internal/oasparser/model/mgw_swagger.go
@@ -29,6 +29,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/go-openapi/spec"
 	parser "github.com/mitchellh/mapstructure"
+
 	"github.com/wso2/product-microgateway/adapter/config"
 	"github.com/wso2/product-microgateway/adapter/internal/interceptor"
 	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
@@ -63,6 +64,7 @@ type MgwSwagger struct {
 	disableSecurity     bool
 	OrganizationID      string
 	IsProtoTyped        bool
+	LifecycleStatus     string
 }
 
 // EndpointCluster represent an upstream cluster
@@ -1085,44 +1087,40 @@ func (swagger *MgwSwagger) GetInterceptor(vendorExtensions map[string]interface{
 	return InterceptEndpoint{}, nil
 }
 
-// GetMgwSwagger converts the openAPI v3 and v2 content
+// GetMgwSwagger converts the openAPI v3, v2 and asyncAPI content
 // To MgwSwagger objects
 func (swagger *MgwSwagger) GetMgwSwagger(apiContent []byte) error {
 
-	apiJsn, err := utills.ToJSON(apiContent)
+	definitionJsn, err := utills.ToJSON(apiContent)
 	if err != nil {
-		logger.LoggerOasparser.Error("Error converting api file to json", err)
+		logger.LoggerOasparser.Error("Error converting api file to json ", err)
 		return err
 	}
-	swaggerVersion := utills.FindSwaggerVersion(apiJsn)
+	definitionVersion := utills.FindAPIDefinitionVersion(definitionJsn)
 
-	if swaggerVersion == "2" {
-		// map json to struct
-		var apiData2 spec.Swagger
-		err = json.Unmarshal(apiJsn, &apiData2)
-		if err != nil {
-			logger.LoggerOasparser.Error("Error openAPI unmarshalling", err)
-		} else {
-			infoSwaggerErr := swagger.SetInfoSwagger(apiData2)
-			if infoSwaggerErr != nil {
-				return infoSwaggerErr
-			}
+	if definitionVersion == constants.Swagger2 {
+		var swaggerSpec spec.Swagger
+		err = json.Unmarshal(definitionJsn, &swaggerSpec)
+		if err == nil {
+			err = swagger.SetInfoSwagger(swaggerSpec)
 		}
-
-	} else if swaggerVersion == "3" {
-		// map json to struct
-		var apiData3 openapi3.Swagger
-
-		err = json.Unmarshal(apiJsn, &apiData3)
-		if err != nil {
-			logger.LoggerOasparser.Error("Error openAPI unmarshalling", err)
-		} else {
-			infoOpenAPIErr := swagger.SetInfoOpenAPI(apiData3)
-			if infoOpenAPIErr != nil {
-				return infoOpenAPIErr
-			}
+	} else if definitionVersion == constants.OpenAPI3 {
+		var openAPISpec openapi3.Swagger
+		err = json.Unmarshal(definitionJsn, &openAPISpec)
+		if err == nil {
+			err = swagger.SetInfoOpenAPI(openAPISpec)
 		}
+	} else if definitionVersion == constants.AsyncAPI2_0_0 {
+
+	} else {
+		return errors.New("API version not specified or not supported")
 	}
+
+	if err != nil {
+		logger.LoggerOasparser.Error("Error occurred while extracting the API definition to MgwSwagger ", err)
+		return err
+	}
+
 	err = swagger.SetXWso2Extensions()
 	if err != nil {
 		logger.LoggerOasparser.Error("Error occurred while setting x-wso2 extensions for ",
@@ -1134,17 +1132,25 @@ func (swagger *MgwSwagger) GetMgwSwagger(apiContent []byte) error {
 
 //PopulateSwaggerFromAPIYaml populates the mgwSwagger object for APIs using API.yaml
 // TODO - (VirajSalaka) read cors config and populate mgwSwagger feild
-func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType string) error {
+func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml) error {
 
 	data := apiData.Data
-	// UUID in the generated api.yaml file is considerd as swagger.id
+	// UUID in the generated api.yaml file is considered as swagger.id
 	swagger.id = data.ID
-	swagger.apiType = apiType
+	swagger.apiType = strings.ToUpper(data.APIType)
 	// name and version in api.yaml corresponds to title and version respectively.
 	swagger.title = data.Name
 	swagger.version = data.Version
 	// context value in api.yaml is assigned as xWso2Basepath
 	swagger.xWso2Basepath = data.Context + "/" + swagger.version
+
+	if data.OrganizationID != "" {
+		swagger.OrganizationID = data.OrganizationID
+	} else {
+		swagger.OrganizationID = config.GetControlPlaneConnectedTenantDomain()
+	}
+
+	swagger.LifecycleStatus = strings.ToUpper(data.LifeCycleStatus)
 
 	// productionURL & sandBoxURL values are extracted from endpointConfig in api.yaml
 	endpointConfig := data.EndpointConfig
@@ -1158,7 +1164,7 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 		endpointType := constants.LoadBalance
 		var unProcessedURLs []interface{}
 		for _, endpointConfig := range endpointConfig.ProductionEndpoints {
-			if apiType == constants.WS {
+			if swagger.apiType == constants.WS {
 				prodEndpoint, err := getEndpointForWebsocketURL(endpointConfig.Endpoint)
 				if err == nil {
 					endpoints = append(endpoints, *prodEndpoint)
@@ -1172,7 +1178,7 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 		if len(endpointConfig.ProductionFailoverEndpoints) > 0 {
 			endpointType = constants.FailOver
 			for _, endpointConfig := range endpointConfig.ProductionFailoverEndpoints {
-				if apiType == constants.WS {
+				if swagger.apiType == constants.WS {
 					failoverEndpoint, err := getEndpointForWebsocketURL(endpointConfig.Endpoint)
 					if err == nil {
 						endpoints = append(endpoints, *failoverEndpoint)
@@ -1184,7 +1190,7 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 				}
 			}
 		}
-		if apiType != constants.WS {
+		if swagger.apiType != constants.WS {
 			productionEndpoints, err := processEndpointUrls(unProcessedURLs)
 			if err == nil {
 				endpoints = append(endpoints, productionEndpoints...)
@@ -1200,7 +1206,7 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 		endpointType := constants.LoadBalance
 		var unProcessedURLs []interface{}
 		for _, endpointConfig := range endpointConfig.SandBoxEndpoints {
-			if apiType == constants.WS {
+			if swagger.apiType == constants.WS {
 				sandBoxEndpoint, err := getEndpointForWebsocketURL(endpointConfig.Endpoint)
 				if err == nil {
 					endpoints = append(endpoints, *sandBoxEndpoint)
@@ -1214,7 +1220,7 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 		if len(endpointConfig.SandboxFailoverEndpoints) > 0 {
 			endpointType = constants.FailOver
 			for _, endpointConfig := range endpointConfig.SandboxFailoverEndpoints {
-				if apiType == constants.WS {
+				if swagger.apiType == constants.WS {
 					failoverEndpoint, err := getEndpointForWebsocketURL(endpointConfig.Endpoint)
 					if err == nil {
 						endpoints = append(endpoints, *failoverEndpoint)
@@ -1226,7 +1232,7 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 				}
 			}
 		}
-		if apiType != constants.WS {
+		if swagger.apiType != constants.WS {
 			sandboxEndpoints, err := processEndpointUrls(unProcessedURLs)
 			if err == nil {
 				endpoints = append(endpoints, sandboxEndpoints...)

--- a/adapter/internal/oasparser/model/mgw_swagger_internal_test.go
+++ b/adapter/internal/oasparser/model/mgw_swagger_internal_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 )
 
+// TestGetXWso2Endpoints for mgwSwagger.getEndpoints()
 func TestGetXWso2Endpoints(t *testing.T) {
 	type getXWso2EndpointsTestItem struct {
 		inputVendorExtensions map[string]interface{}
@@ -33,17 +34,17 @@ func TestGetXWso2Endpoints(t *testing.T) {
 	}
 	dataItems := []getXWso2EndpointsTestItem{
 		{
-			inputEndpointName: "x-wso2-production-endpoints",
-			inputVendorExtensions: map[string]interface{}{"x-wso2-production-endpoints": map[string]interface{}{
-				"type": "loadbalance", "urls": []interface{}{"https://www.facebook.com:80"}}},
+			inputEndpointName: constants.XWso2ProdEndpoints,
+			inputVendorExtensions: map[string]interface{}{constants.XWso2ProdEndpoints: map[string]interface{}{
+				"type": "loadbalance", "urls": []interface{}{"https://www.getxwso2endpoints.com:80"}}},
 			result: &EndpointCluster{
 				EndpointPrefix: "clusterProd",
 				Endpoints: []Endpoint{
 					{
-						Host:    "www.facebook.com",
+						Host:    "www.getxwso2endpoints.com",
 						Port:    80,
 						URLType: "https",
-						RawURL:  "https://www.facebook.com:80",
+						RawURL:  "https://www.getxwso2endpoints.com:80",
 					},
 				},
 				EndpointType: "loadbalance",
@@ -53,9 +54,9 @@ func TestGetXWso2Endpoints(t *testing.T) {
 		{
 			inputEndpointName: "x-wso2-production-endpoints",
 			inputVendorExtensions: map[string]interface{}{"x-wso2-production-endpoints+++": map[string]interface{}{
-				"type": "loadbalance", "urls": []interface{}{"https://www.facebook.com:80/base"}}},
+				"type": "loadbalance", "urls": []interface{}{"https://www.getxwso2endpoints1.com:80/base"}}},
 			result:  nil,
-			message: "when having incorrect extenstion name",
+			message: "when having incorrect extension name",
 		},
 	}
 	for _, item := range dataItems {
@@ -66,6 +67,7 @@ func TestGetXWso2Endpoints(t *testing.T) {
 	}
 }
 
+// TestGetXWso2RefEndpoints for mgwSwagger.setXWso2Endpoints()
 func TestGetXWso2RefEndpoints(t *testing.T) {
 	xWso2EPVendorExtension := []interface{}{map[string]interface{}{
 		"myep": map[string]interface{}{
@@ -98,6 +100,7 @@ func TestGetXWso2RefEndpoints(t *testing.T) {
 	assert.Equal(t, result, resultEP, "x-wso2-endpoints vendor extension has not read correctly")
 }
 
+// TestGetXWso2Basepath for getXWso2Basepath()
 func TestGetXWso2Basepath(t *testing.T) {
 	type getXWso2BasepathTestItem struct {
 		inputVendorExtensions map[string]interface{}
@@ -122,6 +125,7 @@ func TestGetXWso2Basepath(t *testing.T) {
 	}
 }
 
+// TestSetXWso2ProductionEndpoint for mgwSwagger.setXWso2ProductionEndpoint()
 func TestSetXWso2ProductionEndpoint(t *testing.T) {
 	type setXWso2ProductionEndpointTestItem struct {
 		input   MgwSwagger
@@ -213,7 +217,7 @@ func TestSetXWso2ProductionEndpoint(t *testing.T) {
 					"type": "loadbalance", "urls": []interface{}{"https://www.youtube.com:80/base"}},
 					constants.XWso2Cors: map[string]interface{}{
 						"Enabled":                       "true",
-						"AccessControlAllowCredentials": "true",
+						"AccessControlAllowCredentials": true,
 						"AccessControlAllowHeaders":     []interface{}{"Authorization"},
 						"AccessControlAllowMethods":     []interface{}{"GET"},
 						"AccessControlAllowOrigins":     []interface{}{"http://test123.com", "http://test456.com"},
@@ -277,6 +281,7 @@ func TestSetXWso2ProductionEndpoint(t *testing.T) {
 	}
 }
 
+// TestValidateBasePath for mgwSwagger.validateBasePath()
 func TestValidateBasePath(t *testing.T) {
 	type getXWso2BasepathTestItem struct {
 		mgwSwagger MgwSwagger

--- a/adapter/internal/oasparser/model/mgw_swagger_internal_test.go
+++ b/adapter/internal/oasparser/model/mgw_swagger_internal_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 )
 
 func TestGetXWso2Endpoints(t *testing.T) {
@@ -210,7 +211,7 @@ func TestSetXWso2ProductionEndpoint(t *testing.T) {
 			input: MgwSwagger{
 				vendorExtensions: map[string]interface{}{"x-wso2-production-endpoints": map[string]interface{}{
 					"type": "loadbalance", "urls": []interface{}{"https://www.youtube.com:80/base"}},
-					xWso2Cors: map[string]interface{}{
+					constants.XWso2Cors: map[string]interface{}{
 						"Enabled":                       "true",
 						"AccessControlAllowCredentials": "true",
 						"AccessControlAllowHeaders":     []interface{}{"Authorization"},
@@ -264,7 +265,7 @@ func TestSetXWso2ProductionEndpoint(t *testing.T) {
 
 	for _, item := range dataItems {
 		mgwSwag := item.input
-		if cors, corsFound := mgwSwag.vendorExtensions[xWso2Cors]; corsFound {
+		if cors, corsFound := mgwSwag.vendorExtensions[constants.XWso2Cors]; corsFound {
 			assert.NotNil(t, cors, "cors should not be empty")
 		}
 		err := mgwSwag.SetXWso2Extensions()

--- a/adapter/internal/oasparser/model/open_api.go
+++ b/adapter/internal/oasparser/model/open_api.go
@@ -19,10 +19,6 @@ package model
 
 import (
 	"encoding/json"
-	"errors"
-	"net/url"
-	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -81,14 +77,14 @@ func (swagger *MgwSwagger) SetInfoOpenAPI(swagger3 openapi3.Swagger) error {
 
 	swagger.apiType = constants.HTTP
 	var productionUrls []Endpoint
-	// For prototyped APIs, the prototype endpoint is only assinged from api.Yaml. Hence,
+	// For prototyped APIs, the prototype endpoint is only assiged from api.Yaml. Hence,
 	// an exception is made where servers url is not processed when the API is prototyped.
 	if isServerURLIsAvailable(swagger3.Servers) && !swagger.IsProtoTyped {
 		for _, serverEntry := range swagger3.Servers {
 			if len(serverEntry.URL) == 0 || strings.HasPrefix(serverEntry.URL, "/") {
 				continue
 			}
-			endpoint, err := getHostandBasepathandPort(serverEntry.URL)
+			endpoint, err := getHTTPEndpoint(serverEntry.URL)
 			if err == nil {
 				productionUrls = append(productionUrls, *endpoint)
 				swagger.xWso2Basepath = endpoint.Basepath
@@ -156,7 +152,7 @@ func setResourcesOpenAPI(openAPI openapi3.Swagger) ([]*Resource, error) {
 					if len(serverEntry.URL) == 0 || strings.HasPrefix(serverEntry.URL, "/") {
 						continue
 					}
-					endpoint, err := getHostandBasepathandPort(serverEntry.URL)
+					endpoint, err := getHTTPEndpoint(serverEntry.URL)
 					if err == nil {
 						productionUrls = append(productionUrls, *endpoint)
 
@@ -202,60 +198,6 @@ func getOperationLevelDetails(operation *openapi3.Operation, method string) *Ope
 	logger.LoggerOasparser.Debugf("Security array %v", securityArray)
 	return NewOperation(method, securityArray, extensions)
 
-}
-
-// getHostandBasepathandPort retrieves host, basepath and port from the endpoint defintion
-// from of the production endpoints url entry, combination of schemes and host (in openapi v2)
-// or server property.
-//
-// if no scheme is mentioned before the hostname, urlType would be assigned as http
-func getHostandBasepathandPort(rawURL string) (*Endpoint, error) {
-	var (
-		basepath string
-		host     string
-		port     uint32
-		urlType  string
-	)
-
-	if !strings.Contains(rawURL, "://") {
-		rawURL = "http://" + rawURL
-	}
-	parsedURL, err := url.Parse(rawURL)
-	if err != nil {
-		logger.LoggerOasparser.Errorf("Failed to parse the malformed endpoint %v. Error message: %v", rawURL, err)
-		return nil, err
-	}
-
-	// Hostname validation
-	if err == nil && !regexp.MustCompile(hostNameValidator).MatchString(parsedURL.Hostname()) {
-		logger.LoggerOasparser.Error("Malformed endpoint detected (Invalid host name) : ", rawURL)
-		return nil, errors.New("malformed endpoint detected (Invalid host name) : " + rawURL)
-	}
-
-	host = parsedURL.Hostname()
-	basepath = parsedURL.Path
-	if parsedURL.Port() != "" {
-		u32, err := strconv.ParseUint(parsedURL.Port(), 10, 32)
-		if err != nil {
-			logger.LoggerOasparser.Error("Error passing port value to mgwSwagger", err)
-		}
-		port = uint32(u32)
-	} else {
-		if strings.HasPrefix(rawURL, "https://") {
-			port = uint32(443)
-		} else {
-			port = uint32(80)
-		}
-	}
-
-	urlType = "http"
-	if strings.HasPrefix(rawURL, "https://") {
-		urlType = "https"
-	} else if !strings.HasPrefix(rawURL, "http://") {
-		rawURL = "http://" + rawURL
-	}
-
-	return &Endpoint{Host: host, Basepath: basepath, Port: port, URLType: urlType, RawURL: rawURL}, nil
 }
 
 // isServerURLIsAvailable checks the availability od server url in openApi3
@@ -325,48 +267,4 @@ func GetXWso2Label(vendorExtensions openapi3.ExtensionProps) []string {
 		logger.LoggerOasparser.Errorln("Error while parsing the x-wso2-label")
 	}
 	return []string{"default"}
-}
-
-func getEndpointForWebsocketURL(rawURL string) (*Endpoint, error) {
-	var (
-		basepath string
-		host     string
-		port     uint32
-		urlType  string
-	)
-	if !strings.Contains(rawURL, "://") {
-		rawURL = "ws://" + rawURL
-	}
-	parsedURL, err := url.Parse(rawURL)
-	if err != nil {
-		logger.LoggerOasparser.Errorf("Failed to parse the malformed endpoint %v. Error message: %v", rawURL, err)
-		return nil, err
-	}
-
-	host = parsedURL.Hostname()
-	if parsedURL.Path == "" {
-		basepath = "/"
-	} else {
-		basepath = parsedURL.Path
-	}
-	if parsedURL.Port() != "" {
-		u32, err := strconv.ParseUint(parsedURL.Port(), 10, 32)
-		if err != nil {
-			logger.LoggerOasparser.Error("Error passing port value to mgwSwagger", err)
-		}
-		port = uint32(u32)
-	} else {
-		if strings.HasPrefix(rawURL, "wss://") {
-			port = uint32(443)
-		} else {
-			port = uint32(80)
-		}
-	}
-	urlType = "ws"
-	if strings.HasPrefix(rawURL, "wss://") {
-		urlType = "wss"
-	} else if !strings.HasPrefix(rawURL, "ws://") {
-		rawURL = "ws://" + rawURL
-	}
-	return &Endpoint{Host: host, Basepath: basepath, Port: port, URLType: urlType, RawURL: rawURL}, nil
 }

--- a/adapter/internal/oasparser/model/open_api.go
+++ b/adapter/internal/oasparser/model/open_api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/google/uuid"
 	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 )
 
 // hostNameValidator regex is for validate the host name of the URL
@@ -78,7 +79,7 @@ func (swagger *MgwSwagger) SetInfoOpenAPI(swagger3 openapi3.Swagger) error {
 		return err
 	}
 
-	swagger.apiType = HTTP
+	swagger.apiType = constants.HTTP
 	var productionUrls []Endpoint
 	// For prototyped APIs, the prototype endpoint is only assinged from api.Yaml. Hence,
 	// an exception is made where servers url is not processed when the API is prototyped.
@@ -96,7 +97,8 @@ func (swagger *MgwSwagger) SetInfoOpenAPI(swagger3 openapi3.Swagger) error {
 			}
 		}
 		if len(productionUrls) > 0 {
-			swagger.productionEndpoints = generateEndpointCluster(prodClustersConfigNamePrefix, productionUrls, LoadBalance)
+			swagger.productionEndpoints = generateEndpointCluster(constants.ProdClustersConfigNamePrefix,
+				productionUrls, constants.LoadBalance)
 			swagger.sandboxEndpoints = nil
 		}
 	}
@@ -164,7 +166,8 @@ func setResourcesOpenAPI(openAPI openapi3.Swagger) ([]*Resource, error) {
 
 				}
 				if productionUrls != nil && len(productionUrls) > 0 {
-					resource.productionEndpoints = generateEndpointCluster(prodClustersConfigNamePrefix, productionUrls, LoadBalance)
+					resource.productionEndpoints = generateEndpointCluster(constants.ProdClustersConfigNamePrefix,
+						productionUrls, constants.LoadBalance)
 				}
 			}
 			resources = append(resources, &resource)
@@ -288,7 +291,7 @@ func convertExtensibletoReadableFormat(vendorExtensions openapi3.ExtensionProps)
 // 2nd bool represent if the vendor extension present.
 func resolveDisableSecurity(vendorExtensions openapi3.ExtensionProps) (bool, bool) {
 	extensions := convertExtensibletoReadableFormat(vendorExtensions)
-	if y, found := extensions[xWso2DisableSecurity]; found {
+	if y, found := extensions[constants.XWso2DisableSecurity]; found {
 		if val, ok := y.(bool); ok {
 			return val, found
 		}
@@ -301,7 +304,7 @@ func resolveDisableSecurity(vendorExtensions openapi3.ExtensionProps) (bool, boo
 func addDisableSecurityIfNotPresent(vendorExtensions openapi3.ExtensionProps, val bool) openapi3.ExtensionProps {
 	_, found := resolveDisableSecurity(vendorExtensions)
 	if !found {
-		vendorExtensions.Extensions[xWso2DisableSecurity] = val
+		vendorExtensions.Extensions[constants.XWso2DisableSecurity] = val
 	}
 	return vendorExtensions
 }
@@ -312,7 +315,7 @@ func addDisableSecurityIfNotPresent(vendorExtensions openapi3.ExtensionProps, va
 func GetXWso2Label(vendorExtensions openapi3.ExtensionProps) []string {
 	vendorExtensionsMap := convertExtensibletoReadableFormat(vendorExtensions)
 	var labelArray []string
-	if y, found := vendorExtensionsMap[xWso2Label]; found {
+	if y, found := vendorExtensionsMap[constants.XWso2Label]; found {
 		if val, ok := y.([]interface{}); ok {
 			for _, label := range val {
 				labelArray = append(labelArray, label.(string))

--- a/adapter/internal/oasparser/model/open_api_internal_test.go
+++ b/adapter/internal/oasparser/model/open_api_internal_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/wso2/product-microgateway/adapter/config"
 )
 
+// TestSetInfoOpenAPI for mgwSwagger.SetInfoOpenAPI()
 func TestSetInfoOpenAPI(t *testing.T) {
 	type setInfoTestItem struct {
 		input   openapi3.Swagger
@@ -76,6 +77,7 @@ func TestSetInfoOpenAPI(t *testing.T) {
 	}
 }
 
+// TestSetResourcesOpenAPI for setResourcesOpenAPI()
 func TestSetResourcesOpenAPI(t *testing.T) {
 	type setResourcesTestItem struct {
 		input   openapi3.Swagger
@@ -129,6 +131,7 @@ func TestSetResourcesOpenAPI(t *testing.T) {
 	}
 }
 
+// TestGetHostandBasepathandPort for getHostandBasepathandPort()
 func TestGetHostandBasepathandPort(t *testing.T) {
 	type setResourcesTestItem struct {
 		input   string
@@ -157,7 +160,7 @@ func TestGetHostandBasepathandPort(t *testing.T) {
 				URLType:  "https",
 				RawURL:   "https://petstore.io:8000/api/v2",
 			},
-			message: "when port is not provided", //here should find a way to readi configs in tests
+			message: "when port is not provided", //here should find a way to read configs in tests
 		},
 		{
 			input: "petstore.io:8000/api/v2",
@@ -177,7 +180,7 @@ func TestGetHostandBasepathandPort(t *testing.T) {
 		},
 	}
 	for _, item := range dataItems {
-		resultResources, err := getHostandBasepathandPort(item.input)
+		resultResources, err := getHTTPEndpoint(item.input)
 		assert.Equal(t, item.result, resultResources, item.message)
 		if resultResources != nil {
 			assert.Nil(t, err, "Error encountered when processing the endpoint")
@@ -187,6 +190,7 @@ func TestGetHostandBasepathandPort(t *testing.T) {
 	}
 }
 
+// TestGetXWso2Label for GetXWso2Label()
 func TestGetXWso2Label(t *testing.T) {
 	// TODO: (Vajira) add more test scenarios
 	//newLabels := GetXWso2Label(openAPIV3Struct.ExtensionProps)
@@ -198,11 +202,12 @@ func TestGetXWso2Label(t *testing.T) {
 
 	wso2Label := GetXWso2Label(swagger.ExtensionProps)
 
-	assert.NotNil(t, wso2Label, "Lable should at leaset be default")
+	assert.NotNil(t, wso2Label, "Label should at least be default")
 
 }
 
-func TestMalformedUrl(t *testing.T) {
+// TestMalformedURL for getHostandBasepathandPort()
+func TestMalformedURL(t *testing.T) {
 
 	suspectedRawUrls := []string{
 		"http://#de.abc.com:80/api",
@@ -218,7 +223,7 @@ func TestMalformedUrl(t *testing.T) {
 	}
 
 	for index := range suspectedRawUrls {
-		response, _ := getHostandBasepathandPort(suspectedRawUrls[index])
+		response, _ := getHTTPEndpoint(suspectedRawUrls[index])
 		assert.Nil(t, response)
 	}
 

--- a/adapter/internal/oasparser/model/project_structs.go
+++ b/adapter/internal/oasparser/model/project_structs.go
@@ -20,19 +20,13 @@ import "github.com/wso2/product-microgateway/adapter/pkg/synchronizer"
 
 // ProjectAPI contains the extracted from an API project zip
 type ProjectAPI struct {
-	APIYaml            APIYaml
-	APIEnvProps        map[string]synchronizer.APIEnvProps
-	Deployments        []Deployment
-	OpenAPIJsn         []byte
-	InterceptorCerts   []byte
-	APIType            string // read from api.yaml and formatted to upper case
-	APILifeCycleStatus string // read from api.yaml and formatted to upper case
-	OrganizationID     string // read from api.yaml or config
-
-	//UpstreamCerts cert filename -> cert bytes
-	UpstreamCerts map[string][]byte
-	//EndpointCerts url -> cert filename
-	EndpointCerts map[string]string
+	APIYaml          APIYaml
+	APIEnvProps      map[string]synchronizer.APIEnvProps
+	Deployments      []Deployment
+	APIDefinition    []byte
+	InterceptorCerts []byte
+	UpstreamCerts    map[string][]byte // cert filename -> cert bytes
+	EndpointCerts    map[string]string // cert url -> cert filename
 }
 
 // EndpointSecurity contains parameters of endpoint security at api.json
@@ -42,12 +36,6 @@ type EndpointSecurity struct {
 	Enabled          bool              `json:"enabled,omitempty" mapstructure:"enabled"`
 	Username         string            `json:"username,omitempty" mapstructure:"username"`
 	CustomParameters map[string]string `json:"customparameters,omitempty" mapstructure:"customparameters"`
-}
-
-// APIEndpointSecurity represents the structure of endpoint_security param in api.yaml
-type APIEndpointSecurity struct {
-	Production EndpointSecurity `json:"production,omitempty"`
-	Sandbox    EndpointSecurity `json:"sandbox,omitempty"`
 }
 
 // ApimMeta represents APIM meta information of files received from APIM
@@ -82,47 +70,4 @@ type EndpointCertificate struct {
 	Alias       string `json:"alias"`
 	Endpoint    string `json:"endpoint"`
 	Certificate string `json:"certificate"`
-}
-
-// APIYaml contains everything necessary to extract api.json/api.yaml file
-// To support both api.json and api.yaml we convert yaml to json and then use json.Unmarshal()
-// Therefore, the params are defined to support json.Unmarshal()
-type APIYaml struct {
-	ApimMeta
-	Data struct {
-		ID                         string   `json:"Id,omitempty"`
-		Name                       string   `json:"name,omitempty"`
-		Context                    string   `json:"context,omitempty"`
-		Version                    string   `json:"version,omitempty"`
-		RevisionID                 int      `json:"revisionId,omitempty"`
-		APIType                    string   `json:"type,omitempty"`
-		LifeCycleStatus            string   `json:"lifeCycleStatus,omitempty"`
-		EndpointImplementationType string   `json:"endpointImplementationType,omitempty"`
-		AuthorizationHeader        string   `json:"authorizationHeader,omitempty"`
-		SecurityScheme             []string `json:"securityScheme,omitempty"`
-		OrganizationID             string   `json:"organizationId,omitempty"`
-		EndpointConfig             struct {
-			EndpointType                 string              `json:"endpoint_type,omitempty"`
-			LoadBalanceAlgo              string              `json:"algoCombo,omitempty"`
-			LoadBalanceSessionManagement string              `json:"sessionManagement,omitempty"`
-			LoadBalanceSessionTimeOut    string              `json:"sessionTimeOut,omitempty"`
-			APIEndpointSecurity          APIEndpointSecurity `json:"endpoint_security,omitempty"`
-			RawProdEndpoints             interface{}         `json:"production_endpoints,omitempty"`
-			ProductionEndpoints          []EndpointInfo
-			ProductionFailoverEndpoints  []EndpointInfo `json:"production_failovers,omitempty"`
-			RawSandboxEndpoints          interface{}    `json:"sandbox_endpoints,omitempty"`
-			SandBoxEndpoints             []EndpointInfo
-			SandboxFailoverEndpoints     []EndpointInfo `json:"sandbox_failovers,omitempty"`
-			ImplementationStatus         string         `json:"implementation_status,omitempty"`
-		} `json:"endpointConfig,omitempty"`
-	} `json:"data"`
-}
-
-// EndpointInfo holds config values regards to the endpoint
-type EndpointInfo struct {
-	Endpoint string `json:"url,omitempty"`
-	Config   struct {
-		ActionDuration string `json:"actionDuration,omitempty"`
-		RetryTimeOut   string `json:"retryTimeOut,omitempty"`
-	} `json:"config,omitempty"`
 }

--- a/adapter/internal/oasparser/model/project_structs.go
+++ b/adapter/internal/oasparser/model/project_structs.go
@@ -1,0 +1,128 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package model
+
+import "github.com/wso2/product-microgateway/adapter/pkg/synchronizer"
+
+// ProjectAPI contains the extracted from an API project zip
+type ProjectAPI struct {
+	APIYaml            APIYaml
+	APIEnvProps        map[string]synchronizer.APIEnvProps
+	Deployments        []Deployment
+	OpenAPIJsn         []byte
+	InterceptorCerts   []byte
+	APIType            string // read from api.yaml and formatted to upper case
+	APILifeCycleStatus string // read from api.yaml and formatted to upper case
+	OrganizationID     string // read from api.yaml or config
+
+	//UpstreamCerts cert filename -> cert bytes
+	UpstreamCerts map[string][]byte
+	//EndpointCerts url -> cert filename
+	EndpointCerts map[string]string
+}
+
+// EndpointSecurity contains parameters of endpoint security at api.json
+type EndpointSecurity struct {
+	Password         string            `json:"password,omitempty" mapstructure:"password"`
+	Type             string            `json:"type,omitempty" mapstructure:"type"`
+	Enabled          bool              `json:"enabled,omitempty" mapstructure:"enabled"`
+	Username         string            `json:"username,omitempty" mapstructure:"username"`
+	CustomParameters map[string]string `json:"customparameters,omitempty" mapstructure:"customparameters"`
+}
+
+// APIEndpointSecurity represents the structure of endpoint_security param in api.yaml
+type APIEndpointSecurity struct {
+	Production EndpointSecurity `json:"production,omitempty"`
+	Sandbox    EndpointSecurity `json:"sandbox,omitempty"`
+}
+
+// ApimMeta represents APIM meta information of files received from APIM
+type ApimMeta struct {
+	Type    string `yaml:"type" json:"type"`
+	Version string `yaml:"version" json:"version"`
+}
+
+// DeploymentEnvironments represents content of deployment_environments.yaml file
+// of an API_CTL Project
+type DeploymentEnvironments struct {
+	ApimMeta
+	Data []Deployment `yaml:"data"`
+}
+
+// Deployment represents deployment information of an API_CTL project
+type Deployment struct {
+	DisplayOnDevportal    bool   `yaml:"displayOnDevportal"`
+	DeploymentVhost       string `yaml:"deploymentVhost"`
+	DeploymentEnvironment string `yaml:"deploymentEnvironment"`
+}
+
+// EndpointCertificatesDetails represents content of endpoint_certificates.yaml file
+// of an API_CTL Project
+type EndpointCertificatesDetails struct {
+	ApimMeta
+	Data []EndpointCertificate `json:"data"`
+}
+
+// EndpointCertificate represents certificate information of an API_CTL project
+type EndpointCertificate struct {
+	Alias       string `json:"alias"`
+	Endpoint    string `json:"endpoint"`
+	Certificate string `json:"certificate"`
+}
+
+// APIYaml contains everything necessary to extract api.json/api.yaml file
+// To support both api.json and api.yaml we convert yaml to json and then use json.Unmarshal()
+// Therefore, the params are defined to support json.Unmarshal()
+type APIYaml struct {
+	ApimMeta
+	Data struct {
+		ID                         string   `json:"Id,omitempty"`
+		Name                       string   `json:"name,omitempty"`
+		Context                    string   `json:"context,omitempty"`
+		Version                    string   `json:"version,omitempty"`
+		RevisionID                 int      `json:"revisionId,omitempty"`
+		APIType                    string   `json:"type,omitempty"`
+		LifeCycleStatus            string   `json:"lifeCycleStatus,omitempty"`
+		EndpointImplementationType string   `json:"endpointImplementationType,omitempty"`
+		AuthorizationHeader        string   `json:"authorizationHeader,omitempty"`
+		SecurityScheme             []string `json:"securityScheme,omitempty"`
+		OrganizationID             string   `json:"organizationId,omitempty"`
+		EndpointConfig             struct {
+			EndpointType                 string              `json:"endpoint_type,omitempty"`
+			LoadBalanceAlgo              string              `json:"algoCombo,omitempty"`
+			LoadBalanceSessionManagement string              `json:"sessionManagement,omitempty"`
+			LoadBalanceSessionTimeOut    string              `json:"sessionTimeOut,omitempty"`
+			APIEndpointSecurity          APIEndpointSecurity `json:"endpoint_security,omitempty"`
+			RawProdEndpoints             interface{}         `json:"production_endpoints,omitempty"`
+			ProductionEndpoints          []EndpointInfo
+			ProductionFailoverEndpoints  []EndpointInfo `json:"production_failovers,omitempty"`
+			RawSandboxEndpoints          interface{}    `json:"sandbox_endpoints,omitempty"`
+			SandBoxEndpoints             []EndpointInfo
+			SandboxFailoverEndpoints     []EndpointInfo `json:"sandbox_failovers,omitempty"`
+			ImplementationStatus         string         `json:"implementation_status,omitempty"`
+		} `json:"endpointConfig,omitempty"`
+	} `json:"data"`
+}
+
+// EndpointInfo holds config values regards to the endpoint
+type EndpointInfo struct {
+	Endpoint string `json:"url,omitempty"`
+	Config   struct {
+		ActionDuration string `json:"actionDuration,omitempty"`
+		RetryTimeOut   string `json:"retryTimeOut,omitempty"`
+	} `json:"config,omitempty"`
+}

--- a/adapter/internal/oasparser/model/project_structs.go
+++ b/adapter/internal/oasparser/model/project_structs.go
@@ -29,26 +29,12 @@ type ProjectAPI struct {
 	EndpointCerts    map[string]string // cert url -> cert filename
 }
 
-// EndpointSecurity contains parameters of endpoint security at api.json
-type EndpointSecurity struct {
-	Password         string            `json:"password,omitempty" mapstructure:"password"`
-	Type             string            `json:"type,omitempty" mapstructure:"type"`
-	Enabled          bool              `json:"enabled,omitempty" mapstructure:"enabled"`
-	Username         string            `json:"username,omitempty" mapstructure:"username"`
-	CustomParameters map[string]string `json:"customparameters,omitempty" mapstructure:"customparameters"`
-}
-
-// ApimMeta represents APIM meta information of files received from APIM
-type ApimMeta struct {
-	Type    string `yaml:"type" json:"type"`
-	Version string `yaml:"version" json:"version"`
-}
-
 // DeploymentEnvironments represents content of deployment_environments.yaml file
 // of an API_CTL Project
 type DeploymentEnvironments struct {
-	ApimMeta
-	Data []Deployment `yaml:"data"`
+	Type    string       `yaml:"type" json:"type"`
+	Version string       `yaml:"version" json:"version"`
+	Data    []Deployment `yaml:"data"`
 }
 
 // Deployment represents deployment information of an API_CTL project
@@ -61,8 +47,9 @@ type Deployment struct {
 // EndpointCertificatesDetails represents content of endpoint_certificates.yaml file
 // of an API_CTL Project
 type EndpointCertificatesDetails struct {
-	ApimMeta
-	Data []EndpointCertificate `json:"data"`
+	Type    string                `yaml:"type" json:"type"`
+	Version string                `yaml:"version" json:"version"`
+	Data    []EndpointCertificate `json:"data"`
 }
 
 // EndpointCertificate represents certificate information of an API_CTL project

--- a/adapter/internal/oasparser/model/resource.go
+++ b/adapter/internal/oasparser/model/resource.go
@@ -22,6 +22,8 @@ package model
 import (
 	"regexp"
 	"sort"
+
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 )
 
 // Resource represents the object structure holding the information related to the
@@ -91,8 +93,8 @@ func (resource *Resource) GetMethodList() []string {
 func CreateMinimalDummyResourceForTests(path string, methods []*Operation, id string, productionUrls,
 	sandboxUrls []Endpoint) Resource {
 
-	prodEndpints := generateEndpointCluster(prodClustersConfigNamePrefix, productionUrls, LoadBalance)
-	sandboxEndpints := generateEndpointCluster(sandClustersConfigNamePrefix, sandboxUrls, LoadBalance)
+	prodEndpints := generateEndpointCluster(constants.ProdClustersConfigNamePrefix, productionUrls, constants.LoadBalance)
+	sandboxEndpints := generateEndpointCluster(constants.SandClustersConfigNamePrefix, sandboxUrls, constants.LoadBalance)
 
 	return Resource{
 		path:                path,

--- a/adapter/internal/oasparser/model/resource_test.go
+++ b/adapter/internal/oasparser/model/resource_test.go
@@ -14,6 +14,7 @@
  *  limitations under the License.
  *
  */
+
 package model
 
 import (
@@ -22,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestSortResources for SortResources()
 func TestSortResources(t *testing.T) {
 	resources := getResources()
 	sortedPaths := []string{

--- a/adapter/internal/oasparser/model/swagger.go
+++ b/adapter/internal/oasparser/model/swagger.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-openapi/spec"
 	"github.com/google/uuid"
 	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 )
 
 // SetInfoSwagger populates the MgwSwagger object with the properties within the openAPI v2
@@ -45,7 +46,7 @@ func (swagger *MgwSwagger) SetInfoSwagger(swagger2 spec.Swagger) error {
 	swagger.securityScheme = setSecurityDefinitions(swagger2)
 	swagger.security = swagger2.Security
 	swagger.resources = setResourcesSwagger(swagger2)
-	swagger.apiType = HTTP
+	swagger.apiType = constants.HTTP
 	swagger.xWso2Basepath = swagger2.BasePath
 	// According to the definition, multiple schemes can be mentioned. Since the microgateway can assign only one scheme
 	// https is prioritized over http. If it is ws or wss, the microgateway will print an error.
@@ -70,7 +71,8 @@ func (swagger *MgwSwagger) SetInfoSwagger(swagger2 spec.Swagger) error {
 		endpoint, err := getHostandBasepathandPort(urlScheme + swagger2.Host + swagger2.BasePath)
 		if err == nil {
 			productionEndpoints := append([]Endpoint{}, *endpoint)
-			swagger.productionEndpoints = generateEndpointCluster(prodClustersConfigNamePrefix, productionEndpoints, LoadBalance)
+			swagger.productionEndpoints = generateEndpointCluster(constants.ProdClustersConfigNamePrefix,
+				productionEndpoints, constants.LoadBalance)
 			swagger.sandboxEndpoints = nil
 		} else {
 			return errors.New("error encountered when parsing the endpoint")
@@ -87,10 +89,10 @@ func setResourcesSwagger(swagger2 spec.Swagger) []*Resource {
 	// resourve level, if it's not present at resource level using "addResourceLevelDisableSecurity"
 	if swagger2.Paths != nil {
 		for path, pathItem := range swagger2.Paths.Paths {
-			disableSecurity, found := swagger2.VendorExtensible.Extensions.GetBool(xWso2DisableSecurity)
+			disableSecurity, found := swagger2.VendorExtensible.Extensions.GetBool(constants.XWso2DisableSecurity)
 			// Checks for resource level security, if security is disabled in resource level,
 			// below code segment will override above two variable values (disableSecurity & found)
-			disableResourceLevelSecurity, foundInResourceLevel := pathItem.Extensions.GetBool(xWso2DisableSecurity)
+			disableResourceLevelSecurity, foundInResourceLevel := pathItem.Extensions.GetBool(constants.XWso2DisableSecurity)
 			if foundInResourceLevel {
 				logger.LoggerOasparser.Infof("x-wso2-disable-security extension is available in the API: %v %v's resource %v.",
 					swagger2.Info.Title, swagger2.Info.Version, path)
@@ -179,8 +181,8 @@ func setSecurityDefinitions(swagger2 spec.Swagger) []SecurityScheme {
 // This methods adds x-wso2-disable-security vendor extension
 // if it's not present in the given vendor extensions.
 func addResourceLevelDisableSecurity(v *spec.VendorExtensible, enable bool) {
-	if _, found := v.Extensions.GetBool(xWso2DisableSecurity); !found {
-		v.AddExtension(xWso2DisableSecurity, enable)
+	if _, found := v.Extensions.GetBool(constants.XWso2DisableSecurity); !found {
+		v.AddExtension(constants.XWso2DisableSecurity, enable)
 	}
 }
 

--- a/adapter/internal/oasparser/model/swagger.go
+++ b/adapter/internal/oasparser/model/swagger.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 
 	"github.com/go-openapi/spec"
-	"github.com/google/uuid"
 	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 )
@@ -43,9 +42,9 @@ func (swagger *MgwSwagger) SetInfoSwagger(swagger2 spec.Swagger) error {
 		swagger.version = swagger2.Info.Version
 	}
 	swagger.vendorExtensions = swagger2.VendorExtensible.Extensions
-	swagger.securityScheme = setSecurityDefinitions(swagger2)
+	swagger.securityScheme = getSecurityDefinitions(swagger2)
 	swagger.security = swagger2.Security
-	swagger.resources = setResourcesSwagger(swagger2)
+	swagger.resources = getResourcesSwagger(swagger2)
 	swagger.apiType = constants.HTTP
 	swagger.xWso2Basepath = swagger2.BasePath
 	// According to the definition, multiple schemes can be mentioned. Since the microgateway can assign only one scheme
@@ -68,7 +67,7 @@ func (swagger *MgwSwagger) SetInfoSwagger(swagger2 spec.Swagger) error {
 					swagger2.Info.Title, swagger2.Info.Version)
 			}
 		}
-		endpoint, err := getHostandBasepathandPort(urlScheme + swagger2.Host + swagger2.BasePath)
+		endpoint, err := getHTTPEndpoint(urlScheme + swagger2.Host + swagger2.BasePath)
 		if err == nil {
 			productionEndpoints := append([]Endpoint{}, *endpoint)
 			swagger.productionEndpoints = generateEndpointCluster(constants.ProdClustersConfigNamePrefix,
@@ -81,8 +80,8 @@ func (swagger *MgwSwagger) SetInfoSwagger(swagger2 spec.Swagger) error {
 	return nil
 }
 
-// setResourcesSwagger sets swagger (openapi v2) paths as mgwSwagger resources.
-func setResourcesSwagger(swagger2 spec.Swagger) []*Resource {
+// getResourcesSwagger sets swagger (openapi v2) paths as mgwSwagger resources.
+func getResourcesSwagger(swagger2 spec.Swagger) []*Resource {
 	var resources []*Resource
 	// Check if the "x-wso2-disable-security" vendor ext is present at the API level.
 	// If API level vendor ext is present, then the same key:value should be added to
@@ -158,7 +157,7 @@ func setResourcesSwagger(swagger2 spec.Swagger) []*Resource {
 				methodFound = true
 			}
 			if methodFound {
-				resource := setOperationSwagger(path, methodsArray, pathItem)
+				resource := generateResource(path, methodsArray, pathItem.Extensions)
 				resources = append(resources, &resource)
 			}
 		}
@@ -167,14 +166,13 @@ func setResourcesSwagger(swagger2 spec.Swagger) []*Resource {
 }
 
 // Sets security definitions defined in swagger 2 format.
-func setSecurityDefinitions(swagger2 spec.Swagger) []SecurityScheme {
+func getSecurityDefinitions(swagger2 spec.Swagger) []SecurityScheme {
 	var securitySchemes []SecurityScheme
 
 	for key, val := range swagger2.SecurityDefinitions {
 		scheme := SecurityScheme{DefinitionName: key, Type: val.Type, Name: val.Name, In: val.In}
 		securitySchemes = append(securitySchemes, scheme)
 	}
-	logger.LoggerOasparser.Debugf("Security schemes in setSecurityDefinitions  %v:", securitySchemes)
 	return securitySchemes
 }
 
@@ -183,21 +181,5 @@ func setSecurityDefinitions(swagger2 spec.Swagger) []SecurityScheme {
 func addResourceLevelDisableSecurity(v *spec.VendorExtensible, enable bool) {
 	if _, found := v.Extensions.GetBool(constants.XWso2DisableSecurity); !found {
 		v.AddExtension(constants.XWso2DisableSecurity, enable)
-	}
-}
-
-func setOperationSwagger(path string, methods []*Operation, pathItem spec.PathItem) Resource {
-	return Resource{
-		path:    path,
-		methods: methods,
-		// TODO: (VirajSalaka) This will not solve the actual problem when incremental Xds is introduced (used for cluster names)
-		iD: uuid.New().String(),
-		// PathItem object in swagger 2 specification does not contain summary and description properties
-		summary:     "",
-		description: "",
-		//schemes:          operation.Schemes,
-		//tags:             operation.Tags,
-		//security:         operation.Security,
-		vendorExtensions: pathItem.VendorExtensible.Extensions,
 	}
 }

--- a/adapter/internal/oasparser/model/swagger_internal_test.go
+++ b/adapter/internal/oasparser/model/swagger_internal_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestSetInfoSwagger for mgwSwagger.SetInfoSwagger()
 func TestSetInfoSwagger(t *testing.T) {
 	type setInfoTestItem struct {
 		input   spec.Swagger
@@ -81,6 +82,7 @@ func TestSetInfoSwagger(t *testing.T) {
 	}
 }
 
+// TestSetResourcesSwagger for setResourcesSwagger()
 func TestSetResourcesSwagger(t *testing.T) {
 	type setResourcesTestItem struct {
 		input   spec.Swagger
@@ -128,7 +130,7 @@ func TestSetResourcesSwagger(t *testing.T) {
 		},
 	}
 	for _, item := range dataItems {
-		resultResources := setResourcesSwagger(item.input)
+		resultResources := getResourcesSwagger(item.input)
 		if item.result != nil {
 			assert.Equal(t, item.result[0].path, resultResources[0].GetPath(), item.message)
 			assert.Equal(t, item.result[0].methods, resultResources[0].GetMethod(), item.message)

--- a/adapter/internal/oasparser/model/swagger_test.go
+++ b/adapter/internal/oasparser/model/swagger_test.go
@@ -23,7 +23,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wso2/product-microgateway/adapter/config"
-	model "github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/utills"
 )
 
@@ -44,7 +45,7 @@ func TestSetInfoSwaggerWebSocket(t *testing.T) {
 	err = json.Unmarshal(apiJsn, &apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 
 	dataItems := []setInfoSwaggerWebSocketTestItem{

--- a/adapter/internal/oasparser/model/swagger_test.go
+++ b/adapter/internal/oasparser/model/swagger_test.go
@@ -14,7 +14,8 @@
  *  limitations under the License.
  *
  */
-package model_test
+
+package model
 
 import (
 	"encoding/json"
@@ -23,14 +24,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wso2/product-microgateway/adapter/config"
-	"github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/utills"
 )
 
+// TestSetInfoSwaggerWebSocket for mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml)
 func TestSetInfoSwaggerWebSocket(t *testing.T) {
 
 	type setInfoSwaggerWebSocketTestItem struct {
-		input   model.MgwSwagger
+		input   MgwSwagger
 		apiData map[string]interface{}
 	}
 
@@ -40,10 +41,10 @@ func TestSetInfoSwaggerWebSocket(t *testing.T) {
 	apiJsn, conversionErr := utills.ToJSON(apiYamlByteArr)
 	assert.Nil(t, conversionErr, "YAML to JSON conversion error : %v"+apiYamlFilePath)
 
-	var apiYaml model.APIYaml
+	var apiYaml APIYaml
 	err = json.Unmarshal(apiJsn, &apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
-	var mgwSwagger model.MgwSwagger
+	var mgwSwagger MgwSwagger
 	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 
@@ -81,11 +82,12 @@ func TestSetInfoSwaggerWebSocket(t *testing.T) {
 
 }
 
+// TestValidate for mgwSwagger.Validate()
 func TestValidate(t *testing.T) {
 	openapiFilePath := config.GetMgwHome() + "/../adapter/test-resources/envoycodegen/openapi_with_prod_sand_extensions.yaml"
 	openapiByteArr, err := ioutil.ReadFile(openapiFilePath)
 	assert.Nil(t, err, "Error while reading the openapi file : "+openapiFilePath)
-	mgwSwaggerForOpenapi := model.MgwSwagger{}
+	mgwSwaggerForOpenapi := MgwSwagger{}
 	err = mgwSwaggerForOpenapi.GetMgwSwagger(openapiByteArr)
 	assert.Nil(t, err, "Error should not be present when openAPI definition is converted to a MgwSwagger object")
 	err = mgwSwaggerForOpenapi.Validate()

--- a/adapter/internal/oasparser/model/swagger_test.go
+++ b/adapter/internal/oasparser/model/swagger_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wso2/product-microgateway/adapter/config"
-	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/utills"
 )
@@ -45,7 +44,7 @@ func TestSetInfoSwaggerWebSocket(t *testing.T) {
 	err = json.Unmarshal(apiJsn, &apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 
 	dataItems := []setInfoSwaggerWebSocketTestItem{

--- a/adapter/internal/oasparser/operator/operator.go
+++ b/adapter/internal/oasparser/operator/operator.go
@@ -40,7 +40,7 @@ func GetOpenAPIVersionAndJSONContent(apiContent []byte) (string, []byte, error) 
 		logger.LoggerOasparser.Error("Error converting api file to json:", err)
 		return "", apiContent, err
 	}
-	swaggerVersion := utills.FindSwaggerVersion(apiJsn)
+	swaggerVersion := utills.FindAPIDefinitionVersion(apiJsn)
 	return swaggerVersion, apiJsn, nil
 }
 

--- a/adapter/internal/oasparser/operator/operator_test.go
+++ b/adapter/internal/oasparser/operator/operator_test.go
@@ -239,14 +239,14 @@ func testGetMgwSwaggerWebSocket(t *testing.T, apiYamlFilePath string) {
 		productionEndpoints := mgwSwagger.GetProdEndpoints().Endpoints
 		productionEndpoint := productionEndpoints[0]
 		assert.Equal(t, productionEndpoint.Host, "echo.websocket.org", "mgwSwagger production endpoint host mismatch")
-		assert.Equal(t, productionEndpoint.Basepath, "/", "mgwSwagger production endpoint basepath mistmatch")
+		assert.Equal(t, productionEndpoint.Basepath, "", "mgwSwagger production endpoint basepath mistmatch")
 		assert.Equal(t, productionEndpoint.URLType, "ws", "mgwSwagger production endpoint URLType mismatch")
 		var port uint32 = 80
 		assert.Equal(t, productionEndpoint.Port, port, "mgwSwagger production endpoint port mismatch")
 		sandboxEndpoints := mgwSwagger.GetSandEndpoints().Endpoints
 		sandboxEndpoint := sandboxEndpoints[0]
 		assert.Equal(t, sandboxEndpoint.Host, "echo.websocket.org", "mgwSwagger sandbox endpoint host mismatch")
-		assert.Equal(t, sandboxEndpoint.Basepath, "/", "mgwSwagger sandbox endpoint basepath mistmatch")
+		assert.Equal(t, sandboxEndpoint.Basepath, "", "mgwSwagger sandbox endpoint basepath mistmatch")
 		assert.Equal(t, sandboxEndpoint.URLType, "ws", "mgwSwagger sandbox endpoint URLType mismatch")
 		assert.Equal(t, sandboxEndpoint.Port, port, "mgwSwagger sandbox endpoint port mismatch")
 	}
@@ -259,7 +259,7 @@ func testGetMgwSwaggerWebSocket(t *testing.T, apiYamlFilePath string) {
 		productionEndpoint := productionEndpoints[0]
 		var port uint32 = 80
 		assert.Equal(t, productionEndpoint.Host, "echo.websocket.org", "mgwSwagger production endpoint host mismatch")
-		assert.Equal(t, productionEndpoint.Basepath, "/", "mgwSwagger production endpoint basepath mistmatch")
+		assert.Equal(t, productionEndpoint.Basepath, "", "mgwSwagger production endpoint basepath mistmatch")
 		assert.Equal(t, productionEndpoint.URLType, "ws", "mgwSwagger production endpoint URLType mismatch")
 		assert.Equal(t, productionEndpoint.Port, port, "mgwSwagger production endpoint port mismatch")
 		sandboxEndpoints := mgwSwagger.GetSandEndpoints()
@@ -275,7 +275,7 @@ func testGetMgwSwaggerWebSocket(t *testing.T, apiYamlFilePath string) {
 		sandboxEndpoints := mgwSwagger.GetSandEndpoints().Endpoints
 		sandboxEndpoint := sandboxEndpoints[0]
 		assert.Equal(t, sandboxEndpoint.Host, "echo.websocket.org", "mgwSwagger sandbox endpoint host mismatch")
-		assert.Equal(t, sandboxEndpoint.Basepath, "/", "mgwSwagger sandbox endpoint basepath mistmatch")
+		assert.Equal(t, sandboxEndpoint.Basepath, "", "mgwSwagger sandbox endpoint basepath mistmatch")
 		assert.Equal(t, sandboxEndpoint.URLType, "ws", "mgwSwagger sandbox endpoint URLType mismatch")
 		assert.Equal(t, sandboxEndpoint.Port, port, "mgwSwagger sandbox endpoint port mismatch")
 		productionEndpoints := mgwSwagger.GetProdEndpoints()

--- a/adapter/internal/oasparser/operator/operator_test.go
+++ b/adapter/internal/oasparser/operator/operator_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wso2/product-microgateway/adapter/config"
+	"github.com/wso2/product-microgateway/adapter/internal/api/deployer"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/operator"
@@ -171,22 +172,18 @@ func testGetOpenAPIVersionAndJSONContent(t *testing.T, apiYamlFilePath string) {
 
 	apiYamlByteArr, err := ioutil.ReadFile(apiYamlFilePath)
 	assert.Nil(t, err, "Error while reading the yaml file : %v"+apiYamlFilePath)
-	swaggerVerison, apiJsn, err := operator.GetOpenAPIVersionAndJSONContent(apiYamlByteArr)
+	versionOfAPI, apiJsn, err := operator.GetOpenAPIVersionAndJSONContent(apiYamlByteArr)
 
-	assert.NotNil(t, swaggerVerison, "Swagger version should not be empty")
+	assert.NotNil(t, versionOfAPI, "Swagger version should not be empty")
 	assert.NotNil(t, apiJsn, "Swagger version should not be empty")
 
 	// Check for swagger version
 	if strings.HasSuffix(apiYamlFilePath, "/openapi.yaml") {
-		assert.Equal(t, swaggerVerison, "3", "OpenAPI swagger version mismatch")
-	}
-
-	if strings.HasSuffix(apiYamlFilePath, "/api.yaml") {
-		assert.Equal(t, swaggerVerison, "2", "Default swaggerVersion should be 2")
+		assert.Equal(t, constants.OpenAPI3, versionOfAPI, "OpenAPI version mismatch")
 	}
 
 	if strings.HasSuffix(apiYamlFilePath, "/openapi_with_prod_sand_extensions.yaml") {
-		assert.Equal(t, swaggerVerison, "2", "swaggerVersion mismatch")
+		assert.Equal(t, constants.Swagger2, versionOfAPI, "swaggerVersion mismatch")
 	}
 
 	//validate apiJsn
@@ -229,15 +226,10 @@ func testGetOpenAPIV3Struct(t *testing.T, apiYamlFilePath string) {
 func testGetMgwSwaggerWebSocket(t *testing.T, apiYamlFilePath string) {
 	apiYamlByteArr, err := ioutil.ReadFile(apiYamlFilePath)
 	assert.Nil(t, err, "Error while reading the api.yaml file : %v"+apiYamlFilePath)
-	apiJsn, conversionErr := utills.ToJSON(apiYamlByteArr)
-	assert.Nil(t, conversionErr, "YAML to JSON conversion error : %v"+apiYamlFilePath)
-
-	var apiYaml model.APIYaml
-	err = json.Unmarshal(apiJsn, &apiYaml)
-	apiYaml.PopulateEndpointsInfo()
-	assert.Nil(t, err, "Error occured while parsing api.yaml")
+	apiYaml, err := deployer.ExtractAPIYaml(apiYamlByteArr)
+	assert.Nil(t, err, "Error occurred while processing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	if strings.HasSuffix(apiYamlFilePath, "api.yaml") {
 		assert.Equal(t, mgwSwagger.GetAPIType(), "WS", "API type for websocket mismatch")

--- a/adapter/internal/oasparser/operator/operator_test.go
+++ b/adapter/internal/oasparser/operator/operator_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wso2/product-microgateway/adapter/config"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/operator"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/utills"
@@ -233,10 +234,10 @@ func testGetMgwSwaggerWebSocket(t *testing.T, apiYamlFilePath string) {
 
 	var apiYaml model.APIYaml
 	err = json.Unmarshal(apiJsn, &apiYaml)
-	apiYaml = model.PopulateEndpointsInfo(apiYaml)
+	apiYaml.PopulateEndpointsInfo()
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	if strings.HasSuffix(apiYamlFilePath, "api.yaml") {
 		assert.Equal(t, mgwSwagger.GetAPIType(), "WS", "API type for websocket mismatch")

--- a/adapter/internal/oasparser/utills/open_api_utills_test.go
+++ b/adapter/internal/oasparser/utills/open_api_utills_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/utills"
 )
 
@@ -38,7 +39,7 @@ func TestFindSwaggerVersion(t *testing.T) {
 				"basepath": "api/v2"
 							
 				}`,
-			result:  "2",
+			result:  constants.Swagger2,
 			message: "when swagger version is 2",
 		},
 		{
@@ -48,7 +49,7 @@ func TestFindSwaggerVersion(t *testing.T) {
 				"basepath": "api/v2"
 							
 				}`,
-			result:  "3",
+			result:  constants.OpenAPI3,
 			message: "when openAPi version is 3",
 		},
 		{
@@ -57,14 +58,14 @@ func TestFindSwaggerVersion(t *testing.T) {
 				"basepath": "api/v2"
 							
 				}`,
-			result:  "2",
+			result:  constants.NotDefined,
 			message: "when openAPi version is not provided",
 		},
 	}
 
 	for _, item := range dataItems {
 		apiJsn, _ := utills.ToJSON([]byte(item.inputSwagger))
-		resultswaggerVerison := utills.FindSwaggerVersion(apiJsn)
+		resultswaggerVerison := utills.FindAPIDefinitionVersion(apiJsn)
 
 		assert.Equal(t, item.result, resultswaggerVerison, item.message)
 	}

--- a/adapter/internal/synchronizer/apis_fetcher.go
+++ b/adapter/internal/synchronizer/apis_fetcher.go
@@ -111,7 +111,7 @@ func PushAPIProjects(payload []byte, environments []string) error {
 	if conf.GlobalAdapter.Enabled && len(deploymentList) > 0 {
 		notifier.SendRevisionUpdate(deploymentList)
 	}
-	logger.LoggerSync.Infof("Successfully deployed %d API/s", len(zipReader.File)-1)
+	logger.LoggerSync.Infof("Successfully deployed %d API/s", len(deploymentList))
 	// Error nil for successful execution
 	return nil
 }

--- a/adapter/internal/synchronizer/apis_fetcher.go
+++ b/adapter/internal/synchronizer/apis_fetcher.go
@@ -29,13 +29,13 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/wso2/product-microgateway/adapter/config"
-	"github.com/wso2/product-microgateway/adapter/internal/notifier"
 	"github.com/wso2/product-microgateway/adapter/pkg/health"
-
-	apiServer "github.com/wso2/product-microgateway/adapter/internal/api"
-	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
 	sync "github.com/wso2/product-microgateway/adapter/pkg/synchronizer"
+
+	"github.com/wso2/product-microgateway/adapter/config"
+	"github.com/wso2/product-microgateway/adapter/internal/api/deployer"
+	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
+	"github.com/wso2/product-microgateway/adapter/internal/notifier"
 )
 
 const (
@@ -100,7 +100,7 @@ func PushAPIProjects(payload []byte, environments []string) error {
 		// Pass the byte slice for the XDS APIs to push it to the enforcer and router
 		// TODO: (renuka) optimize applying API project, update maps one by one and apply xds once
 		var deployedRevisionList []*notifier.DeployedAPIRevision
-		deployedRevisionList, err = apiServer.ApplyAPIProjectFromAPIM(apiFileData, vhostToEnvsMap, envProps)
+		deployedRevisionList, err = deployer.ApplyAPIProjectFromAPIM(apiFileData, vhostToEnvsMap, envProps)
 		if err != nil {
 			logger.LoggerSync.Errorf("Error occurred while applying project %v", err)
 		} else if deployedRevisionList != nil {

--- a/adapter/test-resources/envoycodegen/asyncapi_websocket.yaml
+++ b/adapter/test-resources/envoycodegen/asyncapi_websocket.yaml
@@ -1,0 +1,33 @@
+asyncapi: 2.0.0
+info:
+  title: WebSocket
+  version: "1"
+servers:
+  production:
+    url: wss://ws.ifelse.io:443
+    protocol: ws
+channels:
+  /notifications:
+    parameters: {}
+    publish: {}
+    subscribe:
+      x-uri-mapping: /notifications
+      x-scopes:
+       - abc
+  /rooms/{roomID}:
+    parameters:
+      roomID:
+        description: ""
+        schema:
+          type: string
+    subscribe:
+      x-uri-mapping: /rooms?room={uri.var.roomID}
+components:
+  securitySchemes:
+    oauth2:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://localhost:9999
+          scopes: {}
+          x-scopes-bindings: {}


### PR DESCRIPTION
### Purpose
-  Divide api.impl into mutiple files as process, standalone, eventhub
    - eventhub - contains methods for APIM mode functions
    - standalone - contains methods for standalone mode functions
    - process - is used by methods used by both `eventhub` and `standalone` functions
- Move model constants to constants package. This does not include the constants that are used for reading API deployment files. Only includes constants that are used in multiple places in the adapter
- move APIYaml struct to apiyaml.go and rename types.go to project_structs.go which contains structs for files that does not describe an API
- support reading AsycnAPI definitions and populating mgwSwagger object accordingly
- move common mgwSwagger methods to mgw_common.go
    - common for OpenAPI and AsyncAPI
    - common for API, resource and/or operation
- Add and update unit tests



### Issues
Fixes https://github.com/wso2/product-microgateway/issues/2609

### Automation tests
 - Unit tests added: Yes
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
