### PR TITLE
Enable health when no apis received from GA at the startup

### DIFF
--- a/adapter/pkg/health/controlplane.go
+++ b/adapter/pkg/health/controlplane.go
@@ -51,6 +51,7 @@ func WaitForControlPlane() {
 	restAPIStarted := false
 	// if wait for both jmsStarted and restAPIStarted becomes true
 	for !brokerStarted || !restAPIStarted {
+		logger.LoggerHealth.Debugf("Waiting for connecting to control plane.. brokerStarted:%v restAPIStarted:%v", brokerStarted, restAPIStarted)
 		select {
 		case brokerStarted = <-controlPlaneBrokerStatusChan:
 			logger.LoggerHealth.Debugf("Connection to Control Plane Broker %v", brokerStarted)


### PR DESCRIPTION
### Purpose
This PR will enables the health (in both adapter and router) when empty xds snapshot received from GA at the startup.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/2618

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
Tested locally on minikube.

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
