### PR TITLE
int-test: Fix intermittent test failure when undeploying API 

### DIFF
--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/standalone/CcWithMultipleEnv.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/standalone/CcWithMultipleEnv.java
@@ -79,7 +79,7 @@ public class CcWithMultipleEnv {
         // Undeploy the API from specific environment
         ApictlUtils.undeployAPI("SwaggerPetstoreDeploy", "1.0.5", "test2", "localhost",
                 "Default");
-        response = HttpsClientRequest.doGet(Utils.getServiceURLHttps(
+        response = HttpsClientRequest.retryUntil404(Utils.getServiceURLHttps(
                 "/v2/new/pet/findByStatus?status=available") , headers);
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_NOT_FOUND,"Response code mismatched " +


### PR DESCRIPTION
### Purpose
Fix intermittent test failure when undeploying API in CcWithMultipleEnv

### Issues
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
