### PR TITLE
Add default version support

### DIFF
--- a/adapter/internal/api/apis_impl.go
+++ b/adapter/internal/api/apis_impl.go
@@ -300,7 +300,14 @@ func ApplyAPIProjectFromAPIM(
 			allEnvironments, vhost, apiYaml.Name, apiYaml.Version, apiYaml.ID)
 		// We don't need to be environment specific when checking default version. It's applied at API level
 		// hence picking 0th index here.
-		apiYaml.IsDefaultVersion = xds.APIListMap[allEnvironments[0]][apiYaml.ID].IsDefaultVersion
+		if api, ok := xds.APIListMap[allEnvironments[0]][apiYaml.ID]; ok {
+			apiYaml.IsDefaultVersion = api.IsDefaultVersion
+		} else {
+			// APIListMap is synchronously updated only for default version changes. In other API deployment
+			// events, this may not be updated. We can safely ignore this case since runtime artifact's
+			// `isDefaultVersion` prop is anyway updated for deployment events.
+			loggers.LoggerAPI.Debugf("API %s is not found in API Metadata map.", apiYaml.ID)
+		}
 		// first update the API for vhost
 		deployedRevision, err := xds.UpdateAPI(vhost, apiProject, allEnvironments)
 		if err != nil {

--- a/adapter/internal/api/apis_impl.go
+++ b/adapter/internal/api/apis_impl.go
@@ -260,7 +260,7 @@ func ApplyAPIProjectFromAPIM(
 	if err != nil {
 		return nil, err
 	}
-	apiYaml := apiProject.APIYaml.Data
+	apiYaml := &apiProject.APIYaml.Data
 	if apiEnvProps, found := apiEnvs[apiProject.APIYaml.Data.ID]; found {
 		loggers.LoggerAPI.Infof("Environment specific values found for the API %v ", apiProject.APIYaml.Data.ID)
 		apiProject.APIEnvProps = apiEnvProps
@@ -298,6 +298,9 @@ func ApplyAPIProjectFromAPIM(
 		allEnvironments := xds.GetAllEnvironments(apiYaml.ID, vhost, environments)
 		loggers.LoggerAPI.Debugf("Update all environments (%v) of API %v %v:%v with UUID \"%v\".",
 			allEnvironments, vhost, apiYaml.Name, apiYaml.Version, apiYaml.ID)
+		// We don't need to be environment specific when checking default version. It's applied at API level
+		// hence picking 0th index here.
+		apiYaml.IsDefaultVersion = xds.APIListMap[allEnvironments[0]][apiYaml.ID].IsDefaultVersion
 		// first update the API for vhost
 		deployedRevision, err := xds.UpdateAPI(vhost, apiProject, allEnvironments)
 		if err != nil {

--- a/adapter/internal/discovery/xds/server.go
+++ b/adapter/internal/discovery/xds/server.go
@@ -482,8 +482,8 @@ func GetAllEnvironments(apiUUID, vhost string, newEnvironments []string) []strin
 	return allEnvironments
 }
 
-// GetDeployedEnvironmets returns all the environments the API with `apiUUID` is deployed to
-func GetDeployedEnvironmets(apiUUID string) []string {
+// GetDeployedEnvironments returns all the environments the API with `apiUUID` is deployed to
+func GetDeployedEnvironments(apiUUID string) []string {
 	var envs []string
 	if envMap, ok := apiUUIDToGatewayToVhosts[apiUUID]; ok {
 		envs = make([]string, 0, len(envMap))

--- a/adapter/internal/discovery/xds/server.go
+++ b/adapter/internal/discovery/xds/server.go
@@ -482,6 +482,18 @@ func GetAllEnvironments(apiUUID, vhost string, newEnvironments []string) []strin
 	return allEnvironments
 }
 
+// GetDeployedEnvironmets returns all the environments the API with `apiUUID` is deployed to
+func GetDeployedEnvironmets(apiUUID string) []string {
+	var envs []string
+	if envMap, ok := apiUUIDToGatewayToVhosts[apiUUID]; ok {
+		envs = make([]string, 0, len(envMap))
+		for k := range envMap {
+			envs = append(envs, k)
+		}
+	}
+	return envs
+}
+
 // GetVhostOfAPI returns the vhost of API deployed in the given gateway environment
 func GetVhostOfAPI(apiUUID, environment string) (vhost string, exists bool) {
 	if envToVhost, ok := apiUUIDToGatewayToVhosts[apiUUID]; ok {

--- a/adapter/internal/eventhub/subscription.go
+++ b/adapter/internal/eventhub/subscription.go
@@ -205,8 +205,8 @@ func LoadSubscriptionData(configFile *config.Config, initialAPIUUIDListMap map[s
 	go retrieveAPIListFromChannel(APIListChannel, nil)
 }
 
-// UpdatAPIMetadataFromCP Invokes `ApisEndpoint` and updates APIList synchronously.
-func UpdatAPIMetadataFromCP(params map[string]string) {
+// UpdateAPIMetadataFromCP Invokes `ApisEndpoint` and updates APIList synchronously.
+func UpdateAPIMetadataFromCP(params map[string]string) {
 	var apiList *types.APIList
 	var responseChannel = make(chan response)
 	go InvokeService(ApisEndpoint, apiList, params, responseChannel, 0)

--- a/adapter/internal/eventhub/subscription.go
+++ b/adapter/internal/eventhub/subscription.go
@@ -205,6 +205,16 @@ func LoadSubscriptionData(configFile *config.Config, initialAPIUUIDListMap map[s
 	go retrieveAPIListFromChannel(APIListChannel, nil)
 }
 
+// UpdatAPIMetadataFromCP Invokes `ApisEndpoint` and updates APIList synchronously.
+func UpdatAPIMetadataFromCP(params map[string]string) {
+	var apiList *types.APIList
+	var responseChannel = make(chan response)
+	go InvokeService(ApisEndpoint, apiList, params, responseChannel, 0)
+	// TODO: (Praminda) - discuss why we wait in a loop in other places?
+	response := <-responseChannel
+	retrieveAPIList(response, nil)
+}
+
 // InvokeService invokes the internal data resource
 func InvokeService(endpoint string, responseType interface{}, queryParamMap map[string]string, c chan response,
 	retryAttempt int) {

--- a/adapter/internal/eventhub/subscription.go
+++ b/adapter/internal/eventhub/subscription.go
@@ -210,7 +210,6 @@ func UpdatAPIMetadataFromCP(params map[string]string) {
 	var apiList *types.APIList
 	var responseChannel = make(chan response)
 	go InvokeService(ApisEndpoint, apiList, params, responseChannel, 0)
-	// TODO: (Praminda) - discuss why we wait in a loop in other places?
 	response := <-responseChannel
 	retrieveAPIList(response, nil)
 }

--- a/adapter/internal/messaging/notification_listener.go
+++ b/adapter/internal/messaging/notification_listener.go
@@ -142,13 +142,13 @@ func processNotificationEvent(conf *config.Config, notification *msg.EventNotifi
 // map and update runtime artifact's `isDefaultVersion` field to correctly deploy default
 // versioned API.
 func handleDefaultVersionUpdate(event msg.APIEvent) {
-	deployedEnvs := xds.GetDeployedEnvironmets(event.UUID)
+	deployedEnvs := xds.GetDeployedEnvironments(event.UUID)
 	for _, env := range deployedEnvs {
 		query := make(map[string]string, 3)
 		query[eh.GatewayLabelParam] = env
 		query[eh.ContextParam] = event.APIContext
 		query[eh.VersionParam] = event.APIVersion
-		eh.UpdatAPIMetadataFromCP(query)
+		eh.UpdateAPIMetadataFromCP(query)
 	}
 
 	synchronizer.FetchAPIsFromControlPlane(event.UUID, deployedEnvs)

--- a/adapter/internal/messaging/notification_listener.go
+++ b/adapter/internal/messaging/notification_listener.go
@@ -226,6 +226,7 @@ func handleAPIEvents(data []byte, eventType string) {
 						logger.LoggerInternalMsg.Debugf("API Metadata for api Id: %s is not updated as it already exists", apiEvent.UUID)
 						continue
 					}
+					logger.LoggerInternalMsg.Debugf("Fetching Metadata for api Id: %s ", apiEvent.UUID)
 					queryParamMap := make(map[string]string, 3)
 					queryParamMap[eh.GatewayLabelParam] = configuredEnv
 					queryParamMap[eh.ContextParam] = apiEvent.Context

--- a/adapter/internal/messaging/notification_listener.go
+++ b/adapter/internal/messaging/notification_listener.go
@@ -169,7 +169,7 @@ func handleAPIEvents(data []byte, eventType string) {
 
 	for _, env := range apiEvent.GatewayLabels {
 		if isLaterEvent(apiListTimeStampMap, apiEvent.UUID+":"+env, currentTimeStamp) {
-			return
+			break
 		}
 		// removeFromGateway event with multiple labels could only appear when the API is subjected
 		// to delete. Hence we could simply delete after checking against just one iteration.
@@ -181,7 +181,7 @@ func handleAPIEvents(data []byte, eventType string) {
 					xds.UpdateEnforcerAPIList(env, xdsAPIList)
 				}
 			}
-			return
+			break
 		}
 		if strings.EqualFold(deployAPIToGateway, apiEvent.Event.Type) {
 			conf, _ := config.ReadConfigs()

--- a/adapter/internal/oasparser/envoyconf/envoyconf_internal_test.go
+++ b/adapter/internal/oasparser/envoyconf/envoyconf_internal_test.go
@@ -46,19 +46,16 @@ func TestGenerateRoutePaths(t *testing.T) {
 	basePath := "/basePath"
 	resourcePath := "/resource"
 
-	completeRoutePath := generateRoutePath(xWso2BasePath, basePath, resourcePath)
+	filteredBasePath := getFilteredBasePath(xWso2BasePath, basePath)
+	completeRoutePath := generateRoutePath(filteredBasePath, resourcePath)
 	// TODO: (VirajSalaka) check if it is possible to perform an equals operation instead of prefix
 	if !strings.HasPrefix(completeRoutePath, "^/xWso2BasePath/resource") {
 		t.Error("The generated path should contain xWso2BasePath as a prefix if xWso2Basepath is available.")
 	}
 
-	xWso2BasePath = "/xWso2BasePath/"
-	if !strings.HasPrefix(completeRoutePath, "^/xWso2BasePath/resource") {
-		t.Error("The generated path should not contain the trailing '\\' of xWso2BasePath property within the generated route path.")
-	}
-
 	xWso2BasePath = ""
-	completeRoutePath = generateRoutePath(xWso2BasePath, basePath, resourcePath)
+	filteredBasePath = getFilteredBasePath(xWso2BasePath, basePath)
+	completeRoutePath = generateRoutePath(filteredBasePath, resourcePath)
 	if !strings.HasPrefix(completeRoutePath, "^/basePath/resource") {
 		t.Error("The generated path should contain basePath as a prefix if xWso2Basepath is unavailable.")
 	}

--- a/adapter/internal/oasparser/envoyconf/envoyconf_internal_test.go
+++ b/adapter/internal/oasparser/envoyconf/envoyconf_internal_test.go
@@ -46,7 +46,7 @@ func TestGenerateRoutePaths(t *testing.T) {
 	basePath := "/basePath"
 	resourcePath := "/resource"
 
-	completeRoutePath := generateRoutePaths(xWso2BasePath, basePath, resourcePath)
+	completeRoutePath := generateRoutePath(xWso2BasePath, basePath, resourcePath)
 	// TODO: (VirajSalaka) check if it is possible to perform an equals operation instead of prefix
 	if !strings.HasPrefix(completeRoutePath, "^/xWso2BasePath/resource") {
 		t.Error("The generated path should contain xWso2BasePath as a prefix if xWso2Basepath is available.")
@@ -58,7 +58,7 @@ func TestGenerateRoutePaths(t *testing.T) {
 	}
 
 	xWso2BasePath = ""
-	completeRoutePath = generateRoutePaths(xWso2BasePath, basePath, resourcePath)
+	completeRoutePath = generateRoutePath(xWso2BasePath, basePath, resourcePath)
 	if !strings.HasPrefix(completeRoutePath, "^/basePath/resource") {
 		t.Error("The generated path should contain basePath as a prefix if xWso2Basepath is unavailable.")
 	}

--- a/adapter/internal/oasparser/envoyconf/internal_dtos.go
+++ b/adapter/internal/oasparser/envoyconf/internal_dtos.go
@@ -43,4 +43,5 @@ type routeCreateParams struct {
 	rewritePath                  string
 	rewriteMethod                bool
 	passRequestPayloadToEnforcer bool
+	isDefaultVersion             bool
 }

--- a/adapter/internal/oasparser/envoyconf/listener_test.go
+++ b/adapter/internal/oasparser/envoyconf/listener_test.go
@@ -107,11 +107,11 @@ func testCreateRoutesForUnitTests(t *testing.T) []*routev3.Route {
 	}
 
 	route1 := createRoute(generateRouteCreateParamsForUnitTests("test", "HTTP", "localhost", "/test", "1.0.0", "/test",
-		"/testPath", []string{"GET"}, "test-cluster", "", corsConfigModel3))
+		"/testPath", []string{"GET"}, "test-cluster", "", corsConfigModel3, false))
 	route2 := createRoute(generateRouteCreateParamsForUnitTests("test", "HTTP", "localhost", "/test", "1.0.0", "/test",
-		"/testPath", []string{"POST"}, "test-cluster", "", corsConfigModel3))
+		"/testPath", []string{"POST"}, "test-cluster", "", corsConfigModel3, false))
 	route3 := createRoute(generateRouteCreateParamsForUnitTests("test", "HTTP", "localhost", "/test", "1.0.0", "/test",
-		"/testPath", []string{"PUT"}, "test-cluster", "", corsConfigModel3))
+		"/testPath", []string{"PUT"}, "test-cluster", "", corsConfigModel3, false))
 
 	routes := []*routev3.Route{route1, route2, route3}
 

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -1328,5 +1328,5 @@ func getDefaultResourceMethods(apiType string) []string {
 
 func getDefaultVersionBasepath(basePath string, version string) string {
 	context := strings.ReplaceAll(basePath, "/"+version, "")
-	return "(" + basePath + "|" + context + ")"
+	return fmt.Sprintf("(%s|%s)", basePath, context)
 }

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -662,9 +662,6 @@ func createTLSProtocolVersion(tlsVersion string) tlsv3.TlsParameters_TlsProtocol
 // endpoint's basePath, resource Object (Microgateway's internal representation), production clusterName and
 // sandbox clusterName needs to be provided.
 func createRoute(params *routeCreateParams) *routev3.Route {
-	// func createRoute(title string, apiType string, xWso2Basepath string, version string, endpointBasepath string,
-	// 	resourcePathParam string, resourceMethods []string, prodClusterName string, sandClusterName string,
-	// 	corsPolicy *routev3.CorsPolicy) *routev3.Route {
 	title := params.title
 	version := params.version
 	vHost := params.vHost
@@ -691,7 +688,7 @@ func createRoute(params *routeCreateParams) *routev3.Route {
 		responseHeadersToRemove []string
 	)
 
-	routePath := generateRoutePaths(xWso2Basepath, endpointBasepath, resourcePath)
+	routePath := generateRoutePath(xWso2Basepath, endpointBasepath, resourcePath)
 
 	match = &routev3.RouteMatch{
 		PathSpecifier: &routev3.RouteMatch_SafeRegex{
@@ -708,7 +705,7 @@ func createRoute(params *routeCreateParams) *routev3.Route {
 
 	// if any of the operations on the route path has a method rewrite policy,
 	// we remove the :method header matching,
-	// because envoy does not allow method rewrting later if the following method regex doesnot have the new method.
+	// because envoy does not allow method rewrting later if the following method regex does not have the new method.
 	// hence when method rewriting is enabled for the resource, the method validation will be handled by the enforcer instead of the router.
 	if !params.rewriteMethod {
 		// OPTIONS is always added even if it is not listed under resources
@@ -1138,15 +1135,14 @@ func CreateReadyEndpoint() *routev3.Route {
 	return &router
 }
 
-// generateRoutePaths generates route paths for the api resources.
-func generateRoutePaths(xWso2Basepath, basePath, resourcePath string) string {
+// generateRoutePath generates route paths for the api resources.
+func generateRoutePath(xWso2Basepath, basePath, resourcePath string) string {
 	prefix := ""
 	newPath := ""
 	if strings.TrimSpace(xWso2Basepath) != "" {
-		prefix = basepathConsistent(xWso2Basepath)
-
+		prefix = getFilteredBasePath(xWso2Basepath)
 	} else {
-		prefix = basepathConsistent(basePath)
+		prefix = getFilteredBasePath(basePath)
 		// TODO: (VirajSalaka) Decide if it is possible to proceed without both basepath options
 	}
 	if strings.Contains(resourcePath, "?") {
@@ -1157,7 +1153,7 @@ func generateRoutePaths(xWso2Basepath, basePath, resourcePath string) string {
 	return newPath
 }
 
-func basepathConsistent(basePath string) string {
+func getFilteredBasePath(basePath string) string {
 	modifiedBasePath := basePath
 	if !strings.HasPrefix(basePath, "/") {
 		modifiedBasePath = "/" + modifiedBasePath

--- a/adapter/internal/oasparser/model/api_yaml.go
+++ b/adapter/internal/oasparser/model/api_yaml.go
@@ -46,6 +46,7 @@ type APIYaml struct {
 		AuthorizationHeader        string   `json:"authorizationHeader,omitempty"`
 		SecurityScheme             []string `json:"securityScheme,omitempty"`
 		OrganizationID             string   `json:"organizationId,omitempty"`
+		IsDefaultVersion           bool     `json:"isDefaultVersion,omitempty"`
 		EndpointConfig             struct {
 			EndpointType                 string              `json:"endpoint_type,omitempty"`
 			LoadBalanceAlgo              string              `json:"algoCombo,omitempty"`

--- a/adapter/internal/oasparser/model/mgw_swagger.go
+++ b/adapter/internal/oasparser/model/mgw_swagger.go
@@ -68,6 +68,7 @@ type MgwSwagger struct {
 	EndpointImplementationType string
 	LifecycleStatus            string
 	xWso2RequestBodyPass       bool
+	IsDefaultVersion           bool
 }
 
 // EndpointCluster represent an upstream cluster
@@ -1134,6 +1135,7 @@ func (swagger *MgwSwagger) PopulateFromAPIYaml(apiYaml APIYaml) error {
 	// context value in api.yaml is assigned as xWso2Basepath
 	swagger.xWso2Basepath = data.Context + "/" + swagger.version
 	swagger.LifecycleStatus = data.LifeCycleStatus
+	swagger.IsDefaultVersion = data.IsDefaultVersion
 
 	// productionURL & sandBoxURL values are extracted from endpointConfig in api.yaml
 	endpointConfig := data.EndpointConfig

--- a/adapter/pkg/messaging/azure_listener.go
+++ b/adapter/pkg/messaging/azure_listener.go
@@ -79,9 +79,9 @@ func startBrokerConsumer(connectionString string, sub Subscription, reconnectInt
 						logger.LoggerMsg.Errorf("Failed to parse the ASB message. %v", err)
 					}
 
-					logger.LoggerMsg.Debugf("Message %s from ASB waits to be processed.", message.MessageID)
+					logger.LoggerMsg.Debugf("Message %s from ASB is waiting to be processed.", message.MessageID)
 					dataChannel <- body
-					logger.LoggerMsg.Debugf("Message %s from ASB is complete", message.MessageID)
+					logger.LoggerMsg.Debugf("Message %s from ASB is processed", message.MessageID)
 
 					err = receiver.CompleteMessage(ctx, message)
 					if err != nil {

--- a/adapter/pkg/messaging/event_types.go
+++ b/adapter/pkg/messaging/event_types.go
@@ -118,6 +118,7 @@ type APIEvent struct {
 	Version string `json:"version"`
 	Context string `json:"context"`
 	Name    string `json:"name"`
+	Action  string `json:"action"`
 }
 
 // ApplicationRegistrationEvent for struct application registration events

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apiDeploy/DefaultVersionApiTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apiDeploy/DefaultVersionApiTestCase.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org).
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy;
+
+import org.apache.http.HttpStatus;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.choreo.connect.tests.common.model.API;
+import org.wso2.choreo.connect.tests.common.model.ApplicationDTO;
+import org.wso2.choreo.connect.tests.context.CCTestException;
+import org.wso2.choreo.connect.tests.util.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test default versioned APIs.
+ */
+public class DefaultVersionApiTestCase {
+    private String testKeyV1, testKeyV2;
+    private final String basePath = "/defaultVersion/";
+    private final String v1 = "1.0.0";
+    private final String v2 = "2.0.0";
+    private final String v1Context = basePath + v1;
+    private final String v2Context = basePath + v2;
+
+    @BeforeClass
+    public void deployAPIs() throws Exception {
+        ApictlUtils.login("test");
+        ApictlUtils.createProject("default_version_v1_OpenAPI.yaml", "default_version_v1", null, null, null,
+                "default_version_v1.yaml");
+        ApictlUtils.createProject("default_version_v2_OpenAPI.yaml", "default_version_v2", null, null, null,
+                "default_version_v2.yaml");
+
+        ApictlUtils.deployAPI("default_version_v1", "test");
+        ApictlUtils.deployAPI("default_version_v2", "test");
+
+        Utils.delay(TestConstant.DEPLOYMENT_WAIT_TIME, "Couldn't wait till deployment completion.");
+
+        API api = new API();
+        api.setName("DefaultVersion");
+        api.setContext(v1Context);
+        api.setVersion(v1);
+        api.setProvider("admin");
+
+        ApplicationDTO app = new ApplicationDTO();
+        app.setName("jwtApp");
+        app.setTier("Unlimited");
+        app.setId((int) (Math.random() * 1000));
+
+        testKeyV1 = TokenUtil.getJWT(api, app, "Unlimited", TestConstant.KEY_TYPE_PRODUCTION, 3600, null, true);
+        api.setContext(v2Context);
+        api.setVersion(v2);
+        testKeyV2 = TokenUtil.getJWT(api, app, "Unlimited", TestConstant.KEY_TYPE_PRODUCTION, 3600, null, true);
+    }
+
+    @Test(description = "Test invoking default versioned API without version in the context")
+    public void testInvokingDefaultVersion() throws CCTestException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Internal-Key", testKeyV2);
+        HttpResponse response = HttpsClientRequest.doGet("https://localhost:9095" + basePath + "store/inventory", headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
+        Assert.assertTrue(response.getData().contains("233539"), "Response body mismatched");
+    }
+
+    @Test(description = "Test invoking default versioned API with version in the context")
+    public void testInvokingDefaultVersionWithVersion() throws CCTestException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Internal-Key", testKeyV2);
+        HttpResponse response = HttpsClientRequest.doGet("https://localhost:9095" + v2Context + "/store/inventory", headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
+        Assert.assertTrue(response.getData().contains("233539"), "Response body mismatched");
+    }
+
+    @Test(description = "Test invoking `non` default versioned API")
+    public void testInvokingNoneDefaultVersion() throws CCTestException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Internal-Key", testKeyV1);
+        HttpResponse response = HttpsClientRequest.doGet("https://localhost:9095" + v1Context + "/pet/3", headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
+        Assert.assertTrue(response.getData().contains("John Doe"), "Response body mismatched");
+
+        // V1 doesn't have /user/john resource. We should try to invoke it and see if the traffic is routing to the
+        // correct API
+        response = HttpsClientRequest.doGet("https://localhost:9095" + v1Context + "/store/inventory", headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_NOT_FOUND, "Response code mismatched");
+    }
+}

--- a/integration/test-integration/src/test/resources/apiYaml/default_version_v1.yaml
+++ b/integration/test-integration/src/test/resources/apiYaml/default_version_v1.yaml
@@ -1,0 +1,24 @@
+type: api
+version: v4.0.0
+data:
+  name: DefaultVersion
+  context: /defaultVersion/1.0.0
+  version: 1.0.0
+  provider: admin
+  lifeCycleStatus: PUBLISHED
+  isDefaultVersion: false
+  isRevision: false
+  revisionId: 0
+  type: HTTP
+  transport:
+    - http
+    - https
+  policies:
+    - Unlimited
+  visibility: PUBLIC
+  endpointConfig:
+    endpoint_type: http
+    production_endpoints:
+      url: http://mockBackend:2383/v2
+  endpointImplementationType: ENDPOINT
+  websubSubscriptionConfiguration: null

--- a/integration/test-integration/src/test/resources/apiYaml/default_version_v2.yaml
+++ b/integration/test-integration/src/test/resources/apiYaml/default_version_v2.yaml
@@ -1,0 +1,24 @@
+type: api
+version: v4.0.0
+data:
+  name: DefaultVersion
+  context: /defaultVersion/2.0.0
+  version: 2.0.0
+  provider: admin
+  lifeCycleStatus: PUBLISHED
+  isDefaultVersion: true
+  isRevision: false
+  revisionId: 0
+  type: HTTP
+  transport:
+    - http
+    - https
+  policies:
+    - Unlimited
+  visibility: PUBLIC
+  endpointConfig:
+    endpoint_type: http
+    production_endpoints:
+      url: http://mockBackend:2383/v2
+  endpointImplementationType: ENDPOINT
+  websubSubscriptionConfiguration: null

--- a/integration/test-integration/src/test/resources/openAPIs/default_version_v1_OpenAPI.yaml
+++ b/integration/test-integration/src/test/resources/openAPIs/default_version_v1_OpenAPI.yaml
@@ -1,0 +1,82 @@
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: DefaultVersion
+x-wso2-production-endpoints:
+  urls:
+    - 'http://mockBackend:2383/v2'
+x-wso2-basePath: /defaultVersion/1.0.0
+schemes:
+  - http
+paths:
+  '/pet/{petId}':
+    get:
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+definitions:
+  Pet:
+    type: object
+    required:
+      - name
+      - photoUrls
+    properties:
+      id:
+        type: integer
+        format: int64
+      category:
+        $ref: '#/definitions/Category'
+      name:
+        type: string
+        example: doggie
+      photoUrls:
+        type: array
+        xml:
+          wrapped: true
+        items:
+          type: string
+          xml:
+            name: photoUrl
+      tags:
+        type: array
+        xml:
+          wrapped: true
+        items:
+          xml:
+            name: tag
+          $ref: '#/definitions/Tag'
+      status:
+        type: string
+        description: pet status in the store
+        enum:
+          - available
+          - pending
+          - sold
+    xml:
+      name: Pet
+  Tag:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+    xml:
+      name: Tag

--- a/integration/test-integration/src/test/resources/openAPIs/default_version_v2_OpenAPI.yaml
+++ b/integration/test-integration/src/test/resources/openAPIs/default_version_v2_OpenAPI.yaml
@@ -1,0 +1,95 @@
+swagger: '2.0'
+info:
+  version: 2.0.0
+  title: DefaultVersion
+x-wso2-production-endpoints:
+  urls:
+    - 'http://mockBackend:2383/v2'
+x-wso2-basePath: /defaultVersion/2.0.0
+schemes:
+  - http
+paths:
+  /store/inventory:
+    get:
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: object
+            additionalProperties:
+              type: integer
+              format: int32
+  '/pet/{petId}':
+    get:
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+definitions:
+  Pet:
+    type: object
+    required:
+      - name
+      - photoUrls
+    properties:
+      id:
+        type: integer
+        format: int64
+      category:
+        $ref: '#/definitions/Category'
+      name:
+        type: string
+        example: doggie
+      photoUrls:
+        type: array
+        xml:
+          wrapped: true
+        items:
+          type: string
+          xml:
+            name: photoUrl
+      tags:
+        type: array
+        xml:
+          wrapped: true
+        items:
+          xml:
+            name: tag
+          $ref: '#/definitions/Tag'
+      status:
+        type: string
+        description: pet status in the store
+        enum:
+          - available
+          - pending
+          - sold
+    xml:
+      name: Pet
+  Tag:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+    xml:
+      name: Tag

--- a/integration/test-integration/src/test/resources/testng-cc-standalone.xml
+++ b/integration/test-integration/src/test/resources/testng-cc-standalone.xml
@@ -55,6 +55,7 @@
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.interceptor.InterceptorServiceNotAvailableTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.extensions.DisableSecurityTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.mockEndpoint.MockApiTestCase"/>
+            <class name="org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy.DefaultVersionApiTestCase"/>
         </classes>
     </test>
     <test name="cc-with-backend-tls" preserve-order="true" parallel="false">


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
$subject.

default version change event is coming as an API_UPDATE type event from CP. This event doesn't contain enough information for CC to figureout if it should redeploy the API. Hence the `Action` property is introduced to API_UPDATE event.
Also API_UPDATE event doesn't contain the `gatewayLabels` property, therefore we are using internal maps to find the deployed envs of an API when default version change event is received.
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #1581

### Automation tests
 - Unit tests added: Yes
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
