### PR TITLE
Fix issue with source watcher startup

### DIFF
--- a/adapter/internal/adapter/adapter.go
+++ b/adapter/internal/adapter/adapter.go
@@ -273,7 +273,15 @@ func Run(conf *config.Config) {
 		go synchronizer.UpdateBlockingConditions()
 	} else {
 		if conf.Adapter.SourceControl.Enabled{
-			sourcewatcher.Start()
+			err := sourcewatcher.Start()
+			if err != nil {
+				logger.LoggerMgw.ErrorC(logging.ErrorDetails{
+					Message:   fmt.Sprintf("Error while starting source watcher. %v", err.Error()),
+					Severity:  logging.CRITICAL,
+					ErrorCode: 1108,
+				})
+				return
+			}
 		} else {
 			_, err := api.ProcessMountedAPIProjects()
 		  	if err != nil {

--- a/adapter/internal/sourcewatcher/sourcewatcher.go
+++ b/adapter/internal/sourcewatcher/sourcewatcher.go
@@ -45,7 +45,7 @@ const (
 var artifactsMap map[string]model.ProjectAPI
 
 // Start fetches the API artifacts at the startup and polls for changes from the remote repository
-func Start() {
+func Start() error{
 	conf, _ := config.ReadConfigs()
 
 	retryInterval := conf.Adapter.SourceControl.RetryInterval
@@ -72,7 +72,7 @@ func Start() {
 			Severity: logging.CRITICAL,
 			ErrorCode: 2511,
 		})
-		return
+		return err
 	}
 
 	artifactsMap, err = api.ProcessMountedAPIProjects()
@@ -82,10 +82,12 @@ func Start() {
 			Severity: logging.CRITICAL,
 			ErrorCode: 2500,
 		})
+		return err
 	}
 
 	loggers.LoggerSourceWatcher.Info("Polling for changes")
 	go pollChanges(repository)
+	return nil
 }
 
 // fetchArtifacts clones the API artifacts from the remote repository into the artifacts directory in the adapter


### PR DESCRIPTION
### Purpose
The readiness API is deployed and the sourcewatcher starts polling even when retrying to fetch artifacts from the repository fails.  This fixes the issue.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2676

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
