### PR TITLE
Revert "Updating APIM hostname"

### DIFF
--- a/resources/k8s-artifacts/apim/apim-config.yaml
+++ b/resources/k8s-artifacts/apim/apim-config.yaml
@@ -19,7 +19,7 @@ metadata:
 data:
   deployment.toml: |-
     [server]
-    hostname = "wso2apim"
+    hostname = "apim.wso2.com"
     #offset=0
     base_path = "${carbon.protocol}://${carbon.host}:${carbon.management.port}"
     #discard_empty_caches = false
@@ -153,7 +153,7 @@ data:
     #enable_token_hashing = false
 
     [apim.devportal]
-    url = "https://wso2apim/devportal"
+    url = "https://apim.wso2.com/devportal"
     #enable_application_sharing = false
     #if application_sharing_type, application_sharing_impl both defined priority goes to application_sharing_impl
     #application_sharing_type = "default" #changed type, saml, default #todo: check the new config for rest api

--- a/resources/k8s-artifacts/apim/apim-service.yaml
+++ b/resources/k8s-artifacts/apim/apim-service.yaml
@@ -44,6 +44,3 @@ spec:
     - name: binary-auth
       port: 9711
       targetPort: 9711
-    - name: servlet-proxy-https
-      port: 443
-      targetPort: 9443

--- a/resources/k8s-artifacts/choreo-connect/choreo-connect-with-apim-ingress.yaml
+++ b/resources/k8s-artifacts/choreo-connect/choreo-connect-with-apim-ingress.yaml
@@ -24,10 +24,10 @@ spec:
   tls:
   - hosts:
       - gw.wso2.com
-      - wso2apim
+      - apim.wso2.com
     secretName: tls-secret
   rules:
-    - host: wso2apim
+    - host: apim.wso2.com
       http:
           paths:
             - path: /

--- a/resources/k8s-artifacts/choreo-connect/config-toml-configmap-for-eventhub.yaml
+++ b/resources/k8s-artifacts/choreo-connect/config-toml-configmap-for-eventhub.yaml
@@ -67,7 +67,7 @@ data:
     [enforcer.security]
     [[enforcer.security.tokenService]]
       name = "Resident Key Manager"
-      issuer = "https://wso2apim/oauth2/token"
+      issuer = "https://apim.wso2.com/oauth2/token"
       certificateAlias = "wso2carbon"
       jwksURL = ""
       validateSubscription = false
@@ -85,7 +85,7 @@ data:
 
     [[enforcer.security.tokenService]]
       name = "APIM Publisher"
-      issuer = "https://wso2apim/publisher"
+      issuer = "https://apim.wso2.com/publisher"
       validateSubscription = true
       certificateFilePath = "/home/wso2/security/truststore/wso2carbon.pem"
 

--- a/resources/k8s-artifacts/choreo-connect/config-toml-configmap.yaml
+++ b/resources/k8s-artifacts/choreo-connect/config-toml-configmap.yaml
@@ -66,7 +66,7 @@ data:
     [enforcer.security]
     [[enforcer.security.tokenService]]
       name = "Resident Key Manager"
-      issuer = "https://wso2apim/oauth2/token"
+      issuer = "https://apim.wso2.com/oauth2/token"
       certificateAlias = "wso2carbon"
       jwksURL = ""
       validateSubscription = false
@@ -84,7 +84,7 @@ data:
 
     [[enforcer.security.tokenService]]
       name = "APIM Publisher"
-      issuer = "https://wso2apim/publisher"
+      issuer = "https://apim.wso2.com/publisher"
       validateSubscription = true
       certificateFilePath = "/home/wso2/security/truststore/wso2carbon.pem"
 

--- a/samples/istio/mtls-mode/README.md
+++ b/samples/istio/mtls-mode/README.md
@@ -126,12 +126,12 @@ kubectl label namespace default istio-injection=enabled
 - Add an `/etc/host` entry for Choreo Connect and WSO2 API Manager
 
     ```
-    127.0.0.1  wso2apim gw.wso2.com
+    127.0.0.1  apim.wso2.com gw.wso2.com
     ```
 
 ### 5. Apply API Management for the microservice
 
-- Access the Publisher portal - https://wso2apim/publisher/
+- Access the Publisher portal - https://apim.wso2.com/publisher/
 
   Use admin:admin as the credentials.
 

--- a/samples/istio/mtls-mode/gw_vs.yaml
+++ b/samples/istio/mtls-mode/gw_vs.yaml
@@ -29,7 +29,7 @@ spec:
       tls:
         mode: PASSTHROUGH
       hosts:
-        - "wso2apim"
+        - "apim.wso2.com"
         - "gw.wso2.com"
 ---
 apiVersion: networking.istio.io/v1alpha3
@@ -38,7 +38,7 @@ metadata:
   name: apim-virtualservice
 spec:
   hosts:
-    - "wso2apim"
+    - "apim.wso2.com"
     - "gw.wso2.com"
   gateways:
     - apim-gateway
@@ -46,7 +46,7 @@ spec:
     - match:
         - port: 443
           sniHosts:
-            - wso2apim
+            - apim.wso2.com
       route:
         - destination:
             host: wso2apim

--- a/samples/istio/sidecar-mode/README.md
+++ b/samples/istio/sidecar-mode/README.md
@@ -81,12 +81,12 @@ kubectl label namespace default istio-injection=enabled
 - Add an `/etc/host` entry for Choreo Connect and WSO2 API Manager
 
     ```
-    127.0.0.1  wso2apim gw.wso2.com
+    127.0.0.1  apim.wso2.com gw.wso2.com
     ```
 
 ### 4. Apply API Management for the microservice
 
-- Access the Publisher portal - https://wso2apim/publisher/
+- Access the Publisher portal - https://apim.wso2.com/publisher/
 
   Use admin:admin as the credentials.
 

--- a/samples/istio/sidecar-mode/gw_vs.yaml
+++ b/samples/istio/sidecar-mode/gw_vs.yaml
@@ -29,7 +29,7 @@ spec:
       tls:
         mode: PASSTHROUGH
       hosts:
-        - "wso2apim"
+        - "apim.wso2.com"
         - "gw.wso2.com"
 ---
 apiVersion: networking.istio.io/v1alpha3
@@ -38,7 +38,7 @@ metadata:
   name: apim-virtualservice
 spec:
   hosts:
-    - "wso2apim"
+    - "apim.wso2.com"
     - "gw.wso2.com"
   gateways:
     - apim-gateway
@@ -46,7 +46,7 @@ spec:
     - match:
         - port: 443
           sniHosts:
-            - wso2apim
+            - apim.wso2.com
       route:
         - destination:
             host: wso2apim


### PR DESCRIPTION
Reverts wso2/product-microgateway#2793

It seems we have to revert this PR to support the istio use cases. We can't use wso2apim as the hostname in Istio and they have the following validation. Basically short names are not allowed. In K8s docs, we can ask the user to change the jwks endpoint from the admin console.

admission webhook "validation.istio.io" denied the request: configuration is invalid: short names (non FQDN) are not allowed