### PR TITLE
[websocket] Send only the payload of a single frame at a time from enforcer to router

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/websocket/WebSocketResponseObserver.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/websocket/WebSocketResponseObserver.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.choreo.connect.enforcer.websocket;
 
+import com.google.protobuf.ByteString;
 import io.grpc.stub.StreamObserver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -78,7 +79,9 @@ public class WebSocketResponseObserver implements StreamObserver<WebSocketFrameR
                 if (framedata.getOpcode() == Opcode.TEXT || framedata.getOpcode() == Opcode.BINARY
                     || framedata.getOpcode() == Opcode.CONTINUOUS) {
                     WebSocketFrameRequest webSocketFrameRequestClone = webSocketFrameRequest.toBuilder()
-                            .setFrameLength(framedata.getPayloadData().remaining()).build();
+                            .setFrameLength(framedata.getPayloadData().remaining())
+                            .setPayload(ByteString.copyFrom(framedata.getPayloadData()))
+                            .build();
                     sendWebSocketFrameResponse(webSocketFrameRequestClone);
                 } else {
                     logger.debug("Websocket frame type not related to throttling: {}", framedata.getOpcode());


### PR DESCRIPTION
### Describe your problem(s)
- We decode the batched of frames at enforcer side to get the exact count of frames
- Thereafter, for each separate frame, we send a `WebSocketFrameResponse` back to the router
- Currently we clone the `WebSocketFrameRequest` and only update the new frame length
- The payload must also be updated

### Purpose
- This PR sets the payload of that single frame to the `WebSocketFrameResponse` within the loop, instead letting it send the payload of the entire batch of frames.

### Issues
Fixes https://github.com/wso2/product-microgateway/issues/2765

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
Tested with the changes in the PR https://github.com/wso2/product-microgateway/pull/2736

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
