### PR TITLE
Support Path Params in Rewrite Paths with API Policy

### DIFF
--- a/adapter/internal/oasparser/model/common.go
+++ b/adapter/internal/oasparser/model/common.go
@@ -203,17 +203,17 @@ func unmarshalSwaggerResources(path string, methods []*Operation, vendorExtensio
 func getRewriteRegexFromPathTemplate(pathTemplate, rewritePathTemplate string) (string, error) {
 	rewriteRegex := "/" + strings.TrimSuffix(strings.TrimPrefix(rewritePathTemplate, "/"), "/")
 	pathParamToIndexMap := getPathParamToIndexMap(pathTemplate)
-	r := regexp.MustCompile(`{uri.var.([^{}]+)}`)
+	r := regexp.MustCompile(`{uri.var.([^{}]+)}`) // define a capture group to catch the path param
 	matches := r.FindAllStringSubmatch(rewritePathTemplate, -1)
 	for _, match := range matches {
-		if len(match) > 1 {
-			templatedParam := match[0]
-			param := match[1]
-			if index, ok := pathParamToIndexMap[param]; ok {
-				rewriteRegex = strings.ReplaceAll(rewriteRegex, templatedParam, fmt.Sprintf(`\%d`, index))
-			} else {
-				return "", fmt.Errorf("invalid path param %q in rewrite path", param)
-			}
+		// match is slice always with length two (since one capture group is defined in the regex)
+		// hence we do not want to explicitly validate the slice length
+		templatedParam := match[0]
+		param := match[1]
+		if index, ok := pathParamToIndexMap[param]; ok {
+			rewriteRegex = strings.ReplaceAll(rewriteRegex, templatedParam, fmt.Sprintf(`\%d`, index))
+		} else {
+			return "", fmt.Errorf("invalid path param %q in rewrite path", param)
 		}
 	}
 
@@ -229,12 +229,12 @@ func getRewriteRegexFromPathTemplate(pathTemplate, rewritePathTemplate string) (
 // getPathParamToIndexMap returns a map of path params to its index (map of path param -> index)
 func getPathParamToIndexMap(pathTemplate string) map[string]int {
 	indexMap := make(map[string]int)
-	r := regexp.MustCompile(`{([^{}]+)}`)
+	r := regexp.MustCompile(`{([^{}]+)}`) // define a capture group to catch the path param
 	matches := r.FindAllStringSubmatch(pathTemplate, -1)
 	for i, paramMatches := range matches {
-		if len(paramMatches) > 1 {
-			indexMap[paramMatches[1]] = i + 1
-		}
+		// paramMatches is slice always with length two (since one capture group is defined in the regex)
+		// hence we do not want to explicitly validate the slice length
+		indexMap[paramMatches[1]] = i + 1
 	}
 	return indexMap
 }

--- a/adapter/internal/oasparser/model/common_test.go
+++ b/adapter/internal/oasparser/model/common_test.go
@@ -39,6 +39,13 @@ func TestGetRewriteRegexFromPathTemplate(t *testing.T) {
 			message:             `Two params with same order`,
 		},
 		{
+			pathTemplate:        `/abc/shop/{shopId}.xyz/pets/{petId}`,
+			rewritePathTemplate: `/abc-shops/shops/{uri.var.shopId}/pets/{uri.var.petId}.pet`,
+			regexRewritePath:    `/abc-shops/shops/\1/pets/\2.pet`,
+			isExpError:          false,
+			message:             `Two params with same order`,
+		},
+		{
 			pathTemplate:        `/abc/shop/{shopId}/pets/{petId}`,
 			rewritePathTemplate: `/abc-shops/pets/{uri.var.petId}/shops/{uri.var.shopId}`,
 			regexRewritePath:    `/abc-shops/pets/\2/shops/\1`,

--- a/adapter/internal/oasparser/model/common_test.go
+++ b/adapter/internal/oasparser/model/common_test.go
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRewriteRegexFromPathTemplate(t *testing.T) {
+	tests := []struct {
+		pathTemplate        string
+		rewritePathTemplate string
+		regexRewritePath    string
+		message             string
+	}{
+		{
+			pathTemplate:        `/abc/shop/{shopId}/pets/{petId}`,
+			rewritePathTemplate: `/abc-shops/shops/{uri.var.shopId}/pets/{uri.var.petId}`,
+			regexRewritePath:    `/abc-shops/shops/\1/pets/\2`,
+			message:             `Two params with same order`,
+		},
+		{
+			pathTemplate:        `/abc/shop/{shopId}/pets/{petId}`,
+			rewritePathTemplate: `/abc-shops/pets/{uri.var.petId}/shops/{uri.var.shopId}`,
+			regexRewritePath:    `/abc-shops/pets/\2/shops/\1`,
+			message:             `Two params with different order`,
+		},
+		{
+			pathTemplate:        `/abc/shop/{shopId}/pets/{petId}`,
+			rewritePathTemplate: `/abc-shops/pets/{uri.var.petId}/shops/{uri.var.shopId}/{uri.var.petId}`,
+			regexRewritePath:    `/abc-shops/pets/\2/shops/\1/\2`,
+			message:             `Two params with multiple times`,
+		},
+		{
+			pathTemplate:        `/abc/shop/pets`,
+			rewritePathTemplate: `/abc-shops/pets/`,
+			regexRewritePath:    `/abc-shops/pets`,
+			message:             `No params`,
+		},
+	}
+
+	for _, test := range tests {
+		regexRewritePath := getRewriteRegexFromPathTemplate(test.pathTemplate, test.rewritePathTemplate)
+		assert.Equal(t, test.regexRewritePath, regexRewritePath)
+	}
+}
+
+func TestGetPathParamToIndexMap(t *testing.T) {
+	tests := []struct {
+		pathTemplate string
+		indexMap     map[string]int
+		message      string
+	}{
+		{
+			pathTemplate: `/abc/shop/{shopId}/pets/{petId}`,
+			indexMap:     map[string]int{"shopId": 1, "petId": 2},
+			message:      `Two params`,
+		},
+		{
+			pathTemplate: `/abc/shop`,
+			indexMap:     map[string]int{},
+			message:      `No params`,
+		},
+	}
+
+	for _, test := range tests {
+		indexMap := getPathParamToIndexMap(test.pathTemplate)
+		assert.Equal(t, test.indexMap, indexMap)
+	}
+}

--- a/adapter/internal/oasparser/model/common_test.go
+++ b/adapter/internal/oasparser/model/common_test.go
@@ -28,37 +28,60 @@ func TestGetRewriteRegexFromPathTemplate(t *testing.T) {
 		pathTemplate        string
 		rewritePathTemplate string
 		regexRewritePath    string
+		isExpError          bool
 		message             string
 	}{
 		{
 			pathTemplate:        `/abc/shop/{shopId}/pets/{petId}`,
 			rewritePathTemplate: `/abc-shops/shops/{uri.var.shopId}/pets/{uri.var.petId}`,
 			regexRewritePath:    `/abc-shops/shops/\1/pets/\2`,
+			isExpError:          false,
 			message:             `Two params with same order`,
 		},
 		{
 			pathTemplate:        `/abc/shop/{shopId}/pets/{petId}`,
 			rewritePathTemplate: `/abc-shops/pets/{uri.var.petId}/shops/{uri.var.shopId}`,
 			regexRewritePath:    `/abc-shops/pets/\2/shops/\1`,
+			isExpError:          false,
 			message:             `Two params with different order`,
 		},
 		{
 			pathTemplate:        `/abc/shop/{shopId}/pets/{petId}`,
 			rewritePathTemplate: `/abc-shops/pets/{uri.var.petId}/shops/{uri.var.shopId}/{uri.var.petId}`,
 			regexRewritePath:    `/abc-shops/pets/\2/shops/\1/\2`,
+			isExpError:          false,
 			message:             `Two params with multiple times`,
 		},
 		{
 			pathTemplate:        `/abc/shop/pets`,
 			rewritePathTemplate: `/abc-shops/pets/`,
 			regexRewritePath:    `/abc-shops/pets`,
+			isExpError:          false,
 			message:             `No params`,
+		},
+		{
+			pathTemplate:        `/abc/shop/{shopId}/pets/{petId}`,
+			rewritePathTemplate: `/abc-shops/pets/{uri.var.nonExistingId}`,
+			regexRewritePath:    `/abc-shops/pets/`,
+			isExpError:          true,
+			message:             `Non existing path param`,
+		},
+		{
+			pathTemplate:        `/abc/shop/{shopId}/pets/{petId}`,
+			rewritePathTemplate: `/abc-shops/pets/{invalidParam}`,
+			regexRewritePath:    `/abc-shops/pets/`,
+			isExpError:          true,
+			message:             `Invalid characters`,
 		},
 	}
 
 	for _, test := range tests {
-		regexRewritePath := getRewriteRegexFromPathTemplate(test.pathTemplate, test.rewritePathTemplate)
-		assert.Equal(t, test.regexRewritePath, regexRewritePath)
+		regexRewritePath, err := getRewriteRegexFromPathTemplate(test.pathTemplate, test.rewritePathTemplate)
+		if test.isExpError {
+			assert.Error(t, err, test.message)
+		} else {
+			assert.Equal(t, test.regexRewritePath, regexRewritePath)
+		}
 	}
 }
 

--- a/adapter/internal/oasparser/model/resource.go
+++ b/adapter/internal/oasparser/model/resource.go
@@ -110,8 +110,8 @@ func (resource *Resource) GetRewriteResource() (string, bool) {
 							}
 							rewritePath, found = paramValue.(string)
 							if found {
-								rewritePath = "/" + strings.TrimSuffix(strings.TrimPrefix(rewritePath, "/"), "/")
-								if matched, _ := regexp.MatchString("^[a-zA-Z0-9~/_.-]*$", rewritePath); !matched {
+								rewritePath = getRewriteRegexFromPathTemplate(resource.path, rewritePath)
+								if matched, _ := regexp.MatchString(`^[a-zA-Z0-9~/_.\-\\]*$`, rewritePath); !matched {
 									logger.LoggerOasparser.Error("Rewrite path includes invalid characters")
 									rewritePath = ""
 								}

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apipolicy/APIPolicyTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apipolicy/APIPolicyTestCase.java
@@ -118,6 +118,28 @@ public class APIPolicyTestCase {
         assertOriginalClientRequestInfo(echoResponse);
     }
 
+    @Test(description = "Test rewrite path API Policy with capture groups with invalid param")
+    public void testRewritePathAPIPolicyWithCaptureGroupsInvalidParam() throws Exception {
+        // HTTP method: GET
+        EchoResponse echoResponse = invokeEchoGet(
+                "/echo-full/rewrite-policy-with-capture-groups-invalid-param/shops/shop1234/pets/pet890/orders" + queryParams, headers);
+
+        Assert.assertEquals(echoResponse.getMethod(), HttpMethod.PUT.name());
+        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/rewrite-policy-with-capture-groups-invalid-param/shops/shop1234/pets/pet890/orders");
+        assertOriginalClientRequestInfo(echoResponse);
+    }
+
+    @Test(description = "Test rewrite path API Policy with capture groups with invalid chars")
+    public void testRewritePathAPIPolicyWithCaptureGroupsInvalidChars() throws Exception {
+        // HTTP method: GET
+        EchoResponse echoResponse = invokeEchoGet(
+                "/echo-full/rewrite-policy-with-capture-groups-invalid-chars/shops/shop1234/pets/pet890/orders" + queryParams, headers);
+
+        Assert.assertEquals(echoResponse.getMethod(), HttpMethod.PUT.name());
+        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/rewrite-policy-with-capture-groups-invalid-chars/shops/shop1234/pets/pet890/orders");
+        assertOriginalClientRequestInfo(echoResponse);
+    }
+
     @Test(description = "Test rewrite path and discard queries in rewrite path API Policies")
     public void testRewritePathAndDiscardQueriesAPIPolicy() throws Exception {
         // HTTP method: GET

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apipolicy/APIPolicyTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apipolicy/APIPolicyTestCase.java
@@ -107,6 +107,17 @@ public class APIPolicyTestCase {
         assertOriginalClientRequestInfo(echoResponse);
     }
 
+    @Test(description = "Test rewrite path API Policy with capture groups")
+    public void testRewritePathAPIPolicyWithCaptureGroups() throws Exception {
+        // HTTP method: GET
+        EchoResponse echoResponse = invokeEchoGet(
+                "/echo-full/rewrite-policy-with-capture-groups/shops/shop1234/pets/pet890/orders" + queryParams, headers);
+
+        Assert.assertEquals(echoResponse.getMethod(), HttpMethod.PUT.name());
+        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/pets/pet890/hello-shops/abcd-shops/shop1234");
+        assertOriginalClientRequestInfo(echoResponse);
+    }
+
     @Test(description = "Test rewrite path and discard queries in rewrite path API Policies")
     public void testRewritePathAndDiscardQueriesAPIPolicy() throws Exception {
         // HTTP method: GET

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apipolicy/APIPolicyTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apipolicy/APIPolicyTestCase.java
@@ -111,10 +111,10 @@ public class APIPolicyTestCase {
     public void testRewritePathAPIPolicyWithCaptureGroups() throws Exception {
         // HTTP method: GET
         EchoResponse echoResponse = invokeEchoGet(
-                "/echo-full/rewrite-policy-with-capture-groups/shops/shop1234/pets/pet890/orders" + queryParams, headers);
+                "/echo-full/rewrite-policy-with-capture-groups/shops/shop1234.xyz/pets/pet890/orders" + queryParams, headers);
 
         Assert.assertEquals(echoResponse.getMethod(), HttpMethod.PUT.name());
-        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/pets/pet890/hello-shops/abcd-shops/shop1234");
+        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/pets/pet890.pets/hello-shops/abcd-shops/shop1234");
         assertOriginalClientRequestInfo(echoResponse);
     }
 

--- a/integration/test-integration/src/test/resources/apiYaml/api_policies.yaml
+++ b/integration/test-integration/src/test/resources/apiYaml/api_policies.yaml
@@ -123,7 +123,7 @@ data:
         response: []
         fault: []
     -
-      target: /echo-full/rewrite-policy-with-capture-groups/shops/{shopId}/pets/{petId}/orders
+      target: /echo-full/rewrite-policy-with-capture-groups/shops/{shopId}.xyz/pets/{petId}/orders
       verb: GET
       operationPolicies:
         request:
@@ -137,7 +137,7 @@ data:
             policyName: rewriteResourcePath
             policyVersion: v1
             parameters:
-              newResourcePath: /echo-full/pets/{uri.var.petId}/hello-shops/abcd-shops/{uri.var.shopId}
+              newResourcePath: /echo-full/pets/{uri.var.petId}.pets/hello-shops/abcd-shops/{uri.var.shopId}
               includeQueryParams: true
         response: []
         fault: []

--- a/integration/test-integration/src/test/resources/apiYaml/api_policies.yaml
+++ b/integration/test-integration/src/test/resources/apiYaml/api_policies.yaml
@@ -142,6 +142,44 @@ data:
         response: []
         fault: []
     -
+      target: /echo-full/rewrite-policy-with-capture-groups-invalid-param/shops/{shopId}/pets/{petId}/orders
+      verb: GET
+      operationPolicies:
+        request:
+          -
+            policyName: ccChangeHTTPMethod
+            policyVersion: v1
+            parameters:
+              currentMethod: GET
+              updatedMethod: PUT
+          -
+            policyName: rewriteResourcePath
+            policyVersion: v1
+            parameters:
+              newResourcePath: /echo-full/pets/{uri.var.invalidParamId}/hello-shops
+              includeQueryParams: true
+        response: []
+        fault: []
+    -
+      target: /echo-full/rewrite-policy-with-capture-groups-invalid-chars/shops/{shopId}/pets/{petId}/orders
+      verb: GET
+      operationPolicies:
+        request:
+          -
+            policyName: ccChangeHTTPMethod
+            policyVersion: v1
+            parameters:
+              currentMethod: GET
+              updatedMethod: PUT
+          -
+            policyName: rewriteResourcePath
+            policyVersion: v1
+            parameters:
+              newResourcePath: /echo-full/pets/{invalidChars}/hello-shops
+              includeQueryParams: true
+        response: []
+        fault: []
+    -
       target: /echo-full/rewrite-policy/discard-query-params
       verb: GET
       operationPolicies:

--- a/integration/test-integration/src/test/resources/apiYaml/api_policies.yaml
+++ b/integration/test-integration/src/test/resources/apiYaml/api_policies.yaml
@@ -123,6 +123,25 @@ data:
         response: []
         fault: []
     -
+      target: /echo-full/rewrite-policy-with-capture-groups/shops/{shopId}/pets/{petId}/orders
+      verb: GET
+      operationPolicies:
+        request:
+          -
+            policyName: ccChangeHTTPMethod
+            policyVersion: v1
+            parameters:
+              currentMethod: GET
+              updatedMethod: PUT
+          -
+            policyName: rewriteResourcePath
+            policyVersion: v1
+            parameters:
+              newResourcePath: /echo-full/pets/{uri.var.petId}/hello-shops/abcd-shops/{uri.var.shopId}
+              includeQueryParams: true
+        response: []
+        fault: []
+    -
       target: /echo-full/rewrite-policy/discard-query-params
       verb: GET
       operationPolicies:

--- a/integration/test-integration/src/test/resources/openAPIs/api_policy_openAPI.yaml
+++ b/integration/test-integration/src/test/resources/openAPIs/api_policy_openAPI.yaml
@@ -44,6 +44,12 @@ paths:
       responses:
         '200':
           description: successful operation
+  /echo-full/rewrite-policy-with-capture-groups/shops/{shopId}/pets/{petId}/orders:
+    get:
+      summary: rewrite based policies appied with capture groups
+      responses:
+        '200':
+          description: successful operation
   /echo-full/rewrite-policy/discard-query-params:
     get:
       summary: rewrite path with discard queries

--- a/integration/test-integration/src/test/resources/openAPIs/api_policy_openAPI.yaml
+++ b/integration/test-integration/src/test/resources/openAPIs/api_policy_openAPI.yaml
@@ -44,7 +44,7 @@ paths:
       responses:
         '200':
           description: successful operation
-  /echo-full/rewrite-policy-with-capture-groups/shops/{shopId}/pets/{petId}/orders:
+  /echo-full/rewrite-policy-with-capture-groups/shops/{shopId}.xyz/pets/{petId}/orders:
     get:
       summary: rewrite based policies appied with capture groups
       responses:

--- a/integration/test-integration/src/test/resources/openAPIs/api_policy_openAPI.yaml
+++ b/integration/test-integration/src/test/resources/openAPIs/api_policy_openAPI.yaml
@@ -50,6 +50,18 @@ paths:
       responses:
         '200':
           description: successful operation
+  /echo-full/rewrite-policy-with-capture-groups-invalid-param/shops/{shopId}/pets/{petId}/orders:
+    get:
+      summary: rewrite based policies appied with capture groups with invalid params
+      responses:
+        '200':
+          description: successful operation
+  /echo-full/rewrite-policy-with-capture-groups-invalid-chars/shops/{shopId}/pets/{petId}/orders:
+    get:
+      summary: rewrite based policies appied with capture groups with invalid chars
+      responses:
+        '200':
+          description: successful operation
   /echo-full/rewrite-policy/discard-query-params:
     get:
       summary: rewrite path with discard queries

--- a/integration/test-integration/src/test/resources/testng-cc-standalone.xml
+++ b/integration/test-integration/src/test/resources/testng-cc-standalone.xml
@@ -58,7 +58,7 @@
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy.DefaultVersionApiTestCase"/>
         </classes>
     </test>
-    <test name="cc-with-backend-tls" preserve-order="true" parallel="false">
+    <test name="cc-with-backend-tls-with-opa-server" preserve-order="true" parallel="false">
         <classes>
             <class name="org.wso2.choreo.connect.tests.setup.standalone.CcWithBackendTlsAndCorsDisabledWithOPA"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.mtls.MtlsFromRouterToBackendTestcase"/>


### PR DESCRIPTION
### Purpose
This will support a rewrite of

```
/shops/{shopId}/pets/{petId}/orders
to
/pets/{uri.var.petId}/hello-shops/abcd-shops/{uri.var.shopId}
```

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/2745

### Automation tests
 - Unit tests added: Yes
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Tested in docker compose setup with apictl

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
