### PR TITLE
[test-case fix] Waiting time increase for source control related tests

### DIFF
--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/standalone/CcWithSourceControl.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/standalone/CcWithSourceControl.java
@@ -45,7 +45,7 @@ public class CcWithSourceControl {
         ccInstance.start();
 
         Awaitility.await().pollDelay(10, TimeUnit.SECONDS).pollInterval(10, TimeUnit.SECONDS)
-                .atMost(4, TimeUnit.MINUTES).until(ccInstance.isGitHealthy());
+                .atMost(6, TimeUnit.MINUTES).until(ccInstance.isGitHealthy());
 
         // Generate an access token for accessing the git instance
         SourceControlUtils.generateAccessToken();


### PR DESCRIPTION
### Purpose
Fixes build failure happens due to the test case failures. This PR increases the waiting time relevant to the CC instance used in source control test cases.

### Issues
https://github.com/wso2/product-microgateway/issues/2676

Fixes # 

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments

Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
