### PR TITLE
Trim spaces in backend endpoints

### DIFF
--- a/adapter/internal/oasparser/model/common.go
+++ b/adapter/internal/oasparser/model/common.go
@@ -129,6 +129,9 @@ func getHostandBasepathandPort(apiType string, rawURL string) (*Endpoint, error)
 		urlType  string
 	)
 
+	// Remove leading and trailing spaces of rawURL
+	rawURL = strings.Trim(rawURL, " ")
+
 	if !strings.Contains(rawURL, "://") {
 		if apiType == constants.HTTP {
 			rawURL = "http://" + rawURL

--- a/adapter/internal/oasparser/model/open_api_internal_test.go
+++ b/adapter/internal/oasparser/model/open_api_internal_test.go
@@ -176,6 +176,17 @@ func TestGetHostandBasepathandPort(t *testing.T) {
 			result:  nil,
 			message: "when malformed endpoint is provided",
 		},
+		{
+			input: "  https://petstore.io:8001/api/v2 ",
+			result: &Endpoint{
+				Host:     "petstore.io",
+				Basepath: "/api/v2",
+				Port:     8001,
+				URLType:  "https",
+				RawURL:   "https://petstore.io:8001/api/v2",
+			},
+			message: "When leading and trailing spaces present",
+		},
 	}
 	for _, item := range dataItems {
 		resultResources, err := getHTTPEndpoint(item.input)


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
Remove leading and/or trailing spaces present in an "endpoint" by trimming the string.
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2707

### Automation tests
 - Unit tests added: Yes
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
OS: Linux
Env: Docker

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
