### PR TITLE
Add fixes related to handling trailing slash in path

### DIFF
--- a/adapter/internal/oasparser/envoyconf/envoyconf_internal_test.go
+++ b/adapter/internal/oasparser/envoyconf/envoyconf_internal_test.go
@@ -103,9 +103,9 @@ func TestCreateRoute(t *testing.T) {
 					MaxProgramSize: nil,
 				},
 			},
-			Regex: "/xWso2BasePath",
+			Regex: "^/xWso2BasePath/resourcePath(/{0,1})",
 		},
-		Substitution: "/basepath",
+		Substitution: "/basepath/resourcePath",
 	}
 
 	UpgradeConfigsDisabled := []*routev3.RouteAction_UpgradeConfig{{
@@ -270,6 +270,24 @@ func TestGenerateRegex(t *testing.T) {
 			isMatched:     true,
 		},
 		{
+			inputpath:     "/v2/pet/{petId}",
+			userInputPath: "/v2/pet/5/",
+			message:       "when the input path does not have tailing slash and user input path has trailing slash",
+			isMatched:     true,
+		},
+		{
+			inputpath:     "/v2/pet/{petId}/",
+			userInputPath: "/v2/pet/5",
+			message:       "when the input path has tailing slash and user input path does not have trailing slash",
+			isMatched:     true,
+		},
+		{
+			inputpath:     "/v2/pet/{petId}/",
+			userInputPath: "/v2/pet/5/",
+			message:       "when both the input path and user input path has trailing slash",
+			isMatched:     true,
+		},
+		{
 			inputpath:     "/v2/pet/{petId}/info",
 			userInputPath: "/v2/pet/5/info",
 			message:       "when path parameter is provided in the middle of the path",
@@ -379,6 +397,130 @@ func TestGenerateRegex(t *testing.T) {
 
 		assert.Equal(t, item.isMatched, resultIsMatching, item.message)
 		assert.Nil(t, err)
+	}
+}
+
+func TestGenerateSubstitutionString(t *testing.T) {
+	type generateSubsStringTestItem struct {
+		inputPath          string
+		expectedSubsString string
+		message            string
+		shouldEqual        bool
+	}
+	dataItems := []generateSubsStringTestItem{
+		{
+			"/v2/pet",
+			"/basepath/v2/pet",
+			"when input path does not have a trailing slash",
+			true,
+		},
+		{
+			"/v2/pet/",
+			"/basepath/v2/pet/",
+			"when input path has a trailing slash",
+			true,
+		},
+		{
+			"/v2/pet/",
+			"/basepath/v2/pet",
+			"when input path has a trailing slash",
+			false,
+		},
+		{
+			"/v2/pet/{petId}",
+			"/basepath/v2/pet/\\1",
+			"when input path has a path param",
+			true,
+		},
+		{
+			"/v2/pet/{petId}/",
+			"/basepath/v2/pet/\\1/",
+			"when input path has a path param and trailing slash",
+			true,
+		},
+		{
+			"/v2/pet/{petId}/info",
+			"/basepath/v2/pet/\\1/info",
+			"when input path has a path param in the middle of the path",
+			true,
+		},
+		{
+			"/v2/pet/{petId}/test/{petId}",
+			"/basepath/v2/pet/\\1/test/\\2",
+			"when input path has a two path params",
+			true,
+		},
+		{
+			"/v2/*",
+			"/basepath/v2",
+			"when input path has a wildcard at the end",
+			true,
+		},
+		{
+			"/v2/{petId}/*",
+			"/basepath/v2/\\1",
+			"when input path has a path param and a wildcard at the end",
+			true,
+		},
+	}
+	for _, item := range dataItems {
+		generatedSubstitutionString := generateSubstitutionString(item.inputPath, "/basepath")
+		isEqual := generatedSubstitutionString == item.expectedSubsString
+		assert.Equal(t, item.shouldEqual, isEqual, item.message)
+	}
+}
+
+func TestGenerateRegexSegment(t *testing.T) {
+
+	type generateRegexSegmentTestItem struct {
+		inputPath    string
+		regexSegment string
+		message      string
+		shouldEqual  bool
+	}
+	dataItems := []generateRegexSegmentTestItem{
+		{
+			inputPath:    "/v2/pet/",
+			regexSegment: "/v2/pet(/{0,1})",
+			message:      "when the input path has a trailing slash",
+			shouldEqual:  true,
+		},
+		{
+			inputPath:    "/v2/pet",
+			regexSegment: "/v2/pet(/{0,1})",
+			message:      "when the input path does not have a trailing slash",
+			shouldEqual:  true,
+		},
+		{
+			inputPath:    "/v2/pet/{petId}",
+			regexSegment: "/v2/pet/([^/]+)(/{0,1})",
+			message:      "when the input path has a path param and does not have a trailing slash",
+			shouldEqual:  true,
+		},
+		{
+			inputPath:    "/v2/pet/{petId}/",
+			regexSegment: "/v2/pet/([^/]+)(/{0,1})",
+			message:      "when the input path has a path param and a trailing slash",
+			shouldEqual:  true,
+		},
+		{
+			inputPath:    "/v2/pet/{petId}/test/{petId}",
+			regexSegment: "/v2/pet/([^/]+)/test/([^/]+)(/{0,1})",
+			message:      "when the input path has two path params",
+			shouldEqual:  true,
+		},
+		{
+			inputPath:    "/v2/pet/*",
+			regexSegment: "/v2/pet((/(.*))*)",
+			message:      "when the input path ends with *",
+			shouldEqual:  true,
+		},
+	}
+
+	for _, item := range dataItems {
+		generatedPathRegexSegment := generatePathRegexSegment(item.inputPath)
+		isEqual := generatedPathRegexSegment == item.regexSegment
+		assert.Equal(t, item.shouldEqual, isEqual, item.message)
 	}
 }
 

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -19,6 +19,7 @@ package envoyconf
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"regexp"
 	"strconv"
@@ -684,6 +685,7 @@ func createRoute(params *routeCreateParams) *routev3.Route {
 		resourcePath            string
 		responseHeadersToRemove []string
 	)
+	basePath := getFilteredBasePath(xWso2Basepath, endpointBasepath)
 
 	// OPTIONS is always added even if it is not listed under resources
 	// This is required to handle CORS preflight request fail scenario
@@ -813,6 +815,16 @@ func createRoute(params *routeCreateParams) *routev3.Route {
 		Value:   luaMarshelled.Bytes(),
 	}
 
+	if strings.Contains(resourcePath, "?") {
+		resourcePath = strings.Split(resourcePath, "?")[0]
+	}
+	resourceRegex := generatePathRegexSegment(resourcePath)
+	substitutionString := generateSubstitutionString(resourcePath, endpointBasepath)
+	if strings.HasSuffix(resourcePath, "/*") {
+		resourceRegex = strings.TrimSuffix(resourceRegex, "((/(.*))*)")
+	}
+	pathRegex := "^" + basePath + resourceRegex
+
 	if xWso2Basepath != "" {
 		action = &routev3.Route_Route{
 			Route: &routev3.RouteAction{
@@ -825,9 +837,9 @@ func createRoute(params *routeCreateParams) *routev3.Route {
 								MaxProgramSize: nil,
 							},
 						},
-						Regex: xWso2Basepath,
+						Regex: pathRegex,
 					},
-					Substitution: endpointBasepath,
+					Substitution: substitutionString,
 				},
 				UpgradeConfigs:    getUpgradeConfig(apiType),
 				MaxStreamDuration: getMaxStreamDuration(apiType),
@@ -1135,6 +1147,61 @@ func generateRoutePaths(xWso2Basepath, basePath, resourcePath string) string {
 	return newPath
 }
 
+func generatePathRegexSegment(resourcePath string) string {
+	pathParaRegex := "([^/]+)"
+	wildCardRegex := "((/(.*))*)"
+	trailingSlashRegex := "(/{0,1})"
+	resourceRegex := ""
+	matcher := regexp.MustCompile(`{([^}]+)}`)
+	resourceRegex = matcher.ReplaceAllString(resourcePath, pathParaRegex)
+	if strings.HasSuffix(resourceRegex, "/*") {
+		resourceRegex = strings.TrimSuffix(resourceRegex, "/*") + wildCardRegex
+	} else {
+		resourceRegex = strings.TrimSuffix(resourceRegex, "/") + trailingSlashRegex
+	}
+	return resourceRegex
+}
+
+func generateSubstitutionString(resourcePath string, endpointBasepath string) string {
+	pathParaRegex := "([^/]+)"
+	trailingSlashRegex := "(/{0,1})"
+	wildCardRegex := "((/(.*))*)"
+	pathParamIndex := 0
+	resourceRegex := generatePathRegexSegment(resourcePath)
+	for {
+		pathParaRemains := strings.Contains(resourceRegex, pathParaRegex)
+		if !pathParaRemains {
+			break
+		}
+		pathParamIndex++
+		resourceRegex = strings.Replace(resourceRegex, pathParaRegex, fmt.Sprintf("\\%d", pathParamIndex), 1)
+	}
+	if strings.HasSuffix(resourceRegex, wildCardRegex) {
+		resourceRegex = strings.TrimSuffix(resourceRegex, wildCardRegex)
+	} else if strings.HasSuffix(resourcePath, "/") {
+		resourceRegex = strings.TrimSuffix(resourceRegex, trailingSlashRegex) + "/"
+	} else {
+		resourceRegex = strings.TrimSuffix(resourceRegex, trailingSlashRegex)
+	}
+	return endpointBasepath + resourceRegex
+}
+
+func getFilteredBasePath(xWso2Basepath string, basePath string) string {
+	var modifiedBasePath string
+
+	if strings.TrimSpace(xWso2Basepath) != "" {
+		modifiedBasePath = xWso2Basepath
+	} else {
+		modifiedBasePath = basePath
+		// TODO: (VirajSalaka) Decide if it is possible to proceed without both basepath options
+	}
+
+	if !strings.HasPrefix(modifiedBasePath, "/") {
+		modifiedBasePath = "/" + modifiedBasePath
+	}
+	modifiedBasePath = strings.TrimSuffix(modifiedBasePath, "/")
+	return modifiedBasePath
+}
 func basepathConsistent(basePath string) string {
 	modifiedBasePath := basePath
 	if !strings.HasPrefix(basePath, "/") {
@@ -1151,18 +1218,8 @@ func basepathConsistent(basePath string) string {
 // It takes the path value as an input and then returns the regex value.
 // TODO: (VirajSalaka) Improve regex specifically for strings, integers etc.
 func generateRegex(fullpath string) string {
-	pathParaRegex := "([^/]+)"
-	wildCardRegex := "((/(.*))*)"
 	endRegex := "(\\?([^/]+))?"
-	newPath := ""
-
-	// Check and replace all the path parameters
-	matcher := regexp.MustCompile(`{([^}]+)}`)
-	newPath = matcher.ReplaceAllString(fullpath, pathParaRegex)
-
-	if strings.HasSuffix(newPath, "/*") {
-		newPath = strings.TrimSuffix(newPath, "/*") + wildCardRegex
-	}
+	newPath := generatePathRegexSegment(fullpath)
 	return "^" + newPath + endRegex + "$"
 }
 

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
@@ -147,8 +147,8 @@ func commonTestForCreateRoutesWithClusters(t *testing.T, openapiFilePath string,
 		assert.Equal(t, uint32(0), pathLevelClusterPriority1, "Path Level Cluster's second endpoint priority is incorrect.")
 	}
 	assert.Equal(t, 2, len(routes), "Created number of routes are incorrect.")
-	assert.Contains(t, []string{"^/pets(\\?([^/]+))?$", "^/pets/([^/]+)(\\?([^/]+))?$"}, routes[0].GetMatch().GetSafeRegex().Regex)
-	assert.Contains(t, []string{"^/pets(\\?([^/]+))?$", "^/pets/([^/]+)(\\?([^/]+))?$"}, routes[1].GetMatch().GetSafeRegex().Regex)
+	assert.Contains(t, []string{"^/pets(/{0,1})(\\?([^/]+))?$", "^/pets/([^/]+)(/{0,1})(\\?([^/]+))?$"}, routes[0].GetMatch().GetSafeRegex().Regex)
+	assert.Contains(t, []string{"^/pets(/{0,1})(\\?([^/]+))?$", "^/pets/([^/]+)(/{0,1})(\\?([^/]+))?$"}, routes[1].GetMatch().GetSafeRegex().Regex)
 	assert.NotEqual(t, routes[0].GetMatch().GetSafeRegex().Regex, routes[1].GetMatch().GetSafeRegex().Regex,
 		"The route regex for the two routes should not be the same")
 }
@@ -233,8 +233,8 @@ func TestCreateRoutesWithClustersForEndpointRef(t *testing.T) {
 	assert.Equal(t, uint32(1), pathLevelClusterPriority1, "Path Level Cluster's second endpoint priority is incorrect.")
 
 	assert.Equal(t, 2, len(routes), "Created number of routes are incorrect.")
-	assert.Contains(t, []string{"^/pets(\\?([^/]+))?$", "^/pets/([^/]+)(\\?([^/]+))?$"}, routes[0].GetMatch().GetSafeRegex().Regex)
-	assert.Contains(t, []string{"^/pets(\\?([^/]+))?$", "^/pets/([^/]+)(\\?([^/]+))?$"}, routes[1].GetMatch().GetSafeRegex().Regex)
+	assert.Contains(t, []string{"^/pets(/{0,1})(\\?([^/]+))?$", "^/pets/([^/]+)(/{0,1})(\\?([^/]+))?$"}, routes[0].GetMatch().GetSafeRegex().Regex)
+	assert.Contains(t, []string{"^/pets(/{0,1})(\\?([^/]+))?$", "^/pets/([^/]+)(/{0,1})(\\?([^/]+))?$"}, routes[1].GetMatch().GetSafeRegex().Regex)
 	assert.NotEqual(t, routes[0].GetMatch().GetSafeRegex().Regex, routes[1].GetMatch().GetSafeRegex().Regex,
 		"The route regex for the two routes should not be the same")
 }
@@ -276,7 +276,7 @@ func testCreateRoutesWithClustersWebsocket(t *testing.T, apiYamlFilePath string)
 		assert.Equal(t, 1, len(routes), "Number of routes incorrect")
 
 		route := routes[0].GetMatch().GetSafeRegex().Regex
-		assert.Equal(t, route, "^/echowebsocket/1.0(\\?([^/]+))?$", "route created mismatch")
+		assert.Equal(t, route, "^/echowebsocket/1.0(/{0,1})(\\?([^/]+))?$", "route created mismatch")
 	}
 	if strings.HasSuffix(apiYamlFilePath, "api_prod.yaml") {
 		assert.Equal(t, len(clusters), 1, "Number of clusters created incorrect")
@@ -292,7 +292,7 @@ func testCreateRoutesWithClustersWebsocket(t *testing.T, apiYamlFilePath string)
 		assert.Equal(t, 1, len(routes), "Number of routes incorrect")
 
 		route := routes[0].GetMatch().GetSafeRegex().Regex
-		assert.Equal(t, route, "^/echowebsocketprod/1.0(\\?([^/]+))?$", "route created mismatch")
+		assert.Equal(t, route, "^/echowebsocketprod/1.0(/{0,1})(\\?([^/]+))?$", "route created mismatch")
 
 	}
 	if strings.HasSuffix(apiYamlFilePath, "api_sand.yaml") {
@@ -309,7 +309,7 @@ func testCreateRoutesWithClustersWebsocket(t *testing.T, apiYamlFilePath string)
 		assert.Equal(t, 1, len(routes), "Number of routes incorrect")
 
 		route := routes[0].GetMatch().GetSafeRegex().Regex
-		assert.Equal(t, route, "^/echowebsocketsand/1.0(\\?([^/]+))?$", "route created mismatch")
+		assert.Equal(t, route, "^/echowebsocketsand/1.0(/{0,1})(\\?([^/]+))?$", "route created mismatch")
 
 	}
 


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/2864


Update route path generation by adding a regex to handle training slash.
Update routing to the backend by updating `pathRegex` and `substitutionString` in the regex_rewrite envoy configs.

Results: 

On a **/pet/getByStatus**

![Screenshot from 2022-04-09 10-31-09](https://user-images.githubusercontent.com/35162901/162557143-02662885-bb1a-4360-9ca7-c47ba00b2360.png)

On a **/pet/{petId}**

![Screenshot from 2022-04-09 09-59-20](https://user-images.githubusercontent.com/35162901/162557120-6afaaa35-134e-465d-9711-27ac9c619657.png)

### Automation tests
 - Unit tests added: Yes
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
 Ubuntu 20.04.4 , openjdk version "11.0.14.1" 


---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
