### PR TITLE
Add trailing slash regex into path regex

### DIFF
--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -1195,6 +1195,7 @@ func generateRegex(fullpath string) string {
 	pathParaRegex := "([^/]+)"
 	wildCardRegex := "((/(.*))*)"
 	endRegex := "(\\?([^/]+))?"
+	trailingSlashRegex := "(/{0,1})"
 	newPath := ""
 
 	// Check and replace all the path parameters
@@ -1203,6 +1204,8 @@ func generateRegex(fullpath string) string {
 
 	if strings.HasSuffix(newPath, "/*") {
 		newPath = strings.TrimSuffix(newPath, "/*") + wildCardRegex
+	} else if strings.HasSuffix(newPath, "/") {
+		newPath = strings.TrimSuffix(newPath, "/") + trailingSlashRegex
 	}
 	return "^" + newPath + endRegex + "$"
 }


### PR DESCRIPTION
### Purpose
To match both the paths with and without slash at the end of the URL when API is invoked.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2-enterprise/choreo/issues/11341

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
 Ubuntu 20.04.4 , openjdk version "11.0.14.1" 

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
