### PR TITLE
Remove webhook from supported API types

### DIFF
--- a/adapter/internal/oasparser/model/api_yaml.go
+++ b/adapter/internal/oasparser/model/api_yaml.go
@@ -257,7 +257,7 @@ func (apiYaml APIYaml) ValidateAPIType() (err error) {
 		// If no api.yaml file is included in the zip folder, return with error.
 		err = errors.New("could not find api.yaml or api.json")
 		return err
-	} else if apiType != constants.HTTP && apiType != constants.WS && apiType != constants.WEBHOOK && apiType == constants.SSE {
+	} else if apiType != constants.HTTP && apiType != constants.WS && apiType == constants.SSE {
 		errMsg := "The given API type is currently not supported in Choreo Connect. API type: " + apiType
 		err = errors.New(errMsg)
 		return err


### PR DESCRIPTION
### Purpose
Remove webhook from supported API types when validating the API type in apiYaml from APIM

### Issues
Related to https://github.com/wso2/product-microgateway/issues/2677

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
