### PR TITLE
Move constants to a seperate package

### DIFF
--- a/adapter/internal/api/apis_impl.go
+++ b/adapter/internal/api/apis_impl.go
@@ -33,8 +33,8 @@ import (
 	xds "github.com/wso2/product-microgateway/adapter/internal/discovery/xds"
 	"github.com/wso2/product-microgateway/adapter/internal/loggers"
 	"github.com/wso2/product-microgateway/adapter/internal/notifier"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
-	mgw "github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
 	"github.com/wso2/product-microgateway/adapter/pkg/synchronizer"
 )
 
@@ -65,7 +65,7 @@ const (
 // extractAPIProject accepts the API project as a zip file and returns the extracted content.
 // The apictl project must be in zipped format.
 // API type is decided by the type field in the api.yaml file.
-func extractAPIProject(payload []byte) (apiProject mgw.ProjectAPI, err error) {
+func extractAPIProject(payload []byte) (apiProject model.ProjectAPI, err error) {
 	zipReader, err := zip.NewReader(bytes.NewReader(payload), int64(len(payload)))
 
 	if err != nil {
@@ -109,7 +109,7 @@ func ProcessMountedAPIProjects() (err error) {
 
 	for _, apiProjectFile := range files {
 		if apiProjectFile.IsDir() {
-			apiProject := mgw.ProjectAPI{
+			apiProject := model.ProjectAPI{
 				EndpointCerts: make(map[string]string),
 				UpstreamCerts: make(map[string][]byte),
 			}
@@ -162,7 +162,7 @@ func ProcessMountedAPIProjects() (err error) {
 	return nil
 }
 
-func validateAndUpdateXds(apiProject mgw.ProjectAPI, override *bool) (err error) {
+func validateAndUpdateXds(apiProject model.ProjectAPI, override *bool) (err error) {
 	apiYaml := apiProject.APIYaml.Data
 	apiProject.OrganizationID = config.GetControlPlaneConnectedTenantDomain()
 
@@ -185,7 +185,7 @@ func validateAndUpdateXds(apiProject mgw.ProjectAPI, override *bool) (err error)
 	// environment
 	if apiProject.Deployments == nil {
 		vhost, _, _ := config.GetDefaultVhost(config.DefaultGatewayName)
-		deployment := mgw.Deployment{
+		deployment := model.Deployment{
 			DisplayOnDevportal:    true,
 			DeploymentEnvironment: config.DefaultGatewayName,
 			DeploymentVhost:       vhost,
@@ -207,7 +207,7 @@ func validateAndUpdateXds(apiProject mgw.ProjectAPI, override *bool) (err error)
 		if exists {
 			loggers.LoggerAPI.Infof("Error creating new API. API %v:%v already exists.",
 				apiYaml.Name, apiYaml.Version)
-			return errors.New(mgw.AlreadyExists)
+			return errors.New(constants.AlreadyExists)
 		}
 	}
 	vhostToEnvsMap := make(map[string][]string)

--- a/adapter/internal/api/restserver/config_restapi.go
+++ b/adapter/internal/api/restserver/config_restapi.go
@@ -27,12 +27,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/wso2/product-microgateway/adapter/internal/discovery/xds"
-
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
+
+	"github.com/wso2/product-microgateway/adapter/pkg/health"
+	"github.com/wso2/product-microgateway/adapter/pkg/tlsutils"
 
 	"github.com/wso2/product-microgateway/adapter/config"
 	apiServer "github.com/wso2/product-microgateway/adapter/internal/api"
@@ -42,10 +43,9 @@ import (
 	"github.com/wso2/product-microgateway/adapter/internal/api/restserver/operations/api_individual"
 	"github.com/wso2/product-microgateway/adapter/internal/api/restserver/operations/authorization"
 	"github.com/wso2/product-microgateway/adapter/internal/auth"
+	"github.com/wso2/product-microgateway/adapter/internal/discovery/xds"
 	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
-	constants "github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
-	"github.com/wso2/product-microgateway/adapter/pkg/health"
-	"github.com/wso2/product-microgateway/adapter/pkg/tlsutils"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 )
 
 var (

--- a/adapter/internal/discovery/xds/server.go
+++ b/adapter/internal/discovery/xds/server.go
@@ -41,12 +41,12 @@ import (
 	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
 	"github.com/wso2/product-microgateway/adapter/internal/notifier"
 	oasParser "github.com/wso2/product-microgateway/adapter/internal/oasparser"
-	envoyconf "github.com/wso2/product-microgateway/adapter/internal/oasparser/envoyconf"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/envoyconf"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
-	mgw "github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
 	"github.com/wso2/product-microgateway/adapter/internal/svcdiscovery"
-	subscription "github.com/wso2/product-microgateway/adapter/pkg/discovery/api/wso2/discovery/subscription"
-	throttle "github.com/wso2/product-microgateway/adapter/pkg/discovery/api/wso2/discovery/throttle"
+	"github.com/wso2/product-microgateway/adapter/pkg/discovery/api/wso2/discovery/subscription"
+	"github.com/wso2/product-microgateway/adapter/pkg/discovery/api/wso2/discovery/throttle"
 	wso2_cache "github.com/wso2/product-microgateway/adapter/pkg/discovery/protocol/cache/v3"
 	wso2_resource "github.com/wso2/product-microgateway/adapter/pkg/discovery/protocol/resource/v3"
 	eventhubTypes "github.com/wso2/product-microgateway/adapter/pkg/eventhub/types"
@@ -78,7 +78,7 @@ var (
 	apiUUIDToGatewayToVhosts map[string]map[string]string   // API_UUID -> gateway-env -> vhost (for un-deploying APIs from APIM or Choreo)
 	apiToVhostsMap           map[string]map[string]struct{} // API_UUID -> VHosts set (for un-deploying APIs from API-CTL)
 
-	orgIDAPIMgwSwaggerMap       map[string]map[string]mgw.MgwSwagger       // organizationID -> Vhost:API_UUID -> MgwSwagger struct map
+	orgIDAPIMgwSwaggerMap       map[string]map[string]model.MgwSwagger     // organizationID -> Vhost:API_UUID -> MgwSwagger struct map
 	orgIDOpenAPIEnvoyMap        map[string]map[string][]string             // organizationID -> Vhost:API_UUID -> Envoy Label Array map
 	orgIDOpenAPIRoutesMap       map[string]map[string][]*routev3.Route     // organizationID -> Vhost:API_UUID -> Envoy Routes map
 	orgIDOpenAPIClustersMap     map[string]map[string][]*clusterv3.Cluster // organizationID -> Vhost:API_UUID -> Envoy Clusters map
@@ -156,7 +156,7 @@ func init() {
 	envoyClusterConfigMap = make(map[string][]*clusterv3.Cluster)
 	envoyEndpointConfigMap = make(map[string][]*corev3.Address)
 
-	orgIDAPIMgwSwaggerMap = make(map[string]map[string]mgw.MgwSwagger)         // organizationID -> Vhost:API_UUID -> MgwSwagger struct map
+	orgIDAPIMgwSwaggerMap = make(map[string]map[string]model.MgwSwagger)       // organizationID -> Vhost:API_UUID -> MgwSwagger struct map
 	orgIDOpenAPIEnvoyMap = make(map[string]map[string][]string)                // organizationID -> Vhost:API_UUID -> Envoy Label Array map
 	orgIDOpenAPIRoutesMap = make(map[string]map[string][]*routev3.Route)       // organizationID -> Vhost:API_UUID -> Envoy Routes map
 	orgIDOpenAPIClustersMap = make(map[string]map[string][]*clusterv3.Cluster) // organizationID -> Vhost:API_UUID -> Envoy Clusters map
@@ -247,8 +247,8 @@ func DeployReadinessAPI(envs []string) {
 }
 
 // UpdateAPI updates the Xds Cache when OpenAPI Json content is provided
-func UpdateAPI(vHost string, apiProject mgw.ProjectAPI, environments []string) (*notifier.DeployedAPIRevision, error) {
-	var mgwSwagger mgw.MgwSwagger
+func UpdateAPI(vHost string, apiProject model.ProjectAPI, environments []string) (*notifier.DeployedAPIRevision, error) {
+	var mgwSwagger model.MgwSwagger
 	var deployedRevision *notifier.DeployedAPIRevision
 	var err error
 	var newLabels []string
@@ -277,7 +277,7 @@ func UpdateAPI(vHost string, apiProject mgw.ProjectAPI, environments []string) (
 		return nil, err
 	}
 
-	if apiProject.APIType == mgw.HTTP || apiProject.APIType == mgw.WEBHOOK {
+	if apiProject.APIType == constants.HTTP || apiProject.APIType == constants.WEBHOOK {
 		err = mgwSwagger.GetMgwSwagger(apiProject.OpenAPIJsn)
 		if err != nil {
 			return nil, err
@@ -287,17 +287,17 @@ func UpdateAPI(vHost string, apiProject mgw.ProjectAPI, environments []string) (
 		isYamlAPIKey := false
 		isYamlOauth := false
 		for _, value := range apiYaml.SecurityScheme {
-			if value == model.APIMAPIKeyType {
+			if value == constants.APIMAPIKeyType {
 				logger.LoggerXds.Debugf("API key is enabled in api.yaml for API %v:%v", apiYaml.Name, apiYaml.Version)
 				isYamlAPIKey = true
-			} else if value == model.APIMOauth2Type {
+			} else if value == constants.APIMOauth2Type {
 				logger.LoggerXds.Debugf("Oauth2 is enabled in api.yaml for API %v:%v", apiYaml.Name, apiYaml.Version)
 				isYamlOauth = true
 			}
 		}
 		mgwSwagger.SanitizeAPISecurity(isYamlAPIKey, isYamlOauth)
 		mgwSwagger.SetXWso2AuthHeader(apiYaml.AuthorizationHeader)
-	} else if apiProject.APIType != mgw.WS {
+	} else if apiProject.APIType != constants.WS {
 		// Unreachable else condition. Added in case previous apiType check fails due to any modifications.
 		logger.LoggerXds.Error("API type not currently supported by Choreo Connect")
 	}
@@ -357,7 +357,7 @@ func UpdateAPI(vHost string, apiProject mgw.ProjectAPI, environments []string) (
 	if _, ok := orgIDAPIMgwSwaggerMap[organizationID]; ok {
 		orgIDAPIMgwSwaggerMap[organizationID][apiIdentifier] = mgwSwagger
 	} else {
-		mgwSwaggerMap := make(map[string]mgw.MgwSwagger)
+		mgwSwaggerMap := make(map[string]model.MgwSwagger)
 		mgwSwaggerMap[apiIdentifier] = mgwSwagger
 		orgIDAPIMgwSwaggerMap[organizationID] = mgwSwaggerMap
 	}
@@ -478,7 +478,7 @@ func GetVhostOfAPI(apiUUID, environment string) (vhost string, exists bool) {
 	return "", false
 }
 
-func addBasepathToMap(mgwSwagger mgw.MgwSwagger, organizationID, vHost, apiIdentifier string) error {
+func addBasepathToMap(mgwSwagger model.MgwSwagger, organizationID, vHost, apiIdentifier string) error {
 	newBasepath := mgwSwagger.GetXWso2Basepath()
 
 	// Check if the basepath exists
@@ -521,7 +521,7 @@ func DeleteAPIs(vhost, apiName, version string, environments []string, organizat
 	vhosts, found := apiToVhostsMap[apiNameVersionHashedID]
 	if !found {
 		logger.LoggerXds.Infof("Unable to delete API %v from Organization %v. API does not exist.", apiNameVersionID, organizationID)
-		return errors.New(mgw.NotFound)
+		return errors.New(constants.NotFound)
 	}
 
 	if vhost == "" {
@@ -585,7 +585,7 @@ func DeleteAPIsWithUUID(vhost, uuid string, environments []string, organizationI
 	vhosts, found := apiToVhostsMap[uuid]
 	if !found {
 		logger.LoggerXds.Infof("Unable to delete API with UUID %v from Organization %v. API does not exist.", uuid, organizationID)
-		return errors.New(mgw.NotFound)
+		return errors.New(constants.NotFound)
 	}
 
 	if vhost == "" {
@@ -667,7 +667,7 @@ func deleteAPI(apiIdentifier string, environments []string, organizationID strin
 	_, exists := orgIDAPIMgwSwaggerMap[organizationID][apiIdentifier]
 	if !exists {
 		logger.LoggerXds.Infof("Unable to delete API: %v from Organization: %v. API Does not exist.", apiIdentifier, organizationID)
-		return errors.New(mgw.NotFound)
+		return errors.New(constants.NotFound)
 	}
 
 	existingLabels := orgIDOpenAPIEnvoyMap[organizationID][apiIdentifier]

--- a/adapter/internal/oasparser/constants/constants.go
+++ b/adapter/internal/oasparser/constants/constants.go
@@ -15,13 +15,13 @@
  *
  */
 
-package model
+package constants
 
 // sub-property keys mentioned under x-wso2-production-endpoints
 const (
-	urls                  string = "urls"
-	typeConst             string = "type"
-	LoadBalance           string = "loadbalance"
+	Urls                  string = "urls"
+	Type                  string = "type"
+	LoadBalance           string = "load_balance"
 	FailOver              string = "failover"
 	AdvanceEndpointConfig string = "advanceEndpointConfig"
 	SecurityConfig        string = "securityConfig"
@@ -29,26 +29,26 @@ const (
 
 // Constants for OpenAPI vendor extension keys
 const (
-	xWso2ProdEndpoints   string = "x-wso2-production-endpoints"
-	xWso2SandbxEndpoints string = "x-wso2-sandbox-endpoints"
-	xWso2endpoints       string = "x-wso2-endpoints"
-	xWso2BasePath        string = "x-wso2-basePath"
-	xWso2Label           string = "x-wso2-label"
-	xWso2Cors            string = "x-wso2-cors"
-	xThrottlingTier      string = "x-throttling-tier"
-	xWso2ThrottlingTier  string = "x-wso2-throttling-tier"
-	xAuthHeader          string = "x-wso2-auth-header"
-	xAuthType            string = "x-auth-type"
-	xWso2DisableSecurity string = "x-wso2-disable-security"
+	XWso2ProdEndpoints   string = "x-wso2-production-endpoints"
+	XWso2SandbxEndpoints string = "x-wso2-sandbox-endpoints"
+	XWso2endpoints       string = "x-wso2-endpoints"
+	XWso2BasePath        string = "x-wso2-basePath"
+	XWso2Label           string = "x-wso2-label"
+	XWso2Cors            string = "x-wso2-cors"
+	XThrottlingTier      string = "x-throttling-tier"
+	XWso2ThrottlingTier  string = "x-wso2-throttling-tier"
+	XAuthHeader          string = "x-wso2-auth-header"
+	XAuthType            string = "x-auth-type"
+	XWso2DisableSecurity string = "x-wso2-disable-security"
 	None                 string = "None"
 	DefaultSecurity      string = "default"
 )
 
 // cluster name prefixes
 const (
-	sandClustersConfigNamePrefix    string = "clusterSand"
-	prodClustersConfigNamePrefix    string = "clusterProd"
-	xWso2EPClustersConfigNamePrefix string = "xwso2cluster"
+	SandClustersConfigNamePrefix    string = "clusterSand"
+	ProdClustersConfigNamePrefix    string = "clusterProd"
+	XWso2EPClustersConfigNamePrefix string = "xwso2cluster"
 )
 
 // sub-property values and keys relevant for x-wso2-application security extension
@@ -66,10 +66,10 @@ const (
 
 // sub-property keys mentioned under x-wso2-request-interceptor and x-wso2-response-interceptor
 const (
-	serviceURL                string = "serviceURL"
-	clusterTimeout            string = "clusterTimeout"
-	requestTimeout            string = "requestTimeout"
-	includes                  string = "includes"
+	ServiceURL                string = "serviceURL"
+	ClusterTimeout            string = "clusterTimeout"
+	RequestTimeout            string = "requestTimeout"
+	Includes                  string = "includes"
 	OperationLevelInterceptor string = "operation"
 )
 

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -22,10 +22,16 @@ import (
 	"net"
 	"regexp"
 	"strconv"
+	"strings"
+	"time"
 
-	"github.com/wso2/product-microgateway/adapter/internal/interceptor"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/golang/protobuf/ptypes/wrappers"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -36,20 +42,13 @@ import (
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoy_type_matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes/any"
-	"github.com/golang/protobuf/ptypes/wrappers"
+
 	"github.com/wso2/product-microgateway/adapter/config"
-	"github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
-	"google.golang.org/protobuf/types/known/wrapperspb"
-
+	"github.com/wso2/product-microgateway/adapter/internal/interceptor"
 	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
 	"github.com/wso2/product-microgateway/adapter/internal/svcdiscovery"
-
-	"strings"
-	"time"
-
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
 )
 
 // CreateRoutesWithClusters creates envoy routes along with clusters and endpoint instances.
@@ -351,7 +350,7 @@ func CreateRoutesWithClusters(mgwSwagger model.MgwSwagger, upstreamCerts map[str
 			clusterNameSand, operationalReqInterceptors, operationalRespInterceptorVal, organizationID))
 		routes = append(routes, routeP)
 	}
-	if mgwSwagger.GetAPIType() == model.WS {
+	if mgwSwagger.GetAPIType() == constants.WS {
 		routesP := createRoute(genRouteCreateParams(&mgwSwagger, nil, vHost, apiLevelbasePath, apiLevelClusterNameProd,
 			apiLevelClusterNameSand, nil, nil, organizationID))
 		routes = append(routes, routesP)
@@ -1163,7 +1162,7 @@ func generateRegex(fullpath string) string {
 
 func getUpgradeConfig(apiType string) []*routev3.RouteAction_UpgradeConfig {
 	var upgradeConfig []*routev3.RouteAction_UpgradeConfig
-	if apiType == model.WS {
+	if apiType == constants.WS {
 		upgradeConfig = []*routev3.RouteAction_UpgradeConfig{{
 			UpgradeType: "websocket",
 			Enabled:     &wrappers.BoolValue{Value: true},
@@ -1274,7 +1273,7 @@ func createAddress(remoteHost string, port uint32) *corev3.Address {
 // getMaxStreamDuration configures a maximum duration for a websocket route.
 func getMaxStreamDuration(apiType string) *routev3.RouteAction_MaxStreamDuration {
 	var maxStreamDuration *routev3.RouteAction_MaxStreamDuration = nil
-	if apiType == model.WS {
+	if apiType == constants.WS {
 		maxStreamDuration = &routev3.RouteAction_MaxStreamDuration{
 			MaxStreamDuration: &durationpb.Duration{
 				Seconds: 60 * 60 * 24,
@@ -1286,7 +1285,7 @@ func getMaxStreamDuration(apiType string) *routev3.RouteAction_MaxStreamDuration
 
 func getDefaultResourceMethods(apiType string) []string {
 	var defaultResourceMethods []string = nil
-	if apiType == model.WS {
+	if apiType == constants.WS {
 		defaultResourceMethods = []string{"GET"}
 	}
 	return defaultResourceMethods

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/utills"
 	"github.com/wso2/product-microgateway/adapter/pkg/synchronizer"
@@ -250,7 +251,7 @@ func testCreateRoutesWithClustersWebsocket(t *testing.T, apiYamlFilePath string)
 	apiYaml = model.PopulateEndpointsInfo(apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	routes, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
 
@@ -335,7 +336,7 @@ func testCreateRoutesWithClustersWebsocketWithEnvProps(t *testing.T, apiYamlFile
 	apiYaml = model.PopulateEndpointsInfo(apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
 	mgwSwagger.SetEnvLabelProperties(envProps)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	routes, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
@@ -459,7 +460,7 @@ func TestCreateRoutesWithClusters(t *testing.T) {
 	apiYaml = model.PopulateEndpointsInfo(apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	routes, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
 	assert.NotNil(t, routes, "CreateRoutesWithClusters failed: returned routes nil")
@@ -489,7 +490,7 @@ func commonTestForClusterPrioritiesInWebSocketAPI(t *testing.T, apiYamlFilePath 
 	apiYaml = model.PopulateEndpointsInfo(apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	_, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")
 
@@ -556,7 +557,7 @@ func commonTestForClusterPrioritiesInWebSocketAPIWithEnvProps(t *testing.T, apiY
 	apiYaml = model.PopulateEndpointsInfo(apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
 	mgwSwagger.SetEnvLabelProperties(envProps)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	_, clusters, _ := envoy.CreateRoutesWithClusters(mgwSwagger, nil, nil, "localhost", "carbon.super")

--- a/adapter/internal/oasparser/model/mgw_swagger.go
+++ b/adapter/internal/oasparser/model/mgw_swagger.go
@@ -29,9 +29,11 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/go-openapi/spec"
 	parser "github.com/mitchellh/mapstructure"
+
 	"github.com/wso2/product-microgateway/adapter/config"
 	"github.com/wso2/product-microgateway/adapter/internal/interceptor"
 	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/utills"
 	"github.com/wso2/product-microgateway/adapter/internal/svcdiscovery"
 	"github.com/wso2/product-microgateway/adapter/pkg/synchronizer"
@@ -290,17 +292,17 @@ func (swagger *MgwSwagger) SanitizeAPISecurity(isYamlAPIKey bool, isYamlOauth bo
 	if isYamlAPIKey {
 		//creating security definition for apikey in header in behalf of apim yaml security
 		overridenAPISecurityDefinitions = append(overridenAPISecurityDefinitions,
-			SecurityScheme{DefinitionName: APIMAPIKeyInHeader,
-				Type: APIKeyTypeInOAS, Name: APIKeyNameWithApim, In: APIKeyInHeaderOAS})
+			SecurityScheme{DefinitionName: constants.APIMAPIKeyInHeader,
+				Type: constants.APIKeyTypeInOAS, Name: constants.APIKeyNameWithApim, In: constants.APIKeyInHeaderOAS})
 
 		//creating security definition for apikey in query in behalf of apim yaml security
 		overridenAPISecurityDefinitions = append(overridenAPISecurityDefinitions,
-			SecurityScheme{DefinitionName: APIMAPIKeyInQuery, Type: APIKeyTypeInOAS,
-				Name: APIKeyNameWithApim, In: APIKeyInQueryOAS})
+			SecurityScheme{DefinitionName: constants.APIMAPIKeyInQuery, Type: constants.APIKeyTypeInOAS,
+				Name: constants.APIKeyNameWithApim, In: constants.APIKeyInQueryOAS})
 	}
 	for _, securityDef := range swagger.securityScheme {
 		//read default oauth2 security with scopes when oauth2 enabled
-		if isYamlOauth && securityDef.DefinitionName == APIMDefaultOauth2Security {
+		if isYamlOauth && securityDef.DefinitionName == constants.APIMDefaultOauth2Security {
 			overridenAPISecurityDefinitions = append(overridenAPISecurityDefinitions, securityDef)
 			apiSecurityDefinitionNames = append(apiSecurityDefinitionNames, securityDef.DefinitionName)
 		} else if !isOverrideSecurityByYaml {
@@ -329,8 +331,8 @@ func (swagger *MgwSwagger) SanitizeAPISecurity(isYamlAPIKey bool, isYamlOauth bo
 	}
 	// Adding api level security when api.yaml apikey security is provided
 	if isYamlAPIKey {
-		sanitizedAPISecurity = append(sanitizedAPISecurity, map[string][]string{APIMAPIKeyInHeader: {}})
-		sanitizedAPISecurity = append(sanitizedAPISecurity, map[string][]string{APIMAPIKeyInQuery: {}})
+		sanitizedAPISecurity = append(sanitizedAPISecurity, map[string][]string{constants.APIMAPIKeyInHeader: {}})
+		sanitizedAPISecurity = append(sanitizedAPISecurity, map[string][]string{constants.APIMAPIKeyInQuery: {}})
 	}
 	swagger.security = sanitizedAPISecurity
 
@@ -350,8 +352,8 @@ func (swagger *MgwSwagger) SanitizeAPISecurity(isYamlAPIKey bool, isYamlOauth bo
 			}
 			// has do the following to enable apikey as well when default oauth2 security is in operation level
 			if isOverrideSecurityByYaml && isYamlOauth && isYamlAPIKey {
-				sanitizedOperationSecurity = append(sanitizedOperationSecurity, map[string][]string{APIMAPIKeyInHeader: {}})
-				sanitizedOperationSecurity = append(sanitizedOperationSecurity, map[string][]string{APIMAPIKeyInQuery: {}})
+				sanitizedOperationSecurity = append(sanitizedOperationSecurity, map[string][]string{constants.APIMAPIKeyInHeader: {}})
+				sanitizedOperationSecurity = append(sanitizedOperationSecurity, map[string][]string{constants.APIMAPIKeyInQuery: {}})
 			}
 			operation.SetSecurity(sanitizedOperationSecurity)
 		}
@@ -429,7 +431,7 @@ func (swagger *MgwSwagger) SetEnvLabelProperties(envProps synchronizer.APIEnvPro
 
 	if len(productionUrls) > 0 {
 		logger.LoggerOasparser.Infof("Production endpoints is overridden by env properties %v : %v", swagger.title, swagger.version)
-		swagger.productionEndpoints = generateEndpointCluster(prodClustersConfigNamePrefix, productionUrls, LoadBalance)
+		swagger.productionEndpoints = generateEndpointCluster(constants.ProdClustersConfigNamePrefix, productionUrls, constants.LoadBalance)
 	}
 
 	if envProps.APIConfigs.SandBoxEndpoint != "" {
@@ -445,7 +447,7 @@ func (swagger *MgwSwagger) SetEnvLabelProperties(envProps synchronizer.APIEnvPro
 
 	if len(sandboxUrls) > 0 {
 		logger.LoggerOasparser.Infof("Sandbox endpoints is overridden by env properties %v : %v", swagger.title, swagger.version)
-		swagger.sandboxEndpoints = generateEndpointCluster(sandClustersConfigNamePrefix, sandboxUrls, LoadBalance)
+		swagger.sandboxEndpoints = generateEndpointCluster(constants.SandClustersConfigNamePrefix, sandboxUrls, constants.LoadBalance)
 	}
 }
 
@@ -454,16 +456,16 @@ func (swagger *MgwSwagger) SetEnvVariables(apiHashValue string) {
 	productionEndpoints, sandboxEndpoints := retrieveEndpointsFromEnv(apiHashValue)
 	if len(productionEndpoints) > 0 {
 		logger.LoggerOasparser.Infof("Applying production endpoints provided in env variables for API %v : %v", swagger.title, swagger.version)
-		swagger.productionEndpoints.EndpointPrefix = prodClustersConfigNamePrefix
+		swagger.productionEndpoints.EndpointPrefix = constants.ProdClustersConfigNamePrefix
 		swagger.productionEndpoints.Endpoints = productionEndpoints
-		swagger.productionEndpoints.EndpointType = LoadBalance
+		swagger.productionEndpoints.EndpointType = constants.LoadBalance
 
 	}
 	if len(sandboxEndpoints) > 0 {
 		logger.LoggerOasparser.Infof("Applying sandbox endpoints provided in env variables for API %v : %v", swagger.title, swagger.version)
-		swagger.sandboxEndpoints.EndpointPrefix = sandClustersConfigNamePrefix
+		swagger.sandboxEndpoints.EndpointPrefix = constants.SandClustersConfigNamePrefix
 		swagger.sandboxEndpoints.Endpoints = sandboxEndpoints
-		swagger.sandboxEndpoints.EndpointType = LoadBalance
+		swagger.sandboxEndpoints.EndpointType = constants.LoadBalance
 	}
 
 	// retrieving security credentials from environment variables
@@ -480,18 +482,18 @@ func (swagger *MgwSwagger) SetEnvVariables(apiHashValue string) {
 // SetSandboxEndpoints set the MgwSwagger object with the SandboxEndpoint when
 // it is not populated by SetXWso2Extensions
 func (swagger *MgwSwagger) SetSandboxEndpoints(sandboxEndpoints []Endpoint) {
-	swagger.sandboxEndpoints = generateEndpointCluster(sandClustersConfigNamePrefix, sandboxEndpoints, LoadBalance)
+	swagger.sandboxEndpoints = generateEndpointCluster(constants.SandClustersConfigNamePrefix, sandboxEndpoints, constants.LoadBalance)
 }
 
 // SetProductionEndpoints set the MgwSwagger object with the productionEndpoint when
 // it is not populated by SetXWso2Extensions
 func (swagger *MgwSwagger) SetProductionEndpoints(productionEndpoints []Endpoint) {
-	swagger.productionEndpoints = generateEndpointCluster(prodClustersConfigNamePrefix, productionEndpoints, LoadBalance)
+	swagger.productionEndpoints = generateEndpointCluster(constants.ProdClustersConfigNamePrefix, productionEndpoints, constants.LoadBalance)
 }
 
 func (swagger *MgwSwagger) setXWso2ProductionEndpoint() (bool, error) {
 	apiLevelEPFound := false
-	xWso2APIEndpoints, err := swagger.getEndpoints(swagger.vendorExtensions, xWso2ProdEndpoints)
+	xWso2APIEndpoints, err := swagger.getEndpoints(swagger.vendorExtensions, constants.XWso2ProdEndpoints)
 	if xWso2APIEndpoints != nil {
 		swagger.productionEndpoints = xWso2APIEndpoints
 		apiLevelEPFound = true
@@ -501,7 +503,7 @@ func (swagger *MgwSwagger) setXWso2ProductionEndpoint() (bool, error) {
 
 	//resources
 	for i, resource := range swagger.resources {
-		xwso2ResourceEndpoints, err := swagger.getEndpoints(resource.vendorExtensions, xWso2ProdEndpoints)
+		xwso2ResourceEndpoints, err := swagger.getEndpoints(resource.vendorExtensions, constants.XWso2ProdEndpoints)
 		if err != nil {
 			return apiLevelEPFound, errors.New("error encountered when extracting resource endpoints for API with basepath: " +
 				swagger.xWso2Basepath + ". " + err.Error())
@@ -515,7 +517,7 @@ func (swagger *MgwSwagger) setXWso2ProductionEndpoint() (bool, error) {
 
 func (swagger *MgwSwagger) setXWso2SandboxEndpoint() (bool, error) {
 	apiLevelEPFound := false
-	xWso2APIEndpoints, err := swagger.getEndpoints(swagger.vendorExtensions, xWso2SandbxEndpoints)
+	xWso2APIEndpoints, err := swagger.getEndpoints(swagger.vendorExtensions, constants.XWso2SandbxEndpoints)
 	if xWso2APIEndpoints != nil {
 		swagger.sandboxEndpoints = xWso2APIEndpoints
 		apiLevelEPFound = true
@@ -525,7 +527,7 @@ func (swagger *MgwSwagger) setXWso2SandboxEndpoint() (bool, error) {
 
 	// resources
 	for i, resource := range swagger.resources {
-		xwso2ResourceEndpoints, err := swagger.getEndpoints(resource.vendorExtensions, xWso2SandbxEndpoints)
+		xwso2ResourceEndpoints, err := swagger.getEndpoints(resource.vendorExtensions, constants.XWso2SandbxEndpoints)
 		if err != nil {
 			return apiLevelEPFound, errors.New("error encountered when extracting resource endpoints for API with basepath: " +
 				swagger.xWso2Basepath + ". " + err.Error())
@@ -539,7 +541,7 @@ func (swagger *MgwSwagger) setXWso2SandboxEndpoint() (bool, error) {
 // GetXWso2Endpoints get x-wso2-endpoints
 func (swagger *MgwSwagger) setXWso2Endpoints() error {
 	endpointClusters := make(map[string]*EndpointCluster)
-	if val, found := swagger.vendorExtensions[xWso2endpoints]; found {
+	if val, found := swagger.vendorExtensions[constants.XWso2endpoints]; found {
 		if val1, ok := val.([]interface{}); ok {
 			for _, val2 := range val1 { // loop thorough multiple endpoints
 				if eps, ok := val2.(map[string]interface{}); ok {
@@ -611,7 +613,7 @@ func (swagger *MgwSwagger) setXWso2ThrottlingTier() {
 // if the property is not available, an empty string is returned.
 func getXWso2AuthHeader(vendorExtensions map[string]interface{}) string {
 	xWso2AuthHeader := ""
-	if y, found := vendorExtensions[xAuthHeader]; found {
+	if y, found := vendorExtensions[constants.XAuthHeader]; found {
 		if val, ok := y.(string); ok {
 			xWso2AuthHeader = val
 		}
@@ -768,24 +770,24 @@ func (swagger *MgwSwagger) getEndpoints(vendorExtensions map[string]interface{},
 	// TODO: (VirajSalaka) x-wso2-production-endpoint 's type does not represent http/https, instead it indicates loadbalance and failover
 	if endpointClusterYaml, found := vendorExtensions[endpointName]; found {
 		if endpointClusterMap, ok := endpointClusterYaml.(map[string]interface{}); ok {
-			endpointPrefix := endpointName + "_" + xWso2EPClustersConfigNamePrefix
-			if strings.EqualFold(endpointName, xWso2ProdEndpoints) {
-				endpointPrefix = prodClustersConfigNamePrefix
-			} else if strings.EqualFold(endpointName, xWso2SandbxEndpoints) {
-				endpointPrefix = sandClustersConfigNamePrefix
+			endpointPrefix := endpointName + "_" + constants.XWso2EPClustersConfigNamePrefix
+			if strings.EqualFold(endpointName, constants.XWso2ProdEndpoints) {
+				endpointPrefix = constants.ProdClustersConfigNamePrefix
+			} else if strings.EqualFold(endpointName, constants.XWso2SandbxEndpoints) {
+				endpointPrefix = constants.SandClustersConfigNamePrefix
 			}
 			endpointCluster := EndpointCluster{
 				EndpointPrefix: endpointPrefix,
 			}
 			// Set URLs
-			if urlsProperty, found := endpointClusterMap[urls]; found {
+			if urlsProperty, found := endpointClusterMap[constants.Urls]; found {
 				if urlsArray, ok := urlsProperty.([]interface{}); ok {
 					endpoints, err := processEndpointUrls(urlsArray)
 					if err != nil {
 						return nil, err
 					}
 					endpointCluster.Endpoints = endpoints
-					endpointCluster.EndpointType = LoadBalance
+					endpointCluster.EndpointType = constants.LoadBalance
 				} else {
 					return nil, errors.New("Error while parsing array of urls in " + endpointName)
 				}
@@ -797,13 +799,13 @@ func (swagger *MgwSwagger) getEndpoints(vendorExtensions map[string]interface{},
 			}
 
 			// Update Endpoint Cluster type
-			if epType, found := endpointClusterMap[typeConst]; found {
+			if epType, found := endpointClusterMap[constants.Type]; found {
 				if endpointType, ok := epType.(string); ok {
 					endpointCluster.EndpointType = endpointType
 				}
 			}
 			// Set Endpoint Config
-			if advanceEndpointConfig, found := endpointClusterMap[AdvanceEndpointConfig]; found {
+			if advanceEndpointConfig, found := endpointClusterMap[constants.AdvanceEndpointConfig]; found {
 				if configMap, ok := advanceEndpointConfig.(map[string]interface{}); ok {
 					var endpointConfig EndpointConfig
 					err := parser.Decode(configMap, &endpointConfig)
@@ -816,7 +818,7 @@ func (swagger *MgwSwagger) getEndpoints(vendorExtensions map[string]interface{},
 				}
 			}
 			// Set Endpoint Config
-			if securityConfig, found := endpointClusterMap[SecurityConfig]; found {
+			if securityConfig, found := endpointClusterMap[constants.SecurityConfig]; found {
 				if configMap, ok := securityConfig.(map[string]interface{}); ok {
 					var epSecurity EndpointSecurity
 					err := parser.Decode(configMap, &epSecurity)
@@ -834,8 +836,8 @@ func (swagger *MgwSwagger) getEndpoints(vendorExtensions map[string]interface{},
 			}
 			return &endpointCluster, nil
 		} else if endpointRef, ok := endpointClusterYaml.(string); ok &&
-			(strings.EqualFold(endpointName, xWso2ProdEndpoints) || strings.EqualFold(endpointName, xWso2SandbxEndpoints)) {
-			refPrefix := "#/" + xWso2endpoints + "/"
+			(strings.EqualFold(endpointName, constants.XWso2ProdEndpoints) || strings.EqualFold(endpointName, constants.XWso2SandbxEndpoints)) {
+			refPrefix := "#/" + constants.XWso2endpoints + "/"
 			if strings.HasPrefix(endpointRef, refPrefix) {
 				epName := strings.TrimPrefix(endpointRef, refPrefix)
 				if _, found := swagger.xWso2Endpoints[epName]; found {
@@ -884,7 +886,7 @@ func processEndpointUrls(urlsArray []interface{}) ([]Endpoint, error) {
 // if the property is not available, an empty string is returned.
 func getXWso2Basepath(vendorExtensions map[string]interface{}) string {
 	xWso2basepath := ""
-	if y, found := vendorExtensions[xWso2BasePath]; found {
+	if y, found := vendorExtensions[constants.XWso2BasePath]; found {
 		if val, ok := y.(string); ok {
 			xWso2basepath = val
 		}
@@ -900,8 +902,8 @@ func (swagger *MgwSwagger) setXWso2Basepath() {
 }
 
 func (swagger *MgwSwagger) setXWso2Cors() {
-	if cors, corsFound := swagger.vendorExtensions[xWso2Cors]; corsFound {
-		logger.LoggerOasparser.Debugf("%v configuration is available", xWso2Cors)
+	if cors, corsFound := swagger.vendorExtensions[constants.XWso2Cors]; corsFound {
+		logger.LoggerOasparser.Debugf("%v configuration is available", constants.XWso2Cors)
 		if parsedCors, parsedCorsOk := cors.(map[string]interface{}); parsedCorsOk {
 			//Default CorsConfiguration
 			corsConfig := &CorsConfig{
@@ -909,7 +911,7 @@ func (swagger *MgwSwagger) setXWso2Cors() {
 			}
 			err := parser.Decode(parsedCors, &corsConfig)
 			if err != nil {
-				logger.LoggerOasparser.Errorf("Error while parsing %v: "+err.Error(), xWso2Cors)
+				logger.LoggerOasparser.Errorf("Error while parsing %v: "+err.Error(), constants.XWso2Cors)
 				return
 			}
 			if corsConfig.Enabled {
@@ -920,7 +922,7 @@ func (swagger *MgwSwagger) setXWso2Cors() {
 			swagger.xWso2Cors = generateGlobalCors()
 			return
 		}
-		logger.LoggerOasparser.Errorf("Error while parsing %v .", xWso2Cors)
+		logger.LoggerOasparser.Errorf("Error while parsing %v .", constants.XWso2Cors)
 	} else {
 		swagger.xWso2Cors = generateGlobalCors()
 	}
@@ -957,11 +959,11 @@ func generateGlobalCors() *CorsConfig {
 // if both the properties are not available, an empty string is returned.
 func ResolveThrottlingTier(vendorExtensions map[string]interface{}) string {
 	xTier := ""
-	if x, found := vendorExtensions[xWso2ThrottlingTier]; found {
+	if x, found := vendorExtensions[constants.XWso2ThrottlingTier]; found {
 		if val, ok := x.(string); ok {
 			xTier = val
 		}
-	} else if y, found := vendorExtensions[xThrottlingTier]; found {
+	} else if y, found := vendorExtensions[constants.XThrottlingTier]; found {
 		if val, ok := y.(string); ok {
 			xTier = val
 		}
@@ -977,8 +979,8 @@ func ResolveThrottlingTier(vendorExtensions map[string]interface{}) string {
 // x-wso2-disable-security : true/false to enable and disable security.
 func ResolveDisableSecurity(vendorExtensions map[string]interface{}) bool {
 	disableSecurity := false
-	y, vExtAuthType := vendorExtensions[xAuthType]
-	z, vExtDisableSecurity := vendorExtensions[xWso2DisableSecurity]
+	y, vExtAuthType := vendorExtensions[constants.XAuthType]
+	z, vExtDisableSecurity := vendorExtensions[constants.XWso2DisableSecurity]
 	if vExtDisableSecurity {
 		// If x-wso2-disable-security is present, then disableSecurity = val
 		if val, ok := z.(bool); ok {
@@ -991,7 +993,7 @@ func ResolveDisableSecurity(vendorExtensions map[string]interface{}) bool {
 		if val, ok := y.(string); ok {
 			// If the x-auth-type vendor ext is None, then the API/resource is considerd
 			// to be non secure
-			if val == None {
+			if val == constants.None {
 				disableSecurity = true
 			}
 		}
@@ -1004,7 +1006,7 @@ func (swagger *MgwSwagger) GetOperationInterceptors(apiInterceptor InterceptEndp
 	interceptorOperationMap := make(map[string]InterceptEndpoint)
 
 	for _, op := range operations {
-		operationInterceptor, _ := swagger.GetInterceptor(op.GetVendorExtensions(), extensionName, OperationLevelInterceptor)
+		operationInterceptor, _ := swagger.GetInterceptor(op.GetVendorExtensions(), extensionName, constants.OperationLevelInterceptor)
 		operationInterceptor.ClusterName = op.iD
 		// if operation interceptor not given
 		if !operationInterceptor.Enable {
@@ -1036,7 +1038,7 @@ func (swagger *MgwSwagger) GetInterceptor(vendorExtensions map[string]interface{
 	if x, found := vendorExtensions[extensionName]; found {
 		if val, ok := x.(map[string]interface{}); ok {
 			//serviceURL mandatory
-			if v, found := val[serviceURL]; found {
+			if v, found := val[constants.ServiceURL]; found {
 				serviceURLV := v.(string)
 				endpoint, err := getHostandBasepathandPort(serviceURLV)
 				if err != nil {
@@ -1054,25 +1056,25 @@ func (swagger *MgwSwagger) GetInterceptor(vendorExtensions map[string]interface{
 				return InterceptEndpoint{}, errors.New("error reading interceptors service url value")
 			}
 			//clusterTimeout optional
-			if v, found := val[clusterTimeout]; found {
+			if v, found := val[constants.ClusterTimeout]; found {
 				p, err := strconv.ParseInt(fmt.Sprint(v), 0, 0)
 				if err == nil {
 					clusterTimeoutV = time.Duration(p)
 				} else {
-					logger.LoggerOasparser.Errorf("Error reading interceptors %v value : %v", clusterTimeout, err.Error())
+					logger.LoggerOasparser.Errorf("Error reading interceptors %v value : %v", constants.ClusterTimeout, err.Error())
 				}
 			}
 			//requestTimeout optional
-			if v, found := val[requestTimeout]; found {
+			if v, found := val[constants.RequestTimeout]; found {
 				p, err := strconv.ParseInt(fmt.Sprint(v), 0, 0)
 				if err == nil {
 					requestTimeoutV = time.Duration(p)
 				} else {
-					logger.LoggerOasparser.Errorf("Error reading interceptors %v value : %v", requestTimeout, err.Error())
+					logger.LoggerOasparser.Errorf("Error reading interceptors %v value : %v", constants.RequestTimeout, err.Error())
 				}
 			}
 			//includes optional
-			if v, found := val[includes]; found {
+			if v, found := val[constants.Includes]; found {
 				includes := v.([]interface{})
 				if len(includes) > 0 {
 					for _, include := range includes {
@@ -1180,10 +1182,10 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 
 	if len(endpointConfig.ProductionEndpoints) > 0 {
 		var endpoints []Endpoint
-		endpointType := LoadBalance
+		endpointType := constants.LoadBalance
 		var unProcessedURLs []interface{}
 		for _, endpointConfig := range endpointConfig.ProductionEndpoints {
-			if apiType == WS {
+			if apiType == constants.WS {
 				prodEndpoint, err := getEndpointForWebsocketURL(endpointConfig.Endpoint)
 				if err == nil {
 					endpoints = append(endpoints, *prodEndpoint)
@@ -1195,9 +1197,9 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 			}
 		}
 		if len(endpointConfig.ProductionFailoverEndpoints) > 0 {
-			endpointType = FailOver
+			endpointType = constants.FailOver
 			for _, endpointConfig := range endpointConfig.ProductionFailoverEndpoints {
-				if apiType == WS {
+				if apiType == constants.WS {
 					failoverEndpoint, err := getEndpointForWebsocketURL(endpointConfig.Endpoint)
 					if err == nil {
 						endpoints = append(endpoints, *failoverEndpoint)
@@ -1209,7 +1211,7 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 				}
 			}
 		}
-		if apiType != WS {
+		if apiType != constants.WS {
 			productionEndpoints, err := processEndpointUrls(unProcessedURLs)
 			if err == nil {
 				endpoints = append(endpoints, productionEndpoints...)
@@ -1217,15 +1219,15 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 				return err
 			}
 		}
-		swagger.productionEndpoints = generateEndpointCluster(prodClustersConfigNamePrefix, endpoints, endpointType)
+		swagger.productionEndpoints = generateEndpointCluster(constants.ProdClustersConfigNamePrefix, endpoints, endpointType)
 	}
 
 	if len(endpointConfig.SandBoxEndpoints) > 0 {
 		var endpoints []Endpoint
-		endpointType := LoadBalance
+		endpointType := constants.LoadBalance
 		var unProcessedURLs []interface{}
 		for _, endpointConfig := range endpointConfig.SandBoxEndpoints {
-			if apiType == WS {
+			if apiType == constants.WS {
 				sandBoxEndpoint, err := getEndpointForWebsocketURL(endpointConfig.Endpoint)
 				if err == nil {
 					endpoints = append(endpoints, *sandBoxEndpoint)
@@ -1237,9 +1239,9 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 			}
 		}
 		if len(endpointConfig.SandboxFailoverEndpoints) > 0 {
-			endpointType = FailOver
+			endpointType = constants.FailOver
 			for _, endpointConfig := range endpointConfig.SandboxFailoverEndpoints {
-				if apiType == WS {
+				if apiType == constants.WS {
 					failoverEndpoint, err := getEndpointForWebsocketURL(endpointConfig.Endpoint)
 					if err == nil {
 						endpoints = append(endpoints, *failoverEndpoint)
@@ -1251,7 +1253,7 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 				}
 			}
 		}
-		if apiType != WS {
+		if apiType != constants.WS {
 			sandboxEndpoints, err := processEndpointUrls(unProcessedURLs)
 			if err == nil {
 				endpoints = append(endpoints, sandboxEndpoints...)
@@ -1259,7 +1261,7 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 				return err
 			}
 		}
-		swagger.sandboxEndpoints = generateEndpointCluster(sandClustersConfigNamePrefix, endpoints, endpointType)
+		swagger.sandboxEndpoints = generateEndpointCluster(constants.SandClustersConfigNamePrefix, endpoints, endpointType)
 	}
 
 	// if yaml has production security, setting it

--- a/adapter/internal/oasparser/model/mgw_swagger_internal_test.go
+++ b/adapter/internal/oasparser/model/mgw_swagger_internal_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 )
 
 func TestGetXWso2Endpoints(t *testing.T) {
@@ -210,7 +211,7 @@ func TestSetXWso2ProductionEndpoint(t *testing.T) {
 			input: MgwSwagger{
 				vendorExtensions: map[string]interface{}{"x-wso2-production-endpoints": map[string]interface{}{
 					"type": "loadbalance", "urls": []interface{}{"https://www.youtube.com:80/base"}},
-					xWso2Cors: map[string]interface{}{
+					constants.XWso2Cors: map[string]interface{}{
 						"Enabled":                       "true",
 						"AccessControlAllowCredentials": "true",
 						"AccessControlAllowHeaders":     []interface{}{"Authorization"},
@@ -264,7 +265,7 @@ func TestSetXWso2ProductionEndpoint(t *testing.T) {
 
 	for _, item := range dataItems {
 		mgwSwag := item.input
-		if cors, corsFound := mgwSwag.vendorExtensions[xWso2Cors]; corsFound {
+		if cors, corsFound := mgwSwag.vendorExtensions[constants.XWso2Cors]; corsFound {
 			assert.NotNil(t, cors, "cors should not be empty")
 		}
 		err := mgwSwag.SetXWso2Extensions()

--- a/adapter/internal/oasparser/model/open_api.go
+++ b/adapter/internal/oasparser/model/open_api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/google/uuid"
 	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 )
 
 // hostNameValidator regex is for validate the host name of the URL
@@ -78,7 +79,7 @@ func (swagger *MgwSwagger) SetInfoOpenAPI(swagger3 openapi3.Swagger) error {
 		return err
 	}
 
-	swagger.apiType = HTTP
+	swagger.apiType = constants.HTTP
 	var productionUrls []Endpoint
 	// For prototyped APIs, the prototype endpoint is only assinged from api.Yaml. Hence,
 	// an exception is made where servers url is not processed when the API is prototyped.
@@ -96,7 +97,7 @@ func (swagger *MgwSwagger) SetInfoOpenAPI(swagger3 openapi3.Swagger) error {
 			}
 		}
 		if len(productionUrls) > 0 {
-			swagger.productionEndpoints = generateEndpointCluster(prodClustersConfigNamePrefix, productionUrls, LoadBalance)
+			swagger.productionEndpoints = generateEndpointCluster(constants.ProdClustersConfigNamePrefix, productionUrls, constants.LoadBalance)
 			swagger.sandboxEndpoints = nil
 		}
 	}
@@ -164,7 +165,7 @@ func setResourcesOpenAPI(openAPI openapi3.Swagger) ([]*Resource, error) {
 
 				}
 				if productionUrls != nil && len(productionUrls) > 0 {
-					resource.productionEndpoints = generateEndpointCluster(prodClustersConfigNamePrefix, productionUrls, LoadBalance)
+					resource.productionEndpoints = generateEndpointCluster(constants.ProdClustersConfigNamePrefix, productionUrls, constants.LoadBalance)
 				}
 			}
 			resources = append(resources, &resource)
@@ -288,7 +289,7 @@ func convertExtensibletoReadableFormat(vendorExtensions openapi3.ExtensionProps)
 // 2nd bool represent if the vendor extension present.
 func resolveDisableSecurity(vendorExtensions openapi3.ExtensionProps) (bool, bool) {
 	extensions := convertExtensibletoReadableFormat(vendorExtensions)
-	if y, found := extensions[xWso2DisableSecurity]; found {
+	if y, found := extensions[constants.XWso2DisableSecurity]; found {
 		if val, ok := y.(bool); ok {
 			return val, found
 		}
@@ -301,7 +302,7 @@ func resolveDisableSecurity(vendorExtensions openapi3.ExtensionProps) (bool, boo
 func addDisableSecurityIfNotPresent(vendorExtensions openapi3.ExtensionProps, val bool) openapi3.ExtensionProps {
 	_, found := resolveDisableSecurity(vendorExtensions)
 	if !found {
-		vendorExtensions.Extensions[xWso2DisableSecurity] = val
+		vendorExtensions.Extensions[constants.XWso2DisableSecurity] = val
 	}
 	return vendorExtensions
 }
@@ -312,7 +313,7 @@ func addDisableSecurityIfNotPresent(vendorExtensions openapi3.ExtensionProps, va
 func GetXWso2Label(vendorExtensions openapi3.ExtensionProps) []string {
 	vendorExtensionsMap := convertExtensibletoReadableFormat(vendorExtensions)
 	var labelArray []string
-	if y, found := vendorExtensionsMap[xWso2Label]; found {
+	if y, found := vendorExtensionsMap[constants.XWso2Label]; found {
 		if val, ok := y.([]interface{}); ok {
 			for _, label := range val {
 				labelArray = append(labelArray, label.(string))

--- a/adapter/internal/oasparser/model/resource.go
+++ b/adapter/internal/oasparser/model/resource.go
@@ -22,6 +22,8 @@ package model
 import (
 	"regexp"
 	"sort"
+
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 )
 
 // Resource represents the object structure holding the information related to the
@@ -91,8 +93,8 @@ func (resource *Resource) GetMethodList() []string {
 func CreateMinimalDummyResourceForTests(path string, methods []*Operation, id string, productionUrls,
 	sandboxUrls []Endpoint) Resource {
 
-	prodEndpints := generateEndpointCluster(prodClustersConfigNamePrefix, productionUrls, LoadBalance)
-	sandboxEndpints := generateEndpointCluster(sandClustersConfigNamePrefix, sandboxUrls, LoadBalance)
+	prodEndpints := generateEndpointCluster(constants.ProdClustersConfigNamePrefix, productionUrls, constants.LoadBalance)
+	sandboxEndpints := generateEndpointCluster(constants.SandClustersConfigNamePrefix, sandboxUrls, constants.LoadBalance)
 
 	return Resource{
 		path:                path,

--- a/adapter/internal/oasparser/model/swagger.go
+++ b/adapter/internal/oasparser/model/swagger.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-openapi/spec"
 	"github.com/google/uuid"
 	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 )
 
 // SetInfoSwagger populates the MgwSwagger object with the properties within the openAPI v2
@@ -45,7 +46,7 @@ func (swagger *MgwSwagger) SetInfoSwagger(swagger2 spec.Swagger) error {
 	swagger.securityScheme = setSecurityDefinitions(swagger2)
 	swagger.security = swagger2.Security
 	swagger.resources = setResourcesSwagger(swagger2)
-	swagger.apiType = HTTP
+	swagger.apiType = constants.HTTP
 	swagger.xWso2Basepath = swagger2.BasePath
 	// According to the definition, multiple schemes can be mentioned. Since the microgateway can assign only one scheme
 	// https is prioritized over http. If it is ws or wss, the microgateway will print an error.
@@ -70,7 +71,7 @@ func (swagger *MgwSwagger) SetInfoSwagger(swagger2 spec.Swagger) error {
 		endpoint, err := getHostandBasepathandPort(urlScheme + swagger2.Host + swagger2.BasePath)
 		if err == nil {
 			productionEndpoints := append([]Endpoint{}, *endpoint)
-			swagger.productionEndpoints = generateEndpointCluster(prodClustersConfigNamePrefix, productionEndpoints, LoadBalance)
+			swagger.productionEndpoints = generateEndpointCluster(constants.ProdClustersConfigNamePrefix, productionEndpoints, constants.LoadBalance)
 			swagger.sandboxEndpoints = nil
 		} else {
 			return errors.New("error encountered when parsing the endpoint")
@@ -87,10 +88,10 @@ func setResourcesSwagger(swagger2 spec.Swagger) []*Resource {
 	// resourve level, if it's not present at resource level using "addResourceLevelDisableSecurity"
 	if swagger2.Paths != nil {
 		for path, pathItem := range swagger2.Paths.Paths {
-			disableSecurity, found := swagger2.VendorExtensible.Extensions.GetBool(xWso2DisableSecurity)
+			disableSecurity, found := swagger2.VendorExtensible.Extensions.GetBool(constants.XWso2DisableSecurity)
 			// Checks for resource level security, if security is disabled in resource level,
 			// below code segment will override above two variable values (disableSecurity & found)
-			disableResourceLevelSecurity, foundInResourceLevel := pathItem.Extensions.GetBool(xWso2DisableSecurity)
+			disableResourceLevelSecurity, foundInResourceLevel := pathItem.Extensions.GetBool(constants.XWso2DisableSecurity)
 			if foundInResourceLevel {
 				logger.LoggerOasparser.Infof("x-wso2-disable-security extension is available in the API: %v %v's resource %v.",
 					swagger2.Info.Title, swagger2.Info.Version, path)
@@ -179,8 +180,8 @@ func setSecurityDefinitions(swagger2 spec.Swagger) []SecurityScheme {
 // This methods adds x-wso2-disable-security vendor extension
 // if it's not present in the given vendor extensions.
 func addResourceLevelDisableSecurity(v *spec.VendorExtensible, enable bool) {
-	if _, found := v.Extensions.GetBool(xWso2DisableSecurity); !found {
-		v.AddExtension(xWso2DisableSecurity, enable)
+	if _, found := v.Extensions.GetBool(constants.XWso2DisableSecurity); !found {
+		v.AddExtension(constants.XWso2DisableSecurity, enable)
 	}
 }
 

--- a/adapter/internal/oasparser/model/swagger_test.go
+++ b/adapter/internal/oasparser/model/swagger_test.go
@@ -14,7 +14,7 @@
  *  limitations under the License.
  *
  */
-package model_test
+package model
 
 import (
 	"encoding/json"
@@ -23,14 +23,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wso2/product-microgateway/adapter/config"
-	model "github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/utills"
 )
 
 func TestSetInfoSwaggerWebSocket(t *testing.T) {
 
 	type setInfoSwaggerWebSocketTestItem struct {
-		input   model.MgwSwagger
+		input   MgwSwagger
 		apiData map[string]interface{}
 	}
 
@@ -40,11 +40,11 @@ func TestSetInfoSwaggerWebSocket(t *testing.T) {
 	apiJsn, conversionErr := utills.ToJSON(apiYamlByteArr)
 	assert.Nil(t, conversionErr, "YAML to JSON conversion error : %v"+apiYamlFilePath)
 
-	var apiYaml model.APIYaml
+	var apiYaml APIYaml
 	err = json.Unmarshal(apiJsn, &apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
-	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
+	var mgwSwagger MgwSwagger
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 
 	dataItems := []setInfoSwaggerWebSocketTestItem{
@@ -85,7 +85,7 @@ func TestValidate(t *testing.T) {
 	openapiFilePath := config.GetMgwHome() + "/../adapter/test-resources/envoycodegen/openapi_with_prod_sand_extensions.yaml"
 	openapiByteArr, err := ioutil.ReadFile(openapiFilePath)
 	assert.Nil(t, err, "Error while reading the openapi file : "+openapiFilePath)
-	mgwSwaggerForOpenapi := model.MgwSwagger{}
+	mgwSwaggerForOpenapi := MgwSwagger{}
 	err = mgwSwaggerForOpenapi.GetMgwSwagger(openapiByteArr)
 	assert.Nil(t, err, "Error should not be present when openAPI definition is converted to a MgwSwagger object")
 	err = mgwSwaggerForOpenapi.Validate()

--- a/adapter/internal/oasparser/model/types.go
+++ b/adapter/internal/oasparser/model/types.go
@@ -22,12 +22,14 @@ import (
 	"os"
 	"strings"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/wso2/product-microgateway/adapter/config"
 	"github.com/wso2/product-microgateway/adapter/internal/loggers"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/utills"
 	"github.com/wso2/product-microgateway/adapter/pkg/synchronizer"
 	"github.com/wso2/product-microgateway/adapter/pkg/tlsutils"
-	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -169,7 +171,7 @@ func (apiProject *ProjectAPI) ValidateAPIType() error {
 		// If no api.yaml file is included in the zip folder, return with error.
 		err = errors.New("could not find api.yaml or api.json")
 		return err
-	} else if apiProject.APIType != HTTP && apiProject.APIType != WS && apiProject.APIType != WEBHOOK {
+	} else if apiProject.APIType != constants.HTTP && apiProject.APIType != constants.WS && apiProject.APIType != constants.WEBHOOK {
 		errMsg := "API type is not currently supported with Choreo Connect"
 		err = errors.New(errMsg)
 		return err
@@ -197,7 +199,7 @@ func (apiProject *ProjectAPI) ProcessFilesInsideProject(fileContent []byte, file
 			return conversionErr
 		}
 		apiProject.OpenAPIJsn = swaggerJsn
-		apiProject.APIType = HTTP
+		apiProject.APIType = constants.HTTP
 	} else if strings.Contains(fileName, interceptorCertDir+string(os.PathSeparator)) &&
 		(strings.HasSuffix(fileName, crtExtension) || strings.HasSuffix(fileName, pemExtension)) {
 		if !tlsutils.IsPublicCertificate(fileContent) {

--- a/adapter/internal/oasparser/operator/operator_test.go
+++ b/adapter/internal/oasparser/operator/operator_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wso2/product-microgateway/adapter/config"
+	"github.com/wso2/product-microgateway/adapter/internal/oasparser/constants"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/model"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/operator"
 	"github.com/wso2/product-microgateway/adapter/internal/oasparser/utills"
@@ -236,7 +237,7 @@ func testGetMgwSwaggerWebSocket(t *testing.T, apiYamlFilePath string) {
 	apiYaml = model.PopulateEndpointsInfo(apiYaml)
 	assert.Nil(t, err, "Error occured while parsing api.yaml")
 	var mgwSwagger model.MgwSwagger
-	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, model.WS)
+	err = mgwSwagger.PopulateSwaggerFromAPIYaml(apiYaml, constants.WS)
 	assert.Nil(t, err, "Error while populating the MgwSwagger object for web socket APIs")
 	if strings.HasSuffix(apiYamlFilePath, "api.yaml") {
 		assert.Equal(t, mgwSwagger.GetAPIType(), "WS", "API type for websocket mismatch")


### PR DESCRIPTION
### Purpose
Move constants to a separate package to avoid confusions with variables and models, and having to use special patterns when naming constants.

### Issues
Fixes https://github.com/wso2/product-microgateway/issues/2629
Related to https://github.com/wso2/product-microgateway/issues/2613

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
