### PR TITLE
Remove additional log related to websocket stream

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/grpc/WebSocketFrameService.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/grpc/WebSocketFrameService.java
@@ -48,10 +48,13 @@ public class WebSocketFrameService extends WebSocketFrameServiceGrpc.WebSocketFr
     }
 
     public static void removeObserver(String streamId) {
+        // As per the class java doc, the map of observers is maintained to keep track of open grpc streams.
+        // The map is updated when the first message from the router arrives at the enforcer. If a stream
+        // was created, yet no WebSocketFrameRequests arrives, and the stream gets deleted, the class variable
+        // streamId will not be set (streamId will be null) and an observer will not be added to the map.
+        // Ex: when a backend does not exist.
         if (streamId != null) {
             responseObservers.remove(streamId);
-        } else {
-            logger.warn("Not removing observer since streamId is null");
         }
     }
 


### PR DESCRIPTION
### Purpose
- In the class [WebSocketFrameService](https://github.com/wso2/product-microgateway/blob/main/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/grpc/WebSocketFrameService.java), a map of observers is maintained to keep track of **open** grpc streams.
-  A grpc stream is created right when we receive the websocket upgrade request. https://github.com/wso2/product-microgateway/blob/e12313de297e143d877664f3be6654e1c1272155/envoy-filters/mgw-source/filters/http/mgw-wasm-websocket/filter.cc#L374
  - Here, we do not `sendEnforcerRequest` since we do not know if the handshake was successful https://github.com/wso2/product-microgateway/blob/e12313de297e143d877664f3be6654e1c1272155/envoy-filters/mgw-source/filters/http/mgw-wasm-websocket/filter.cc#L393
  - This is where we send the first enforcer message https://github.com/wso2/product-microgateway/blob/e12313de297e143d877664f3be6654e1c1272155/envoy-filters/mgw-source/filters/http/mgw-wasm-websocket/filter.cc#L152
- The map is updated when the first message from the router arrives at the enforcer. 
- Therefore, if a grpc stream was created, yet no WebSocketFrameRequests arrives, and the stream gets deleted, the class variable streamId will not be set (streamId will be null) and an observer will not be added to the map. Hence, the map not having the observer and streamId being null is expected.
  - Ex: when a backend does not exist.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
