### PR TITLE
[Analytics] Publish analytics events for blocked API calls.

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/ChoreoFaultAnalyticsProvider.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/ChoreoFaultAnalyticsProvider.java
@@ -39,6 +39,7 @@ import org.wso2.choreo.connect.enforcer.commons.model.RequestContext;
 import org.wso2.choreo.connect.enforcer.config.ConfigHolder;
 import org.wso2.choreo.connect.enforcer.constants.APIConstants;
 import org.wso2.choreo.connect.enforcer.constants.AnalyticsConstants;
+import org.wso2.choreo.connect.enforcer.constants.GeneralErrorCodeConstants;
 import org.wso2.choreo.connect.enforcer.util.FilterUtils;
 
 /**
@@ -91,6 +92,16 @@ public class ChoreoFaultAnalyticsProvider implements AnalyticsDataProvider {
                     return FaultCategory.AUTH;
                 case 429:
                     return FaultCategory.THROTTLED;
+                case 503:
+                    // for API Blocked Scenario, it is considered as an Auth Failure although the status code
+                    // is 503
+                    if (requestContext.getProperties().containsKey(APIConstants.MessageFormat.ERROR_CODE) &&
+                            GeneralErrorCodeConstants.API_BLOCKED_CODE ==
+                                    Integer.parseInt(requestContext.getProperties()
+                                            .get(APIConstants.MessageFormat.ERROR_CODE).toString())) {
+                        return FaultCategory.AUTH;
+                    }
+                    return FaultCategory.OTHER;
                 default:
                     return FaultCategory.OTHER;
             }

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/FaultCodeClassifier.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/FaultCodeClassifier.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.apimgt.common.analytics.publishers.dto.enums.FaultSubCate
 import org.wso2.carbon.apimgt.common.analytics.publishers.dto.enums.FaultSubCategory;
 import org.wso2.choreo.connect.enforcer.constants.APISecurityConstants;
 import org.wso2.choreo.connect.enforcer.constants.AnalyticsConstants;
+import org.wso2.choreo.connect.enforcer.constants.GeneralErrorCodeConstants;
 
 /**
  * FaultCodeClassifier classifies the fault and returns error code.
@@ -70,6 +71,7 @@ public class FaultCodeClassifier {
             case APISecurityConstants.API_AUTH_INCORRECT_ACCESS_TOKEN_TYPE:
             case APISecurityConstants.INVALID_SCOPE:
                 return FaultSubCategories.Authentication.AUTHORIZATION_FAILURE;
+            case GeneralErrorCodeConstants.API_BLOCKED_CODE:
             case APISecurityConstants.API_SUBSCRIPTION_BLOCKED:
             case APISecurityConstants.API_AUTH_FORBIDDEN:
             case APISecurityConstants.SUBSCRIPTION_INACTIVE:

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyAuthenticator.java
@@ -186,18 +186,20 @@ public class APIKeyAuthenticator extends APIKeyHandler {
                 if (!validationInfoDto.isAuthorized()) {
                     if (GeneralErrorCodeConstants.API_BLOCKED_CODE == validationInfoDto
                             .getValidationStatus()) {
-                        requestContext.getProperties().put(APIConstants.MessageFormat.ERROR_MESSAGE,
-                                GeneralErrorCodeConstants.API_BLOCKED_MESSAGE);
-                        requestContext.getProperties().put(APIConstants.MessageFormat.ERROR_DESCRIPTION,
+                        FilterUtils.setErrorToContext(requestContext,
+                                GeneralErrorCodeConstants.API_BLOCKED_CODE,
+                                APIConstants.StatusCodes.SERVICE_UNAVAILABLE.getCode(),
+                                GeneralErrorCodeConstants.API_BLOCKED_MESSAGE,
                                 GeneralErrorCodeConstants.API_BLOCKED_DESCRIPTION);
                         throw new APISecurityException(APIConstants.StatusCodes.SERVICE_UNAVAILABLE
                                 .getCode(), validationInfoDto.getValidationStatus(),
                                 GeneralErrorCodeConstants.API_BLOCKED_MESSAGE);
                     } else if (APISecurityConstants.API_SUBSCRIPTION_BLOCKED == validationInfoDto
                             .getValidationStatus()) {
-                        requestContext.getProperties().put(APIConstants.MessageFormat.ERROR_MESSAGE,
-                                APISecurityConstants.API_SUBSCRIPTION_BLOCKED_MESSAGE);
-                        requestContext.getProperties().put(APIConstants.MessageFormat.ERROR_DESCRIPTION,
+                        FilterUtils.setErrorToContext(requestContext,
+                                APISecurityConstants.API_SUBSCRIPTION_BLOCKED,
+                                APIConstants.StatusCodes.UNAUTHENTICATED.getCode(),
+                                APISecurityConstants.API_SUBSCRIPTION_BLOCKED_MESSAGE,
                                 APISecurityConstants.API_SUBSCRIPTION_BLOCKED_DESCRIPTION);
                         throw new APISecurityException(APIConstants.StatusCodes.UNAUTHENTICATED
                                 .getCode(), validationInfoDto.getValidationStatus(),

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
@@ -231,7 +231,7 @@ public class InternalAPIKeyAuthenticator extends APIKeyHandler {
                     } catch (APISecurityException e) {
                         throw e;
                     } finally {
-                        log.debug("Internal Key authentication complete.");
+                        log.debug("Internal Key authentication is completed.");
                         if (Utils.tracingEnabled()) {
                             apiKeyValidateSubscriptionSpanScope.close();
                             Utils.finishSpan(apiKeyValidateSubscriptionSpan);

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
@@ -39,8 +39,12 @@ import org.wso2.choreo.connect.enforcer.config.ConfigHolder;
 import org.wso2.choreo.connect.enforcer.config.EnforcerConfig;
 import org.wso2.choreo.connect.enforcer.constants.APIConstants;
 import org.wso2.choreo.connect.enforcer.constants.APISecurityConstants;
+import org.wso2.choreo.connect.enforcer.constants.GeneralErrorCodeConstants;
 import org.wso2.choreo.connect.enforcer.dto.APIKeyValidationInfoDTO;
 import org.wso2.choreo.connect.enforcer.dto.JWTTokenPayloadInfo;
+import org.wso2.choreo.connect.enforcer.models.API;
+import org.wso2.choreo.connect.enforcer.subscription.SubscriptionDataHolder;
+import org.wso2.choreo.connect.enforcer.subscription.SubscriptionDataStore;
 import org.wso2.choreo.connect.enforcer.tracing.TracingConstants;
 import org.wso2.choreo.connect.enforcer.tracing.TracingSpan;
 import org.wso2.choreo.connect.enforcer.tracing.TracingTracer;
@@ -203,8 +207,31 @@ public class InternalAPIKeyAuthenticator extends APIKeyHandler {
                     try {
                         api = validateAPISubscription(apiContext, apiVersion, payload, splitToken,
                                 false);
+                        if (api != null) {
+                            String context = requestContext.getMatchedAPI().getBasePath();
+                            String uuid = requestContext.getMatchedAPI().getUuid();
+                            String apiTenantDomain = FilterUtils.getTenantDomainFromRequestURL(context);
+                            SubscriptionDataStore datastore = SubscriptionDataHolder.getInstance()
+                                    .getTenantSubscriptionStore(apiTenantDomain);
+                            API subscriptionDataStoreAPI = datastore.getApiByContextAndVersion(uuid);
+                            if (subscriptionDataStoreAPI != null &&
+                                    APIConstants.LifecycleStatus.BLOCKED
+                                            .equals(subscriptionDataStoreAPI.getLcState())) {
+                                FilterUtils.setErrorToContext(requestContext,
+                                        GeneralErrorCodeConstants.API_BLOCKED_CODE,
+                                        APIConstants.StatusCodes.SERVICE_UNAVAILABLE.getCode(),
+                                        GeneralErrorCodeConstants.API_BLOCKED_MESSAGE,
+                                        GeneralErrorCodeConstants.API_BLOCKED_DESCRIPTION);
+                                throw new APISecurityException(APIConstants.StatusCodes.SERVICE_UNAVAILABLE.getCode(),
+                                        GeneralErrorCodeConstants.API_BLOCKED_CODE,
+                                        GeneralErrorCodeConstants.API_BLOCKED_MESSAGE);
+                            }
+                            log.debug("Internal Key Authentication is successful.");
+                        }
+                    } catch (APISecurityException e) {
+                        throw e;
                     } finally {
-                        log.debug("Internal Key authentication successful.");
+                        log.debug("Internal Key authentication complete.");
                         if (Utils.tracingEnabled()) {
                             apiKeyValidateSubscriptionSpanScope.close();
                             Utils.finishSpan(apiKeyValidateSubscriptionSpan);

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
@@ -218,18 +218,20 @@ public class JWTAuthenticator implements Authenticator {
                                 if (!apiKeyValidationInfoDTO.isAuthorized()) {
                                     if (GeneralErrorCodeConstants.API_BLOCKED_CODE == apiKeyValidationInfoDTO
                                             .getValidationStatus()) {
-                                        requestContext.getProperties().put(APIConstants.MessageFormat.ERROR_MESSAGE,
-                                                GeneralErrorCodeConstants.API_BLOCKED_MESSAGE);
-                                        requestContext.getProperties().put(APIConstants.MessageFormat.ERROR_DESCRIPTION,
+                                        FilterUtils.setErrorToContext(requestContext,
+                                                GeneralErrorCodeConstants.API_BLOCKED_CODE,
+                                                APIConstants.StatusCodes.SERVICE_UNAVAILABLE.getCode(),
+                                                GeneralErrorCodeConstants.API_BLOCKED_MESSAGE,
                                                 GeneralErrorCodeConstants.API_BLOCKED_DESCRIPTION);
                                         throw new APISecurityException(APIConstants.StatusCodes.SERVICE_UNAVAILABLE
                                                 .getCode(), apiKeyValidationInfoDTO.getValidationStatus(),
                                                 GeneralErrorCodeConstants.API_BLOCKED_MESSAGE);
                                     } else if (APISecurityConstants.API_SUBSCRIPTION_BLOCKED == apiKeyValidationInfoDTO
                                             .getValidationStatus()) {
-                                        requestContext.getProperties().put(APIConstants.MessageFormat.ERROR_MESSAGE,
-                                                APISecurityConstants.API_SUBSCRIPTION_BLOCKED_MESSAGE);
-                                        requestContext.getProperties().put(APIConstants.MessageFormat.ERROR_DESCRIPTION,
+                                        FilterUtils.setErrorToContext(requestContext,
+                                                APISecurityConstants.API_SUBSCRIPTION_BLOCKED,
+                                                APIConstants.StatusCodes.UNAUTHENTICATED.getCode(),
+                                                APISecurityConstants.API_SUBSCRIPTION_BLOCKED_MESSAGE,
                                                 APISecurityConstants.API_SUBSCRIPTION_BLOCKED_DESCRIPTION);
                                         throw new APISecurityException(APIConstants.StatusCodes.UNAUTHENTICATED
                                                 .getCode(), apiKeyValidationInfoDTO.getValidationStatus(),

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/UnsecuredAPIAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/UnsecuredAPIAuthenticator.java
@@ -72,9 +72,10 @@ public class UnsecuredAPIAuthenticator implements Authenticator {
                     .getTenantSubscriptionStore(apiTenantDomain);
             API api = datastore.getApiByContextAndVersion(uuid);
             if (api != null && APIConstants.LifecycleStatus.BLOCKED.equals(api.getLcState())) {
-                requestContext.getProperties()
-                        .put(APIConstants.MessageFormat.ERROR_MESSAGE, GeneralErrorCodeConstants.API_BLOCKED_MESSAGE);
-                requestContext.getProperties().put(APIConstants.MessageFormat.ERROR_DESCRIPTION,
+                FilterUtils.setErrorToContext(requestContext,
+                        GeneralErrorCodeConstants.API_BLOCKED_CODE,
+                        APIConstants.StatusCodes.SERVICE_UNAVAILABLE.getCode(),
+                        GeneralErrorCodeConstants.API_BLOCKED_MESSAGE,
                         GeneralErrorCodeConstants.API_BLOCKED_DESCRIPTION);
                 throw new APISecurityException(APIConstants.StatusCodes.SERVICE_UNAVAILABLE.getCode(),
                         GeneralErrorCodeConstants.API_BLOCKED_CODE, GeneralErrorCodeConstants.API_BLOCKED_MESSAGE);

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/util/FilterUtils.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/util/FilterUtils.java
@@ -67,7 +67,6 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -87,7 +86,7 @@ public class FilterUtils {
     public static final String HOST_NAME_VERIFIER = "httpclient.hostnameVerifier";
     public static final String STRICT = "Strict";
     public static final String ALLOW_ALL = "AllowAll";
-    public static final List<String> SKIPPED_FAULT_CODES = new ArrayList<>(Arrays.asList("700700"));
+    public static final List<String> SKIPPED_FAULT_CODES = new ArrayList<>();
 
     public static String getMaskedToken(String token) {
 
@@ -505,7 +504,7 @@ public class FilterUtils {
                                          String desc) {
         Map<String, Object> properties = context.getProperties();
         properties.putIfAbsent(APIConstants.MessageFormat.STATUS_CODE, statusCode);
-        properties.putIfAbsent(APIConstants.MessageFormat.ERROR_CODE, errorCode);
+        properties.putIfAbsent(APIConstants.MessageFormat.ERROR_CODE, String.valueOf(errorCode));
         properties.putIfAbsent(APIConstants.MessageFormat.ERROR_MESSAGE, message);
         properties.putIfAbsent(APIConstants.MessageFormat.ERROR_DESCRIPTION,
                 APISecurityConstants.getFailureMessageDetailDescription(errorCode, desc));

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/BlockedApiTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/BlockedApiTestCase.java
@@ -65,7 +65,7 @@ public class BlockedApiTestCase extends ApimBaseTest {
                 user, storeRestClient);
         requestHeaders.put(TestConstant.AUTHORIZATION_HEADER, "Bearer " + accessToken);
         API api = new API();
-        api.setContext(API_CONTEXT);
+        api.setContext(API_CONTEXT + "/1.0.0");
         api.setName(API_NAME);
         api.setVersion("1.0.0");
         api.setProvider("admin");

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/BlockedApiTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/BlockedApiTestCase.java
@@ -28,11 +28,13 @@ import org.wso2.choreo.connect.tests.apim.ApimBaseTest;
 import org.wso2.choreo.connect.tests.apim.ApimResourceProcessor;
 import org.wso2.choreo.connect.tests.apim.utils.PublisherUtils;
 import org.wso2.choreo.connect.tests.apim.utils.StoreUtils;
+import org.wso2.choreo.connect.tests.common.model.API;
 import org.wso2.choreo.connect.tests.context.CCTestException;
+import org.wso2.choreo.connect.tests.util.HttpResponse;
 import org.wso2.choreo.connect.tests.util.HttpsClientRequest;
 import org.wso2.choreo.connect.tests.util.TestConstant;
+import org.wso2.choreo.connect.tests.util.TokenUtil;
 import org.wso2.choreo.connect.tests.util.Utils;
-import org.wso2.choreo.connect.tests.util.HttpResponse;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -46,6 +48,7 @@ public class BlockedApiTestCase extends ApimBaseTest {
     private static final String API_CONTEXT = "blocked";
     private static final String APPLICATION_NAME = "BlockedApiApp";
     private final Map<String, String> requestHeaders = new HashMap<>();
+    String internalKey;
 
     private String apiId;
     private String endpointURL;
@@ -61,7 +64,14 @@ public class BlockedApiTestCase extends ApimBaseTest {
         String accessToken = StoreUtils.generateUserAccessToken(apimServiceURLHttps, applicationId,
                 user, storeRestClient);
         requestHeaders.put(TestConstant.AUTHORIZATION_HEADER, "Bearer " + accessToken);
+        API api = new API();
+        api.setContext(API_CONTEXT);
+        api.setName(API_NAME);
+        api.setVersion("1.0.0");
+        api.setProvider("admin");
 
+        internalKey = TokenUtil.getJWT(api, null, "Unlimited", TestConstant.KEY_TYPE_PRODUCTION,
+                3600, null, true);
         endpointURL = Utils.getServiceURLHttps(API_CONTEXT + "/1.0.0/pet/findByStatus");
     }
 
@@ -75,7 +85,8 @@ public class BlockedApiTestCase extends ApimBaseTest {
                 "Response message mismatched. Response Data: " + response.getData());
     }
 
-    @Test(description = "Send a request to a blocked  REST API and check 700700 error code is received", dependsOnMethods = "testPublishedStateAPI")
+    @Test(description = "Send a request to a blocked  REST API and check 700700 error code is received",
+            dependsOnMethods = "testPublishedStateAPI")
     public void testBlockedStateAPI() throws CCTestException, InterruptedException {
         PublisherUtils.changeLCStateAPI(apiId, APILifeCycleAction.BLOCK.getAction(), publisherRestClient, false);
         Thread.sleep(3000);
@@ -87,9 +98,36 @@ public class BlockedApiTestCase extends ApimBaseTest {
                 "Response message mismatched. Expected the error code 700700, but Response Data: " + response.getData());
     }
 
-    @Test(description = "Re publish the blocked API and test", dependsOnMethods = "testBlockedStateAPI")
+    @Test(description = "Send a request to a blocked  REST API and check 700700 error code is received", dependsOnMethods = "testBlockedStateAPI")
+    public void testBlockedStateAPIWithInternalKey() throws CCTestException, InterruptedException {
+        Map<String, String> requestHeaders = new HashMap<>();
+        requestHeaders.put("Internal-Key", internalKey);
+        Thread.sleep(3000);
+        HttpResponse response = HttpsClientRequest.retryGetRequestUntilDeployed(endpointURL, requestHeaders);
+        Assert.assertNotNull(response, "Error occurred while invoking the endpoint " + endpointURL + ". HttpResponse");
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_SERVICE_UNAVAILABLE,
+                "Expected error code is 503, but received the code : " + response.getResponseCode());
+        Assert.assertTrue(response.getData().contains("700700") && response.getData().contains("API blocked"),
+                "Response message mismatched. Expected the error code 700700, but Response Data: " + response.getData());
+    }
+
+    @Test(description = "Re publish the blocked API and test", dependsOnMethods = {"testBlockedStateAPI",
+            "testBlockedStateAPIWithInternalKey"})
     public void testRePublishAPI() throws CCTestException, InterruptedException {
         PublisherUtils.changeLCStateAPI(apiId, APILifeCycleAction.RE_PUBLISH.getAction(), publisherRestClient, false);
+        Thread.sleep(3000);
+        HttpResponse response = HttpsClientRequest.retryGetRequestUntilDeployed(endpointURL, requestHeaders);
+        Assert.assertNotNull(response, "Error occurred while invoking the endpoint " + endpointURL + ". HttpResponse");
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_SUCCESS,
+                "Valid subscription should be able to invoke the associated API");
+        Assert.assertEquals(response.getData(), ResponseConstants.RESPONSE_BODY,
+                "Response message mismatched. Response Data: " + response.getData());
+    }
+
+    @Test(description = "Re publish the blocked API and test", dependsOnMethods = "testRePublishAPI")
+    public void testRePublishAPIWithInternalKey() throws CCTestException, InterruptedException {
+        Map<String, String> requestHeaders = new HashMap<>();
+        requestHeaders.put("Internal-Key", internalKey);
         Thread.sleep(3000);
         HttpResponse response = HttpsClientRequest.retryGetRequestUntilDeployed(endpointURL, requestHeaders);
         Assert.assertNotNull(response, "Error occurred while invoking the endpoint " + endpointURL + ". HttpResponse");

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/websocket/WsClient.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/websocket/WsClient.java
@@ -119,7 +119,7 @@ public final class WsClient {
             Channel ch = b.connect(uri.getHost(), uri.getPort()).sync().channel();
             handler.handshakeFuture().sync();
 
-            log.info("Websocket client handshake complete");
+            log.info("Websocket client handshake is complete");
 
             sendMessages(ch, messages);
             Utils.delay(delayAfterSending, "interrupted while waiting for response frames");

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/websocket/WsClient.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/websocket/WsClient.java
@@ -119,7 +119,7 @@ public final class WsClient {
             Channel ch = b.connect(uri.getHost(), uri.getPort()).sync().channel();
             handler.handshakeFuture().sync();
 
-            log.info("Websocket client handshake is complete");
+            log.info("Websocket client handshake is completed");
 
             sendMessages(ch, messages);
             Utils.delay(delayAfterSending, "interrupted while waiting for response frames");


### PR DESCRIPTION
### Purpose

Following API Manager's implementation, the blocked API calls would be categorized under Auth failures despite the fact that the status code is 503.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2701 
Fixes #2791 

### Automation tests
 - Unit tests added: No
 - Integration tests added: Yes (for Internal key for blocked APIs test case_

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
