### PR TITLE
Fix websocket compressed frames not being throttled

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/websocket/WebSocketResponseObserver.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/websocket/WebSocketResponseObserver.java
@@ -79,37 +79,44 @@ public class WebSocketResponseObserver implements StreamObserver<WebSocketFrameR
                     || framedata.getOpcode() == Opcode.CONTINUOUS) {
                     WebSocketFrameRequest webSocketFrameRequestClone = webSocketFrameRequest.toBuilder()
                             .setFrameLength(framedata.getPayloadData().remaining()).build();
-                    WebSocketThrottleResponse webSocketThrottleResponse = webSocketHandler
-                            .process(webSocketFrameRequestClone);
-                    if (WebSocketThrottleState.OK == webSocketThrottleResponse.getWebSocketThrottleState()) {
-                        WebSocketFrameResponse response = WebSocketFrameResponse.newBuilder().setThrottleState(
-                                WebSocketFrameResponse.Code.OK).setApimErrorCode(0).build();
-                        responseStreamObserver.onNext(response);
-                    } else if (WebSocketThrottleState.OVER_LIMIT == webSocketThrottleResponse
-                            .getWebSocketThrottleState()) {
-                        logger.debug("throttle out period" + webSocketThrottleResponse.getThrottlePeriod());
-                        WebSocketFrameResponse response = WebSocketFrameResponse.newBuilder()
-                                .setThrottleState(WebSocketFrameResponse.Code.OVER_LIMIT)
-                                .setThrottlePeriod(webSocketThrottleResponse.getThrottlePeriod())
-                                .setApimErrorCode(webSocketThrottleResponse.getApimErrorCode())
-                                .build();
-                        responseStreamObserver.onNext(response);
-                    } else {
-                        logger.debug("throttle state of the connection is not available in enforcer");
-                        WebSocketFrameResponse webSocketFrameResponse = WebSocketFrameResponse.newBuilder()
-                                .setThrottleState(WebSocketFrameResponse.Code.UNKNOWN).build();
-                        responseStreamObserver.onNext(webSocketFrameResponse);
-                    }
+                    sendWebSocketFrameResponse(webSocketFrameRequestClone);
                 } else {
                     logger.debug("Websocket frame type not related to throttling: {}", framedata.getOpcode());
                 }
             }));
         } catch (InvalidDataException e) {
-            logger.error(e);
+            // temp fix for https://github.com/wso2/product-microgateway/issues/2693
+            logger.error("Error {} when decoding websocket frame. Could be a batched set of " +
+                    "multiple compressed frames. Processing the frame in raw form.", e.getMessage());
+            sendWebSocketFrameResponse(webSocketFrameRequest);
         }
 
         if (!this.throttleKeysInitiated) {
             initializeThrottleKeys(webSocketFrameRequest);
+        }
+    }
+
+    private void sendWebSocketFrameResponse(WebSocketFrameRequest webSocketFrameRequest) {
+        WebSocketThrottleResponse webSocketThrottleResponse = webSocketHandler
+                .process(webSocketFrameRequest);
+        if (WebSocketThrottleState.OK == webSocketThrottleResponse.getWebSocketThrottleState()) {
+            WebSocketFrameResponse response = WebSocketFrameResponse.newBuilder().setThrottleState(
+                    WebSocketFrameResponse.Code.OK).setApimErrorCode(0).build();
+            responseStreamObserver.onNext(response);
+        } else if (WebSocketThrottleState.OVER_LIMIT == webSocketThrottleResponse
+                .getWebSocketThrottleState()) {
+            logger.debug("throttle out period" + webSocketThrottleResponse.getThrottlePeriod());
+            WebSocketFrameResponse response = WebSocketFrameResponse.newBuilder()
+                    .setThrottleState(WebSocketFrameResponse.Code.OVER_LIMIT)
+                    .setThrottlePeriod(webSocketThrottleResponse.getThrottlePeriod())
+                    .setApimErrorCode(webSocketThrottleResponse.getApimErrorCode())
+                    .build();
+            responseStreamObserver.onNext(response);
+        } else {
+            logger.debug("throttle state of the connection is not available in enforcer");
+            WebSocketFrameResponse webSocketFrameResponse = WebSocketFrameResponse.newBuilder()
+                    .setThrottleState(WebSocketFrameResponse.Code.UNKNOWN).build();
+            responseStreamObserver.onNext(webSocketFrameResponse);
         }
     }
 


### PR DESCRIPTION
### Purpose

- Previously when compressed websocket frames arrived, we were unable to get the actual count since we were unable to decode them into separate frames. We logged an error and did not count the frames or throttle. 
- This PR temporarily fixes the issue by counting the raw frames arriving from the router. 
- There can be cases where an entire batch of frames is considered as one frame with this fix. The purpose is to have some sought of a limit.
- This is only relevant to compressed or other extended versions of the websocket protocol. 
- Checkout the issue for more info.

### Issues
Fixes https://github.com/wso2/product-microgateway/issues/2693

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
Tested by using the changes in https://github.com/wso2/product-microgateway/pull/2736 together with the following additional changes:

- Uncomment `WebSocketClientCompressionHandler.INSTANCE` in the class wsClient
- Bandwidth throttling - Update API and app related throttling test cases to send 1024000 byte payloads
- Event count throttling - Run the existing websocket event count testcases as it is

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
