### PR TITLE
Bug fix: Default versioned APIs would be called when a versioned API is expected if it has the resource /*

### DIFF
--- a/adapter/internal/api/apis_impl.go
+++ b/adapter/internal/api/apis_impl.go
@@ -306,7 +306,6 @@ func ApplyAPIProjectFromAPIM(
 			// APIListMap is synchronously updated only for default version changes. In other API deployment
 			// events, this may not be updated. We can safely ignore this case since runtime artifact's
 			// `isDefaultVersion` prop is anyway updated for deployment events.
-			// TODO: (VirajSalaka) Is it better to set it to false?
 			loggers.LoggerAPI.Debugf("API %s is not found in API Metadata map.", apiYaml.ID)
 		}
 		// first update the API for vhost

--- a/adapter/internal/api/apis_impl.go
+++ b/adapter/internal/api/apis_impl.go
@@ -306,6 +306,7 @@ func ApplyAPIProjectFromAPIM(
 			// APIListMap is synchronously updated only for default version changes. In other API deployment
 			// events, this may not be updated. We can safely ignore this case since runtime artifact's
 			// `isDefaultVersion` prop is anyway updated for deployment events.
+			// TODO: (VirajSalaka) Is it better to set it to false?
 			loggers.LoggerAPI.Debugf("API %s is not found in API Metadata map.", apiYaml.ID)
 		}
 		// first update the API for vhost

--- a/adapter/internal/discovery/xds/server.go
+++ b/adapter/internal/discovery/xds/server.go
@@ -846,8 +846,23 @@ func GenerateEnvoyResoucesForLabel(label string) ([]types.Resource, []types.Reso
 					})
 					continue
 				}
+				isDefaultVersion := false
+				if enforcerAPISwagger, ok := orgIDAPIMgwSwaggerMap[organizationID][apiKey]; ok {
+					isDefaultVersion = enforcerAPISwagger.IsDefaultVersion
+				} else {
+					// If the mgwSwagger is not found, proceed with other APIs. (Unreachable condition at this point)
+					// If that happens, there is no purpose in processing clusters too.
+					continue
+				}
+				// If it is a default versioned API, the routes are added to the end of the existing array.
+				// Otherwise the routes would be added to the front.
+				// /fooContext/2.0.0/* resource path should be matched prior to the /fooContext/* .
+				if isDefaultVersion {
+					vhostToRouteArrayMap[vhost] = append(vhostToRouteArrayMap[vhost], orgIDOpenAPIRoutesMap[organizationID][apiKey]...)
+				} else {
+					vhostToRouteArrayMap[vhost] = append(orgIDOpenAPIRoutesMap[organizationID][apiKey], vhostToRouteArrayMap[vhost]...)
+				}
 				clusterArray = append(clusterArray, orgIDOpenAPIClustersMap[organizationID][apiKey]...)
-				vhostToRouteArrayMap[vhost] = append(vhostToRouteArrayMap[vhost], orgIDOpenAPIRoutesMap[organizationID][apiKey]...)
 				endpointArray = append(endpointArray, orgIDOpenAPIEndpointsMap[organizationID][apiKey]...)
 				enfocerAPI, ok := orgIDOpenAPIEnforcerApisMap[organizationID][apiKey]
 				if ok {


### PR DESCRIPTION
### Purpose
$subject

Solution:
To the routes array, all the default versioned apis should be in the tail. 
Hence always, 
/context/version pattern is matched prior to matching /context/*

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/2831

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
