### PR TITLE
Pass JWT transformer within methods

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/config/EnforcerConfig.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/config/EnforcerConfig.java
@@ -19,6 +19,7 @@
 package org.wso2.choreo.connect.enforcer.config;
 
 import org.wso2.carbon.apimgt.common.gateway.dto.JWTConfigurationDto;
+import org.wso2.carbon.apimgt.common.gateway.jwttransformer.DefaultJWTTransformer;
 import org.wso2.carbon.apimgt.common.gateway.jwttransformer.JWTTransformer;
 import org.wso2.choreo.connect.enforcer.config.dto.AdminRestServerDto;
 import org.wso2.choreo.connect.enforcer.config.dto.AnalyticsDTO;
@@ -156,8 +157,13 @@ public class EnforcerConfig {
         this.analyticsConfig = analyticsConfig;
     }
 
-    public Map<String, JWTTransformer> getJwtTransformerMap() {
-        return jwtTransformerMap;
+    public JWTTransformer getJwtTransformer(String issuer) {
+        if (jwtTransformerMap.containsKey(issuer)) {
+            return jwtTransformerMap.get(issuer);
+        }
+        JWTTransformer defaultJWTTransformer = new DefaultJWTTransformer();
+        jwtTransformerMap.put(issuer, defaultJWTTransformer);
+        return defaultJWTTransformer;
     }
 
     public void setJwtTransformerMap(Map<String, JWTTransformer> jwtTransformerMap) {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/validator/JWTValidator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/validator/JWTValidator.java
@@ -29,7 +29,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.apimgt.common.gateway.dto.JWTValidationInfo;
 import org.wso2.carbon.apimgt.common.gateway.exception.JWTGeneratorException;
-import org.wso2.carbon.apimgt.common.gateway.jwttransformer.DefaultJWTTransformer;
 import org.wso2.carbon.apimgt.common.gateway.jwttransformer.JWTTransformer;
 import org.wso2.choreo.connect.enforcer.commons.exception.EnforcerException;
 import org.wso2.choreo.connect.enforcer.config.ConfigHolder;
@@ -64,10 +63,7 @@ public class JWTValidator {
 
         if (StringUtils.isNotEmpty(issuer) && tokenIssuers.containsKey(issuer)) {
             ExtendedTokenIssuerDto tokenIssuer = tokenIssuers.get(issuer);
-            JWTTransformer jwtTransformer = ConfigHolder.getInstance().getConfig().getJwtTransformerMap().get(issuer);
-            if (jwtTransformer == null) {
-                jwtTransformer = new DefaultJWTTransformer();
-            }
+            JWTTransformer jwtTransformer = ConfigHolder.getInstance().getConfig().getJwtTransformer(issuer);
             jwtTransformer.loadConfiguration(tokenIssuer);
             return validateToken(signedJWTInfo, tokenIssuer, jwtTransformer);
         }


### PR DESCRIPTION
### Purpose
The same JWTValidator object is used within the matched API, if users invoke with different tokens from different issuers with high concurrent they could mix one transformer for scopes another transformer for consumer key or other claims


### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fix wso2/product-microgateway#2817

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
