### PR TITLE
[main] Update fix for trailing stash and add tests

### DIFF
--- a/adapter/internal/oasparser/envoyconf/envoyconf_internal_test.go
+++ b/adapter/internal/oasparser/envoyconf/envoyconf_internal_test.go
@@ -156,9 +156,8 @@ func TestCreateRoute(t *testing.T) {
 	generatedRouteWithDefaultVersion := createRoute(generateRouteCreateParamsForUnitTests(title, apiType, vHost, context, version,
 		endpoint.Basepath, resourceWithGetPost.GetPath(), resourceWithGetPost.GetMethodList(), clusterName, "", nil, true))
 	assert.NotNil(t, generatedRouteWithDefaultVersion, "Route should not be null")
-	assert.True(t, strings.HasPrefix(generatedRouteWithDefaultVersion.GetMatch().GetSafeRegex().Regex, fmt.Sprintf("^(%s|%s)", context, xWso2BasePath)),
+	assert.True(t, strings.HasPrefix(generatedRouteWithDefaultVersion.GetMatch().GetSafeRegex().Regex, fmt.Sprintf("^(?:%s|%s)", context, xWso2BasePath)),
 		"Default version basepath is not generated correctly")
-
 }
 
 func TestCreateRouteClusterSpecifier(t *testing.T) {

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -1390,6 +1390,8 @@ func getDefaultResourceMethods(apiType string) []string {
 }
 
 func getDefaultVersionBasepath(basePath string, version string) string {
-	context := strings.ReplaceAll(basePath, "/"+version, "")
+	// Following is used to replace only the version when basepath = /foo/v2 and version = v2 and context => /foo/v2/v2
+	indexOfVersionString := strings.LastIndex(basePath, "/"+version)
+	context := strings.Replace(basePath, "/"+version, "", indexOfVersionString)
 	return fmt.Sprintf("(?:%s|%s)", basePath, context)
 }

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -1393,5 +1393,8 @@ func getDefaultVersionBasepath(basePath string, version string) string {
 	// Following is used to replace only the version when basepath = /foo/v2 and version = v2 and context => /foo/v2/v2
 	indexOfVersionString := strings.LastIndex(basePath, "/"+version)
 	context := strings.Replace(basePath, "/"+version, "", indexOfVersionString)
+
+	// Having ?: in the regex below, avoids this regex acting as a capturing group. Without this the basepath
+	// would again be added in the locations of path variables when sending the request to backend.
 	return fmt.Sprintf("(?:%s|%s)", basePath, context)
 }

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -1391,5 +1391,5 @@ func getDefaultResourceMethods(apiType string) []string {
 
 func getDefaultVersionBasepath(basePath string, version string) string {
 	context := strings.ReplaceAll(basePath, "/"+version, "")
-	return fmt.Sprintf("(%s|%s)", basePath, context)
+	return fmt.Sprintf("(?:%s|%s)", basePath, context)
 }

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/standalone/CcWithDefaultConf.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/standalone/CcWithDefaultConf.java
@@ -55,6 +55,7 @@ public class CcWithDefaultConf {
                 .atMost(2, TimeUnit.MINUTES).until(ccInstance.isHealthy());
 
         ApictlUtils.createProject( "trailing_slash_openAPI.yaml", "trailing_slash");
+        ApictlUtils.createProject( "all_http_methods_for_wildcard_openAPI.yaml", "all_http_methods_for_wildcard_openAPI");
         ApictlUtils.createProject( "prod_and_sand_openAPI.yaml", "prod_and_sand_petstore");
         //todo:(amali) enable this test once apictl side get fixed.
         // ApictlUtils.createProject( "endpoint_ref_openAPI.yaml", "ep_ref_petstore", null, null);
@@ -78,6 +79,7 @@ public class CcWithDefaultConf {
 
         ApictlUtils.deployAPI("petstore", "test");
         ApictlUtils.deployAPI("trailing_slash", "test");
+        ApictlUtils.deployAPI("all_http_methods_for_wildcard_openAPI", "test");
         ApictlUtils.deployAPI("prod_and_sand_petstore", "test");
 //        ApictlUtils.deployAPI("ep_ref_petstore", "test");
         ApictlUtils.deployAPI("prod_petstore", "test");

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/standalone/CcWithDefaultConf.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/standalone/CcWithDefaultConf.java
@@ -54,6 +54,7 @@ public class CcWithDefaultConf {
         Awaitility.await().pollDelay(5, TimeUnit.SECONDS).pollInterval(5, TimeUnit.SECONDS)
                 .atMost(2, TimeUnit.MINUTES).until(ccInstance.isHealthy());
 
+        ApictlUtils.createProject( "trailing_slash_openAPI.yaml", "trailing_slash");
         ApictlUtils.createProject( "prod_and_sand_openAPI.yaml", "prod_and_sand_petstore");
         //todo:(amali) enable this test once apictl side get fixed.
         // ApictlUtils.createProject( "endpoint_ref_openAPI.yaml", "ep_ref_petstore", null, null);
@@ -76,6 +77,7 @@ public class CcWithDefaultConf {
         ApictlUtils.login("test");
 
         ApictlUtils.deployAPI("petstore", "test");
+        ApictlUtils.deployAPI("trailing_slash", "test");
         ApictlUtils.deployAPI("prod_and_sand_petstore", "test");
 //        ApictlUtils.deployAPI("ep_ref_petstore", "test");
         ApictlUtils.deployAPI("prod_petstore", "test");

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/standalone/CcWithMultipleEnv.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/standalone/CcWithMultipleEnv.java
@@ -48,18 +48,12 @@ public class CcWithMultipleEnv {
         Awaitility.await().pollDelay(5, TimeUnit.SECONDS).pollInterval(5, TimeUnit.SECONDS)
                 .atMost(2, TimeUnit.MINUTES).until(ccInstance.isHealthy());
 
-        ApictlUtils.createProject( "all_http_methods_for_wildcard_openAPI.yaml",
-                "all_http_methods_for_wildcard_openAPI");
         ApictlUtils.createProject( "deploy_openAPI.yaml", "apictl_petstore2", null,
                 "apictl_test_deploy_multiple_env.yaml", null, null);
-
-        ApictlUtils.addEnv("test");
-        ApictlUtils.login("test");
 
         ApictlUtils.addEnv("test2");
         ApictlUtils.login("test2");
 
-        ApictlUtils.deployAPI("all_http_methods_for_wildcard_openAPI", "test");
         ApictlUtils.deployAPI("apictl_petstore2", "test2");
 
         String endpoint = Utils.getServiceURLHttps(

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/standalone/CcWithMultipleEnv.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/standalone/CcWithMultipleEnv.java
@@ -48,13 +48,20 @@ public class CcWithMultipleEnv {
         Awaitility.await().pollDelay(5, TimeUnit.SECONDS).pollInterval(5, TimeUnit.SECONDS)
                 .atMost(2, TimeUnit.MINUTES).until(ccInstance.isHealthy());
 
+        ApictlUtils.createProject( "all_http_methods_for_wildcard_openAPI.yaml",
+                "all_http_methods_for_wildcard_openAPI");
         ApictlUtils.createProject( "deploy_openAPI.yaml", "apictl_petstore2", null,
                 "apictl_test_deploy_multiple_env.yaml", null, null);
+
+        ApictlUtils.addEnv("test");
+        ApictlUtils.login("test");
 
         ApictlUtils.addEnv("test2");
         ApictlUtils.login("test2");
 
+        ApictlUtils.deployAPI("all_http_methods_for_wildcard_openAPI", "test");
         ApictlUtils.deployAPI("apictl_petstore2", "test2");
+
         String endpoint = Utils.getServiceURLHttps(
                 "/v2/new/pet/findByStatus?status=available");
         Awaitility.await().pollInterval(2, TimeUnit.SECONDS).atMost(60, TimeUnit.SECONDS).until(
@@ -97,6 +104,7 @@ public class CcWithMultipleEnv {
     @AfterTest(description = "stop the setup")
     void stop() throws CCTestException {
         ccInstance.stop();
+        ApictlUtils.removeEnv("test");
         ApictlUtils.removeEnv("test2");
     }
 }

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/standalone/StandaloneBeforeTestSuite.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/standalone/StandaloneBeforeTestSuite.java
@@ -33,6 +33,7 @@ public class StandaloneBeforeTestSuite {
         Assert.assertEquals(versionByApictl, versionFromPomXml,"Expected apictl version is not downloaded");
 
         ApictlUtils.removeEnv("test");
+        ApictlUtils.removeEnv("test2");
         ApictlUtils.createProject( "openAPI.yaml", "petstore");
     }
 }

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apiDeploy/AllHttpMethodsForWildcardTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apiDeploy/AllHttpMethodsForWildcardTestCase.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy;
+
+import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.choreo.connect.mockbackend.dto.EchoResponse;
+import org.wso2.choreo.connect.tests.util.HttpResponse;
+import org.wso2.choreo.connect.tests.util.HttpsClientRequest;
+import org.wso2.choreo.connect.tests.util.TestConstant;
+import org.wso2.choreo.connect.tests.util.TokenUtil;
+import org.wso2.choreo.connect.tests.util.Utils;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AllHttpMethodsForWildcardTestCase {
+    private String jwtTokenProd;
+    private final Map<String, String> headers = new HashMap<>();
+    private static final String API_CONTEXT = "/all_http_methods_for_wildcard";
+
+    @BeforeClass(description = "Get Prod token")
+    void start() throws Exception {
+        jwtTokenProd = TokenUtil.getJwtForPetstore(TestConstant.KEY_TYPE_PRODUCTION, null, false);
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
+    }
+
+    @Test(description = "test path with trailing slash for GET")
+    public void testTrailingSlashGET() throws Exception {
+        EchoResponse echoResponse = Utils.invokeEchoGet(API_CONTEXT, "/",
+                headers, jwtTokenProd);
+        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/","Request path mismatched");
+
+        EchoResponse echoResponse1 = Utils.invokeEchoGet(API_CONTEXT, "/test",
+                headers, jwtTokenProd);
+        Assert.assertEquals(echoResponse1.getPath(), "/v2/echo-full/test","Request path mismatched");
+    }
+
+    @Test(description = "test path with trailing slash for POST")
+    public void testTrailingSlashPOST() throws Exception {
+        EchoResponse echoResponse = Utils.invokeEchoPost(API_CONTEXT, "/",
+                "Hello", headers, jwtTokenProd);
+        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/","Request path mismatched");
+
+        EchoResponse echoResponse1 = Utils.invokeEchoPost(API_CONTEXT, "/test",
+                "Hello", headers, jwtTokenProd);
+        Assert.assertEquals(echoResponse1.getPath(), "/v2/echo-full/test","Request path mismatched");
+    }
+
+    @Test(description = "test path with trailing slash for PUT")
+    public void testTrailingSlashPUT() throws Exception {
+        HttpResponse httpResponse = HttpsClientRequest.doPut(
+                Utils.getServiceURLHttps(API_CONTEXT + "/"), "Hello", headers);
+        EchoResponse echoResponse = Utils.extractToEchoResponse(httpResponse);
+        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/","Request path mismatched");
+
+        HttpResponse httpResponse1 = HttpsClientRequest.doPut(
+                Utils.getServiceURLHttps(API_CONTEXT + "/test"), "Hello", headers);
+        EchoResponse echoResponse1 = Utils.extractToEchoResponse(httpResponse1);
+        Assert.assertEquals(echoResponse1.getPath(), "/v2/echo-full/test","Request path mismatched");
+    }
+
+    @Test(description = "test path with trailing slash for PATCH")
+    public void testTrailingSlashPATCH() throws Exception {
+        java.net.http.HttpResponse<String> httpResponse = HttpsClientRequest.doPatch(
+                Utils.getServiceURLHttps(API_CONTEXT + "/"), "Hello", headers);
+        EchoResponse echoResponse = Utils.extractToEchoResponse(httpResponse);
+        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/","Request path mismatched");
+
+        java.net.http.HttpResponse<String> httpResponse1 = HttpsClientRequest.doPatch(
+                Utils.getServiceURLHttps(API_CONTEXT + "/test"), "Hello", headers);
+        EchoResponse echoResponse1 = Utils.extractToEchoResponse(httpResponse1);
+        Assert.assertEquals(echoResponse1.getPath(), "/v2/echo-full/test","Request path mismatched");
+    }
+
+    @Test(description = "test path with trailing slash for DELETE")
+    public void testTrailingSlashDELETE() throws Exception {
+        HttpResponse httpResponse = HttpsClientRequest.doDelete(
+                Utils.getServiceURLHttps(API_CONTEXT + "/"), headers);
+        EchoResponse echoResponse = Utils.extractToEchoResponse(httpResponse);
+        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/","Request path mismatched");
+
+        HttpResponse httpResponse1 = HttpsClientRequest.doDelete(
+                Utils.getServiceURLHttps(API_CONTEXT + "/test"), headers);
+        EchoResponse echoResponse1 = Utils.extractToEchoResponse(httpResponse1);
+        Assert.assertEquals(echoResponse1.getPath(), "/v2/echo-full/test","Request path mismatched");
+    }
+
+    @Test(description = "test path with trailing slash for OPTIONS")
+    public void testTrailingSlashOPTIONS() throws Exception {
+        Object[] expectedAllowArray = {"DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"};
+
+        HttpResponse httpResponse = HttpsClientRequest.doOptions(
+                Utils.getServiceURLHttps(API_CONTEXT + "/"), headers);
+        Assert.assertEquals(httpResponse.getResponseCode(), HttpStatus.SC_NO_CONTENT, "Response code mismatched");
+        Assert.assertNotNull(httpResponse.getHeaders().get("allow"));
+        Object[] responseAllowArray = Arrays.stream(httpResponse.getHeaders().get("allow")
+                .split(", ")).sorted().toArray();
+        Assert.assertEquals(responseAllowArray, expectedAllowArray,"Responded with invalid allow header");
+
+        HttpResponse httpResponse1 = HttpsClientRequest.doOptions(
+                Utils.getServiceURLHttps(API_CONTEXT + "/test"), headers);
+        Assert.assertEquals(httpResponse1.getResponseCode(), HttpStatus.SC_NO_CONTENT, "Response code mismatched");
+        Assert.assertNotNull(httpResponse1.getHeaders().get("allow"));
+        Object[] responseAllowArray1 = Arrays.stream(httpResponse1.getHeaders().get("allow")
+                .split(", ")).sorted().toArray();
+        Assert.assertEquals(responseAllowArray1, expectedAllowArray,"Responded with invalid allow header");
+    }
+
+    @Test(description = "test path with trailing slash for HEAD")
+    public void testTrailingSlashHEAD() throws Exception {
+        HttpResponse httpResponse = HttpsClientRequest.doHead(
+                Utils.getServiceURLHttps(API_CONTEXT + "/"), headers);
+        EchoResponse echoResponse = Utils.extractToEchoResponse(httpResponse);
+        Assert.assertNull(echoResponse, "HEAD request returned a payload");
+
+        HttpResponse httpResponse1 = HttpsClientRequest.doHead(
+                Utils.getServiceURLHttps(API_CONTEXT + "/test"), headers);
+        EchoResponse echoResponse1 = Utils.extractToEchoResponse(httpResponse1);
+        Assert.assertNull(echoResponse1, "HEAD request returned a payload");
+    }
+}

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apiDeploy/AllHttpMethodsForWildcardTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apiDeploy/AllHttpMethodsForWildcardTestCase.java
@@ -51,6 +51,10 @@ public class AllHttpMethodsForWildcardTestCase {
                 headers, jwtTokenProd);
         Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/","Request path mismatched");
 
+        EchoResponse echoResponse0 = Utils.invokeEchoGet(API_CONTEXT, "",
+                headers, jwtTokenProd);
+        Assert.assertEquals(echoResponse0.getPath(), "/v2/echo-full","Request path mismatched");
+
         EchoResponse echoResponse1 = Utils.invokeEchoGet(API_CONTEXT, "/test",
                 headers, jwtTokenProd);
         Assert.assertEquals(echoResponse1.getPath(), "/v2/echo-full/test","Request path mismatched");
@@ -61,6 +65,10 @@ public class AllHttpMethodsForWildcardTestCase {
         EchoResponse echoResponse = Utils.invokeEchoPost(API_CONTEXT, "/",
                 "Hello", headers, jwtTokenProd);
         Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/","Request path mismatched");
+
+        EchoResponse echoResponse0 = Utils.invokeEchoPost(API_CONTEXT, "",
+                "Hello", headers, jwtTokenProd);
+        Assert.assertEquals(echoResponse0.getPath(), "/v2/echo-full","Request path mismatched");
 
         EchoResponse echoResponse1 = Utils.invokeEchoPost(API_CONTEXT, "/test",
                 "Hello", headers, jwtTokenProd);

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apiDeploy/DefaultVersionApiTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apiDeploy/DefaultVersionApiTestCase.java
@@ -99,9 +99,49 @@ public class DefaultVersionApiTestCase {
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
         Assert.assertTrue(response.getData().contains("John Doe"), "Response body mismatched");
 
-        // V1 doesn't have /user/john resource. We should try to invoke it and see if the traffic is routing to the
+        // V1 doesn't have /store/inventory resource. We should try to invoke it and see if the traffic is routing to the
         // correct API
         response = HttpsClientRequest.doGet("https://localhost:9095" + v1Context + "/store/inventory", headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_NOT_FOUND, "Response code mismatched");
+    }
+
+    /**
+     * Test default versioned APIs with trailing a slash in the path
+     */
+
+    @Test(description = "Test invoking default versioned API without version in the context with trailing slash in path")
+    public void testInvokingDefaultVersionWithTrailingSlashInPath() throws CCTestException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Internal-Key", testKeyV2);
+        HttpResponse response = HttpsClientRequest.doGet("https://localhost:9095" + basePath + "store/inventory/", headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
+        Assert.assertTrue(response.getData().contains("233539"), "Response body mismatched");
+    }
+
+    @Test(description = "Test invoking default versioned API with version in the context with trailing slash in path")
+    public void testInvokingDefaultVersionWithVersionWithTrailingSlashInPath() throws CCTestException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Internal-Key", testKeyV2);
+        HttpResponse response = HttpsClientRequest.doGet("https://localhost:9095" + v2Context + "/store/inventory/", headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
+        Assert.assertTrue(response.getData().contains("233539"), "Response body mismatched");
+    }
+
+    @Test(description = "Test invoking `non` default versioned API with trailing slash in path")
+    public void testInvokingNoneDefaultVersionWithTrailingSlashInPath() throws CCTestException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Internal-Key", testKeyV1);
+        HttpResponse response = HttpsClientRequest.doGet("https://localhost:9095" + v1Context + "/pet/3/", headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
+        Assert.assertTrue(response.getData().contains("John Doe"), "Response body mismatched");
+
+        // V1 doesn't have /store/inventory resource. We should try to invoke it and see if the traffic is routing to the
+        // correct API
+        response = HttpsClientRequest.doGet("https://localhost:9095" + v1Context + "/store/inventory/", headers);
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_NOT_FOUND, "Response code mismatched");
     }

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apiDeploy/TrailingSlashTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apiDeploy/TrailingSlashTestCase.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy;
+
+import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus;
+import com.google.common.net.HttpHeaders;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.choreo.connect.mockbackend.ResponseConstants;
+import org.wso2.choreo.connect.mockbackend.dto.EchoResponse;
+import org.wso2.choreo.connect.tests.context.CCTestException;
+import org.wso2.choreo.connect.tests.util.HttpResponse;
+import org.wso2.choreo.connect.tests.util.HttpsClientRequest;
+import org.wso2.choreo.connect.tests.util.TestConstant;
+import org.wso2.choreo.connect.tests.util.TokenUtil;
+import org.wso2.choreo.connect.tests.util.Utils;
+
+import java.net.MalformedURLException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TrailingSlashTestCase {
+    private String jwtTokenProd;
+    private final Map<String, String> headers = new HashMap<>();
+    private static final String API_CONTEXT = "/trailing-slash";
+
+    @BeforeClass(description = "Get Prod token")
+    void start() throws Exception {
+        jwtTokenProd = TokenUtil.getJwtForPetstore(TestConstant.KEY_TYPE_PRODUCTION, null, false);
+    }
+
+    @Test(description = "test path with trailing slash but without path parameters")
+    public void testTrailingSlashWithoutPathParam() throws Exception {
+        EchoResponse echoResponse = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/findByStatus", jwtTokenProd, headers);
+        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/findByStatus","Request path mismatched");
+
+        EchoResponse echoResponse2 = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/findByStatus/", jwtTokenProd, headers);
+        // Asserting without slash, which is the resource given in the API definition.
+        Assert.assertEquals(echoResponse2.getPath(), "/v2/echo-full/findByStatus","Request path mismatched");
+    }
+
+    @Test(description = "test path with trailing slash with path parameter")
+    public void testTrailingSlashWithPathParam() throws Exception {
+        EchoResponse echoResponse = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/1", jwtTokenProd, headers);
+        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/1","Request path mismatched");
+
+        EchoResponse echoResponse2 = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/1/", jwtTokenProd, headers);
+        // Asserting without slash, which is the resource given in the API definition.
+        Assert.assertEquals(echoResponse2.getPath(), "/v2/echo-full/1","Request path mismatched");
+    }
+
+    @Test(description = "test path with trailing slash with multiple path parameters")
+    public void testTrailingSlashWithMultiplePathParams() throws Exception {
+        EchoResponse echoResponse = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/1/pet/123", jwtTokenProd, headers);
+        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/1/pet/123","Request path mismatched");
+
+        EchoResponse echoResponse2 = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/1/pet/123/", jwtTokenProd, headers);
+        // Asserting without slash, which is the resource given in the API definition.
+        Assert.assertEquals(echoResponse2.getPath(), "/v2/echo-full/1/pet/123","Request path mismatched");
+    }
+}

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apiDeploy/TrailingSlashTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apiDeploy/TrailingSlashTestCase.java
@@ -49,30 +49,36 @@ public class TrailingSlashTestCase {
 
     @Test(description = "test path with trailing slash but without path parameters")
     public void testTrailingSlashWithoutPathParam() throws Exception {
-        EchoResponse echoResponse = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/findByStatus", jwtTokenProd, headers);
+        EchoResponse echoResponse = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/findByStatus",
+                headers, jwtTokenProd);
         Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/findByStatus","Request path mismatched");
 
-        EchoResponse echoResponse2 = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/findByStatus/", jwtTokenProd, headers);
+        EchoResponse echoResponse2 = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/findByStatus/",
+                headers, jwtTokenProd);
         // Asserting without slash, which is the resource given in the API definition.
         Assert.assertEquals(echoResponse2.getPath(), "/v2/echo-full/findByStatus","Request path mismatched");
     }
 
     @Test(description = "test path with trailing slash with path parameter")
     public void testTrailingSlashWithPathParam() throws Exception {
-        EchoResponse echoResponse = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/1", jwtTokenProd, headers);
+        EchoResponse echoResponse = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/1",
+                headers, jwtTokenProd);
         Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/1","Request path mismatched");
 
-        EchoResponse echoResponse2 = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/1/", jwtTokenProd, headers);
+        EchoResponse echoResponse2 = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/1/",
+                headers, jwtTokenProd);
         // Asserting without slash, which is the resource given in the API definition.
         Assert.assertEquals(echoResponse2.getPath(), "/v2/echo-full/1","Request path mismatched");
     }
 
     @Test(description = "test path with trailing slash with multiple path parameters")
     public void testTrailingSlashWithMultiplePathParams() throws Exception {
-        EchoResponse echoResponse = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/1/pet/123", jwtTokenProd, headers);
+        EchoResponse echoResponse = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/1/pet/123",
+                headers, jwtTokenProd);
         Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/1/pet/123","Request path mismatched");
 
-        EchoResponse echoResponse2 = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/1/pet/123/", jwtTokenProd, headers);
+        EchoResponse echoResponse2 = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/1/pet/123/",
+                headers, jwtTokenProd);
         // Asserting without slash, which is the resource given in the API definition.
         Assert.assertEquals(echoResponse2.getPath(), "/v2/echo-full/1/pet/123","Request path mismatched");
     }

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apiDeploy/TrailingSlashTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apiDeploy/TrailingSlashTestCase.java
@@ -18,22 +18,14 @@
 
 package org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy;
 
-import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus;
-import com.google.common.net.HttpHeaders;
-import org.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.choreo.connect.mockbackend.ResponseConstants;
 import org.wso2.choreo.connect.mockbackend.dto.EchoResponse;
-import org.wso2.choreo.connect.tests.context.CCTestException;
-import org.wso2.choreo.connect.tests.util.HttpResponse;
-import org.wso2.choreo.connect.tests.util.HttpsClientRequest;
 import org.wso2.choreo.connect.tests.util.TestConstant;
 import org.wso2.choreo.connect.tests.util.TokenUtil;
 import org.wso2.choreo.connect.tests.util.Utils;
 
-import java.net.MalformedURLException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -48,38 +40,79 @@ public class TrailingSlashTestCase {
     }
 
     @Test(description = "test path with trailing slash but without path parameters")
-    public void testTrailingSlashWithoutPathParam() throws Exception {
-        EchoResponse echoResponse = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/findByStatus",
+    public void testPathWithoutSlashWithoutPathParam() throws Exception {
+        EchoResponse echoResponse = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/no-slash/findByStatus",
                 headers, jwtTokenProd);
-        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/findByStatus","Request path mismatched");
+        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/no-slash/findByStatus","Request path mismatched");
 
-        EchoResponse echoResponse2 = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/findByStatus/",
+        EchoResponse echoResponse2 = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/no-slash/findByStatus/",
                 headers, jwtTokenProd);
         // Asserting without slash, which is the resource given in the API definition.
-        Assert.assertEquals(echoResponse2.getPath(), "/v2/echo-full/findByStatus","Request path mismatched");
+        Assert.assertEquals(echoResponse2.getPath(), "/v2/echo-full/no-slash/findByStatus","Request path mismatched");
     }
 
     @Test(description = "test path with trailing slash with path parameter")
-    public void testTrailingSlashWithPathParam() throws Exception {
-        EchoResponse echoResponse = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/1",
+    public void testPathWithoutSlashWithPathParam() throws Exception {
+        EchoResponse echoResponse = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/no-slash/1",
                 headers, jwtTokenProd);
-        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/1","Request path mismatched");
+        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/no-slash/1","Request path mismatched");
 
-        EchoResponse echoResponse2 = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/1/",
+        EchoResponse echoResponse2 = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/no-slash/1/",
                 headers, jwtTokenProd);
         // Asserting without slash, which is the resource given in the API definition.
-        Assert.assertEquals(echoResponse2.getPath(), "/v2/echo-full/1","Request path mismatched");
+        Assert.assertEquals(echoResponse2.getPath(), "/v2/echo-full/no-slash/1","Request path mismatched");
     }
 
     @Test(description = "test path with trailing slash with multiple path parameters")
-    public void testTrailingSlashWithMultiplePathParams() throws Exception {
-        EchoResponse echoResponse = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/1/pet/123",
+    public void testPathWithoutSlashWithMultiplePathParams() throws Exception {
+        EchoResponse echoResponse = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/no-slash/1/pet/123",
                 headers, jwtTokenProd);
-        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/1/pet/123","Request path mismatched");
+        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/no-slash/1/pet/123","Request path mismatched");
 
-        EchoResponse echoResponse2 = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/1/pet/123/",
+        EchoResponse echoResponse2 = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/no-slash/1/pet/123/",
                 headers, jwtTokenProd);
         // Asserting without slash, which is the resource given in the API definition.
-        Assert.assertEquals(echoResponse2.getPath(), "/v2/echo-full/1/pet/123","Request path mismatched");
+        Assert.assertEquals(echoResponse2.getPath(), "/v2/echo-full/no-slash/1/pet/123","Request path mismatched");
+    }
+
+    /*
+     * In the test upto now, the paths were given in the OpenAPI without a trailing slash.
+     * The remaining tests in this class are for the scenario where the path in the OpenAPI contains a trailing slash.
+     */
+
+    @Test(description = "test path with trailing slash but without path parameters")
+    public void testPathWithSlashWithoutPathParam() throws Exception {
+        EchoResponse echoResponse = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/with-slash/findByStatus",
+                headers, jwtTokenProd);
+        // Asserting with slash, which is the resource given in the API definition.
+        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/with-slash/findByStatus/","Request path mismatched");
+
+        EchoResponse echoResponse2 = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/with-slash/findByStatus/",
+                headers, jwtTokenProd);
+        Assert.assertEquals(echoResponse2.getPath(), "/v2/echo-full/with-slash/findByStatus/","Request path mismatched");
+    }
+
+    @Test(description = "test path with trailing slash with path parameter")
+    public void testPathWithSlashWithPathParam() throws Exception {
+        EchoResponse echoResponse = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/with-slash/1",
+                headers, jwtTokenProd);
+        // Asserting with slash, which is the resource given in the API definition.
+        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/with-slash/1/","Request path mismatched");
+
+        EchoResponse echoResponse2 = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/with-slash/1/",
+                headers, jwtTokenProd);
+        Assert.assertEquals(echoResponse2.getPath(), "/v2/echo-full/with-slash/1/","Request path mismatched");
+    }
+
+    @Test(description = "test path with trailing slash with multiple path parameters")
+    public void testPathWithSlashWithMultiplePathParams() throws Exception {
+        EchoResponse echoResponse = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/with-slash/1/pet/123",
+                headers, jwtTokenProd);
+        // Asserting with slash, which is the resource given in the API definition.
+        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/with-slash/1/pet/123/","Request path mismatched");
+
+        EchoResponse echoResponse2 = Utils.invokeEchoGet(API_CONTEXT, "/echo-full/with-slash/1/pet/123/",
+                headers, jwtTokenProd);
+        Assert.assertEquals(echoResponse2.getPath(), "/v2/echo-full/with-slash/1/pet/123/","Request path mismatched");
     }
 }

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apipolicy/APIPolicyTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apipolicy/APIPolicyTestCase.java
@@ -19,8 +19,6 @@
 package org.wso2.choreo.connect.tests.testcases.standalone.apipolicy;
 
 import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus;
-import com.google.gson.Gson;
-import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
@@ -63,7 +61,7 @@ public class APIPolicyTestCase {
     public void testSetHeaderRemoveHeaderAPIPolicies() throws Exception {
         headers.put("RemoveThisHeader", "Unnecessary Header");
         EchoResponse echoResponse = Utils.invokeEchoPost(basePath,
-                "/echo-full/headers-policy/123" + queryParams, "Hello World!", jwtTokenProd, headers);
+                "/echo-full/headers-policy/123" + queryParams, "Hello World!", headers, jwtTokenProd);
         
         Assert.assertFalse(echoResponse.getHeaders().containsKey("RemoveThisHeader"),
                 getPolicyFailAssertMessage("Remove Header"));
@@ -78,7 +76,7 @@ public class APIPolicyTestCase {
     public void testUnsupportedAPIPolicies() throws Exception {
         headers.put("RemoveThisHeader", "Unnecessary Header");
         EchoResponse echoResponse = Utils.invokeEchoPost(basePath,
-                "/echo-full/unsupported-policy/123" + queryParams, "Hello World!", jwtTokenProd, headers);
+                "/echo-full/unsupported-policy/123" + queryParams, "Hello World!", headers, jwtTokenProd);
 
         // check supported policies
         Assert.assertFalse(echoResponse.getHeaders().containsKey("RemoveThisHeader"),
@@ -99,7 +97,7 @@ public class APIPolicyTestCase {
     @Test(description = "Test custom API Policies and Policy Versions")
     public void testCustomAPIPoliciesAndPolicyVersions() throws Exception {
         EchoResponse echoResponse = Utils.invokeEchoPost(basePath,
-                "/echo-full/custom-policy/123" + queryParams, "Hello World!", jwtTokenProd, headers);
+                "/echo-full/custom-policy/123" + queryParams, "Hello World!", headers, jwtTokenProd);
 
         Assert.assertEquals(echoResponse.getHeaders().getFirst("customV1NewHeaderKey"), "customV1NewHeaderVal",
                 getPolicyFailAssertMessage("Custom Add Header V1"));
@@ -110,8 +108,8 @@ public class APIPolicyTestCase {
 
     @Test(description = "Test query based API Policies")
     public void testQueryAPIPolicy() throws Exception {
-        EchoResponse echoResponse = Utils.invokeEchoGet(basePath, "/echo-full/query-policy" + queryParams,
-                jwtTokenProd, headers);
+        EchoResponse echoResponse = Utils.invokeEchoGet(basePath,
+                "/echo-full/query-policy" + queryParams, headers, jwtTokenProd);
         
         Assert.assertEquals(echoResponse.getQuery().get("helloQ1"), "worldQ1",
                 getPolicyFailAssertMessage("Add Query Param"));
@@ -124,7 +122,7 @@ public class APIPolicyTestCase {
     public void testRewriteMethodAndPathAPIPolicy() throws Exception {
         // HTTP method: GET
         EchoResponse echoResponse = Utils.invokeEchoGet(basePath,
-                "/echo-full/rewrite-policy/345" + queryParams, jwtTokenProd, headers);
+                "/echo-full/rewrite-policy/345" + queryParams, headers, jwtTokenProd);
         
         Assert.assertEquals(echoResponse.getMethod(), HttpMethod.PUT.name());
         Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/new-path");
@@ -132,7 +130,7 @@ public class APIPolicyTestCase {
 
         // HTTP method: POST
         echoResponse = Utils.invokeEchoPost(basePath,
-                "/echo-full/rewrite-policy/345" + queryParams, "Hello World", jwtTokenProd, headers);
+                "/echo-full/rewrite-policy/345" + queryParams, "Hello World", headers, jwtTokenProd);
 
         Assert.assertEquals(echoResponse.getMethod(), HttpMethod.POST.name());
         Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/new-path");
@@ -144,7 +142,7 @@ public class APIPolicyTestCase {
         // HTTP method: GET
         EchoResponse echoResponse = Utils.invokeEchoGet(basePath,
                 "/echo-full/rewrite-policy-with-capture-groups/shops/shop1234.xyz/pets/pet890/orders"
-                        + queryParams, jwtTokenProd, headers);
+                        + queryParams, headers, jwtTokenProd);
 
         Assert.assertEquals(echoResponse.getMethod(), HttpMethod.PUT.name());
         Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/pets/pet890.pets/hello-shops/abcd-shops/shop1234");
@@ -156,7 +154,7 @@ public class APIPolicyTestCase {
         // HTTP method: GET
         EchoResponse echoResponse = Utils.invokeEchoGet(basePath,
                 "/echo-full/rewrite-policy-with-capture-groups-invalid-param/shops/shop1234/pets/pet890/orders"
-                        + queryParams, jwtTokenProd, headers);
+                        + queryParams, headers, jwtTokenProd);
 
         Assert.assertEquals(echoResponse.getMethod(), HttpMethod.PUT.name());
         Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/rewrite-policy-with-capture-groups-invalid-param/shops/shop1234/pets/pet890/orders");
@@ -168,7 +166,7 @@ public class APIPolicyTestCase {
         // HTTP method: GET
         EchoResponse echoResponse = Utils.invokeEchoGet(basePath,
                 "/echo-full/rewrite-policy-with-capture-groups-invalid-chars/shops/shop1234/pets/pet890/orders"
-                        + queryParams, jwtTokenProd, headers);
+                        + queryParams, headers, jwtTokenProd);
 
         Assert.assertEquals(echoResponse.getMethod(), HttpMethod.PUT.name());
         Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/rewrite-policy-with-capture-groups-invalid-chars/shops/shop1234/pets/pet890/orders");
@@ -178,8 +176,8 @@ public class APIPolicyTestCase {
     @Test(description = "Test rewrite path and discard queries in rewrite path API Policies")
     public void testRewritePathAndDiscardQueriesAPIPolicy() throws Exception {
         // HTTP method: GET
-        EchoResponse echoResponse = Utils.invokeEchoGet(basePath, "/echo-full/rewrite-policy/discard-query-params"
-                + queryParams, jwtTokenProd, headers);
+        EchoResponse echoResponse = Utils.invokeEchoGet(basePath,
+                "/echo-full/rewrite-policy/discard-query-params" + queryParams, headers, jwtTokenProd);
 
         Assert.assertEquals(echoResponse.getMethod(), HttpMethod.DELETE.name());
         Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/new-path2");
@@ -189,8 +187,8 @@ public class APIPolicyTestCase {
     @Test(description = "Test OPA API policy - Success Validation")
     public void testOPAAPIPolicySuccessValidation() throws Exception {
         headers.put("foo", "bar"); // this header is validated in OPA policy
-        EchoResponse echoResponse = Utils.invokeEchoPost(basePath,
-                "/echo-full/opa-policy" + queryParams, "Hello", jwtTokenProd, headers);
+        EchoResponse echoResponse = Utils.invokeEchoPost(basePath, "/echo-full/opa-policy" + queryParams,
+                "Hello", headers, jwtTokenProd);
 
         Assert.assertEquals(echoResponse.getData(), "Hello");
         Assert.assertEquals(echoResponse.getHeaders().getFirst("newHeaderKey1"), "newHeaderVal1");
@@ -200,8 +198,8 @@ public class APIPolicyTestCase {
     @Test(description = "Test Custom OPA API policy - Success Validation")
     public void testCustomOPAAPIPolicySuccessValidation() throws Exception {
         headers.put("custom-foo", "custom-bar"); // this header is validated in OPA policy
-        EchoResponse echoResponse = Utils.invokeEchoPost(basePath,
-                "/echo-full/custom-opa-policy" + queryParams, "Hello", jwtTokenProd, headers);
+        EchoResponse echoResponse = Utils.invokeEchoPost(basePath, "/echo-full/custom-opa-policy" + queryParams,
+                "Hello", headers, jwtTokenProd);
 
         Assert.assertEquals(echoResponse.getData(), "Hello");
         Assert.assertEquals(echoResponse.getHeaders().getFirst("newHeaderKey1"), "newHeaderVal1");
@@ -212,7 +210,7 @@ public class APIPolicyTestCase {
     public void testOPAAPIPolicyFailedValidation() throws Exception {
         // missing the header "foo"
         HttpResponse response = Utils.invokePost(basePath, "/echo-full/opa-policy" + queryParams,
-                jwtTokenProd, "Hello", headers);
+                "Hello", headers, jwtTokenProd);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_FORBIDDEN, "Response code mismatched");
     }
 
@@ -220,7 +218,7 @@ public class APIPolicyTestCase {
     public void testCustomOPAAPIPolicyFailedValidation() throws Exception {
         // missing the header "custom-foo"
         HttpResponse response = Utils.invokePost(basePath, "/echo-full/custom-opa-policy" + queryParams,
-                jwtTokenProd, "Hello", headers);
+                "Hello", headers, jwtTokenProd);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_FORBIDDEN, "Response code mismatched");
     }
 
@@ -228,7 +226,7 @@ public class APIPolicyTestCase {
     public void testCustomOPAAPIPolicyNotFoundImpl() throws Exception {
         // missing the header "custom-foo"
         HttpResponse response = Utils.invokePost(basePath, "/echo-full/custom-opa-policy-not-found" + queryParams,
-                "Hello", jwtTokenProd, headers);
+                "Hello", headers, jwtTokenProd);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_INTERNAL_SERVER_ERROR, "Response code mismatched");
     }
 
@@ -237,7 +235,7 @@ public class APIPolicyTestCase {
         headers.put("foo", "bar"); // this header is validated in OPA policy
         // auth key type is validated in OPA policy, since it is missing, validation failed
         HttpResponse response = Utils.invokePost(basePath, "/echo-full/opa-policy-no-access-token" + queryParams,
-                "Hello", jwtTokenProd, headers);
+                "Hello", headers, jwtTokenProd);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_FORBIDDEN, "Response code mismatched");
     }
 
@@ -245,7 +243,7 @@ public class APIPolicyTestCase {
     @Test(description = "Test OPA API policy - Invalid Response from OPA server")
     public void testOPAAPIPolicyInvalidResponse() throws Exception {
         HttpResponse response = Utils.invokePost(basePath, "/echo-full/opa-policy-invalid-response" + queryParams,
-                "Hello", jwtTokenProd, headers);
+                "Hello", headers, jwtTokenProd);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_INTERNAL_SERVER_ERROR, "Response code mismatched");
     }
 
@@ -254,7 +252,7 @@ public class APIPolicyTestCase {
         headers.put("RemoveThisHeader", "Unnecessary Header");
         headers.put("foo", "bar"); // this header is validated in OPA policy
         EchoResponse echoResponse = Utils.invokeEchoPost(basePath,
-                "/echo-full/all-policies/123-abc" + queryParams, "Hello World!", jwtTokenProd, headers);
+                "/echo-full/all-policies/123-abc" + queryParams, "Hello World!", headers, jwtTokenProd);
 
         Assert.assertFalse(echoResponse.getHeaders().containsKey("RemoveThisHeader"),
                 getPolicyFailAssertMessage("Remove Header"));

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apipolicy/APIPolicyTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apipolicy/APIPolicyTestCase.java
@@ -62,7 +62,8 @@ public class APIPolicyTestCase {
     @Test(description = "Test header based API Policies")
     public void testSetHeaderRemoveHeaderAPIPolicies() throws Exception {
         headers.put("RemoveThisHeader", "Unnecessary Header");
-        EchoResponse echoResponse = invokeEchoPost("/echo-full/headers-policy/123" + queryParams, "Hello World!", headers);
+        EchoResponse echoResponse = Utils.invokeEchoPost(basePath,
+                "/echo-full/headers-policy/123" + queryParams, "Hello World!", jwtTokenProd, headers);
         
         Assert.assertFalse(echoResponse.getHeaders().containsKey("RemoveThisHeader"),
                 getPolicyFailAssertMessage("Remove Header"));
@@ -76,7 +77,8 @@ public class APIPolicyTestCase {
     @Test(description = "Test header based unsupported API Policies")
     public void testUnsupportedAPIPolicies() throws Exception {
         headers.put("RemoveThisHeader", "Unnecessary Header");
-        EchoResponse echoResponse = invokeEchoPost("/echo-full/unsupported-policy/123" + queryParams, "Hello World!", headers);
+        EchoResponse echoResponse = Utils.invokeEchoPost(basePath,
+                "/echo-full/unsupported-policy/123" + queryParams, "Hello World!", jwtTokenProd, headers);
 
         // check supported policies
         Assert.assertFalse(echoResponse.getHeaders().containsKey("RemoveThisHeader"),
@@ -96,7 +98,8 @@ public class APIPolicyTestCase {
 
     @Test(description = "Test custom API Policies and Policy Versions")
     public void testCustomAPIPoliciesAndPolicyVersions() throws Exception {
-        EchoResponse echoResponse = invokeEchoPost("/echo-full/custom-policy/123" + queryParams, "Hello World!", headers);
+        EchoResponse echoResponse = Utils.invokeEchoPost(basePath,
+                "/echo-full/custom-policy/123" + queryParams, "Hello World!", jwtTokenProd, headers);
 
         Assert.assertEquals(echoResponse.getHeaders().getFirst("customV1NewHeaderKey"), "customV1NewHeaderVal",
                 getPolicyFailAssertMessage("Custom Add Header V1"));
@@ -107,7 +110,8 @@ public class APIPolicyTestCase {
 
     @Test(description = "Test query based API Policies")
     public void testQueryAPIPolicy() throws Exception {
-        EchoResponse echoResponse = invokeEchoGet("/echo-full/query-policy" + queryParams, headers);
+        EchoResponse echoResponse = Utils.invokeEchoGet(basePath, "/echo-full/query-policy" + queryParams,
+                jwtTokenProd, headers);
         
         Assert.assertEquals(echoResponse.getQuery().get("helloQ1"), "worldQ1",
                 getPolicyFailAssertMessage("Add Query Param"));
@@ -119,14 +123,16 @@ public class APIPolicyTestCase {
     @Test(description = "Test rewrite method and rewrite path API Policies")
     public void testRewriteMethodAndPathAPIPolicy() throws Exception {
         // HTTP method: GET
-        EchoResponse echoResponse = invokeEchoGet("/echo-full/rewrite-policy/345" + queryParams, headers);
+        EchoResponse echoResponse = Utils.invokeEchoGet(basePath,
+                "/echo-full/rewrite-policy/345" + queryParams, jwtTokenProd, headers);
         
         Assert.assertEquals(echoResponse.getMethod(), HttpMethod.PUT.name());
         Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/new-path");
         assertOriginalClientRequestInfo(echoResponse);
 
         // HTTP method: POST
-        echoResponse = invokeEchoPost("/echo-full/rewrite-policy/345" + queryParams, "Hello World", headers);
+        echoResponse = Utils.invokeEchoPost(basePath,
+                "/echo-full/rewrite-policy/345" + queryParams, "Hello World", jwtTokenProd, headers);
 
         Assert.assertEquals(echoResponse.getMethod(), HttpMethod.POST.name());
         Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/new-path");
@@ -136,8 +142,9 @@ public class APIPolicyTestCase {
     @Test(description = "Test rewrite path API Policy with capture groups")
     public void testRewritePathAPIPolicyWithCaptureGroups() throws Exception {
         // HTTP method: GET
-        EchoResponse echoResponse = invokeEchoGet(
-                "/echo-full/rewrite-policy-with-capture-groups/shops/shop1234.xyz/pets/pet890/orders" + queryParams, headers);
+        EchoResponse echoResponse = Utils.invokeEchoGet(basePath,
+                "/echo-full/rewrite-policy-with-capture-groups/shops/shop1234.xyz/pets/pet890/orders"
+                        + queryParams, jwtTokenProd, headers);
 
         Assert.assertEquals(echoResponse.getMethod(), HttpMethod.PUT.name());
         Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/pets/pet890.pets/hello-shops/abcd-shops/shop1234");
@@ -147,8 +154,9 @@ public class APIPolicyTestCase {
     @Test(description = "Test rewrite path API Policy with capture groups with invalid param")
     public void testRewritePathAPIPolicyWithCaptureGroupsInvalidParam() throws Exception {
         // HTTP method: GET
-        EchoResponse echoResponse = invokeEchoGet(
-                "/echo-full/rewrite-policy-with-capture-groups-invalid-param/shops/shop1234/pets/pet890/orders" + queryParams, headers);
+        EchoResponse echoResponse = Utils.invokeEchoGet(basePath,
+                "/echo-full/rewrite-policy-with-capture-groups-invalid-param/shops/shop1234/pets/pet890/orders"
+                        + queryParams, jwtTokenProd, headers);
 
         Assert.assertEquals(echoResponse.getMethod(), HttpMethod.PUT.name());
         Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/rewrite-policy-with-capture-groups-invalid-param/shops/shop1234/pets/pet890/orders");
@@ -158,8 +166,9 @@ public class APIPolicyTestCase {
     @Test(description = "Test rewrite path API Policy with capture groups with invalid chars")
     public void testRewritePathAPIPolicyWithCaptureGroupsInvalidChars() throws Exception {
         // HTTP method: GET
-        EchoResponse echoResponse = invokeEchoGet(
-                "/echo-full/rewrite-policy-with-capture-groups-invalid-chars/shops/shop1234/pets/pet890/orders" + queryParams, headers);
+        EchoResponse echoResponse = Utils.invokeEchoGet(basePath,
+                "/echo-full/rewrite-policy-with-capture-groups-invalid-chars/shops/shop1234/pets/pet890/orders"
+                        + queryParams, jwtTokenProd, headers);
 
         Assert.assertEquals(echoResponse.getMethod(), HttpMethod.PUT.name());
         Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/rewrite-policy-with-capture-groups-invalid-chars/shops/shop1234/pets/pet890/orders");
@@ -169,7 +178,8 @@ public class APIPolicyTestCase {
     @Test(description = "Test rewrite path and discard queries in rewrite path API Policies")
     public void testRewritePathAndDiscardQueriesAPIPolicy() throws Exception {
         // HTTP method: GET
-        EchoResponse echoResponse = invokeEchoGet("/echo-full/rewrite-policy/discard-query-params" + queryParams, headers);
+        EchoResponse echoResponse = Utils.invokeEchoGet(basePath, "/echo-full/rewrite-policy/discard-query-params"
+                + queryParams, jwtTokenProd, headers);
 
         Assert.assertEquals(echoResponse.getMethod(), HttpMethod.DELETE.name());
         Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/new-path2");
@@ -179,7 +189,8 @@ public class APIPolicyTestCase {
     @Test(description = "Test OPA API policy - Success Validation")
     public void testOPAAPIPolicySuccessValidation() throws Exception {
         headers.put("foo", "bar"); // this header is validated in OPA policy
-        EchoResponse echoResponse = invokeEchoPost("/echo-full/opa-policy" + queryParams, "Hello", headers);
+        EchoResponse echoResponse = Utils.invokeEchoPost(basePath,
+                "/echo-full/opa-policy" + queryParams, "Hello", jwtTokenProd, headers);
 
         Assert.assertEquals(echoResponse.getData(), "Hello");
         Assert.assertEquals(echoResponse.getHeaders().getFirst("newHeaderKey1"), "newHeaderVal1");
@@ -189,7 +200,8 @@ public class APIPolicyTestCase {
     @Test(description = "Test Custom OPA API policy - Success Validation")
     public void testCustomOPAAPIPolicySuccessValidation() throws Exception {
         headers.put("custom-foo", "custom-bar"); // this header is validated in OPA policy
-        EchoResponse echoResponse = invokeEchoPost("/echo-full/custom-opa-policy" + queryParams, "Hello", headers);
+        EchoResponse echoResponse = Utils.invokeEchoPost(basePath,
+                "/echo-full/custom-opa-policy" + queryParams, "Hello", jwtTokenProd, headers);
 
         Assert.assertEquals(echoResponse.getData(), "Hello");
         Assert.assertEquals(echoResponse.getHeaders().getFirst("newHeaderKey1"), "newHeaderVal1");
@@ -199,21 +211,24 @@ public class APIPolicyTestCase {
     @Test(description = "Test OPA API policy - Failed Validation")
     public void testOPAAPIPolicyFailedValidation() throws Exception {
         // missing the header "foo"
-        HttpResponse response = invokePost("/echo-full/opa-policy" + queryParams, "Hello", headers);
+        HttpResponse response = Utils.invokePost(basePath, "/echo-full/opa-policy" + queryParams,
+                jwtTokenProd, "Hello", headers);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_FORBIDDEN, "Response code mismatched");
     }
 
     @Test(description = "Test Custom OPA API policy - Failed Validation")
     public void testCustomOPAAPIPolicyFailedValidation() throws Exception {
         // missing the header "custom-foo"
-        HttpResponse response = invokePost("/echo-full/custom-opa-policy" + queryParams, "Hello", headers);
+        HttpResponse response = Utils.invokePost(basePath, "/echo-full/custom-opa-policy" + queryParams,
+                jwtTokenProd, "Hello", headers);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_FORBIDDEN, "Response code mismatched");
     }
 
     @Test(description = "Test Custom OPA API policy - Not found Impl of Request Generator")
     public void testCustomOPAAPIPolicyNotFoundImpl() throws Exception {
         // missing the header "custom-foo"
-        HttpResponse response = invokePost("/echo-full/custom-opa-policy-not-found" + queryParams, "Hello", headers);
+        HttpResponse response = Utils.invokePost(basePath, "/echo-full/custom-opa-policy-not-found" + queryParams,
+                "Hello", jwtTokenProd, headers);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_INTERNAL_SERVER_ERROR, "Response code mismatched");
     }
 
@@ -221,14 +236,16 @@ public class APIPolicyTestCase {
     public void testOPAAPIPolicyNoTokenFailedValidation() throws Exception {
         headers.put("foo", "bar"); // this header is validated in OPA policy
         // auth key type is validated in OPA policy, since it is missing, validation failed
-        HttpResponse response = invokePost("/echo-full/opa-policy-no-access-token" + queryParams, "Hello", headers);
+        HttpResponse response = Utils.invokePost(basePath, "/echo-full/opa-policy-no-access-token" + queryParams,
+                "Hello", jwtTokenProd, headers);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_FORBIDDEN, "Response code mismatched");
     }
 
 
     @Test(description = "Test OPA API policy - Invalid Response from OPA server")
     public void testOPAAPIPolicyInvalidResponse() throws Exception {
-        HttpResponse response = invokePost("/echo-full/opa-policy-invalid-response" + queryParams, "Hello", headers);
+        HttpResponse response = Utils.invokePost(basePath, "/echo-full/opa-policy-invalid-response" + queryParams,
+                "Hello", jwtTokenProd, headers);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_INTERNAL_SERVER_ERROR, "Response code mismatched");
     }
 
@@ -236,7 +253,8 @@ public class APIPolicyTestCase {
     public void testAllPoliciesTogether() throws Exception {
         headers.put("RemoveThisHeader", "Unnecessary Header");
         headers.put("foo", "bar"); // this header is validated in OPA policy
-        EchoResponse echoResponse = invokeEchoPost("/echo-full/all-policies/123-abc" + queryParams, "Hello World!", headers);
+        EchoResponse echoResponse = Utils.invokeEchoPost(basePath,
+                "/echo-full/all-policies/123-abc" + queryParams, "Hello World!", jwtTokenProd, headers);
 
         Assert.assertFalse(echoResponse.getHeaders().containsKey("RemoveThisHeader"),
                 getPolicyFailAssertMessage("Remove Header"));
@@ -248,30 +266,6 @@ public class APIPolicyTestCase {
         Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/new-path-all-policies");
         Assert.assertEquals(echoResponse.getData(), "Hello World!");
         assertOriginalClientRequestInfo(echoResponse);
-    }
-
-    private EchoResponse invokeEchoGet(String resourcePath, Map<String, String> headers) throws Exception {
-        HttpResponse response = invokeGet(resourcePath, headers);
-        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
-        Assert.assertNotNull(response);
-        return new Gson().fromJson(response.getData(), EchoResponse.class);
-    }
-
-    private EchoResponse invokeEchoPost(String resourcePath, String payload, Map<String, String> headers) throws Exception {
-        HttpResponse response = invokePost(resourcePath, payload, headers);
-        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
-        Assert.assertNotNull(response);
-        return new Gson().fromJson(response.getData(), EchoResponse.class);
-    }
-
-    private HttpResponse invokeGet(String resourcePath, Map<String, String> headers) throws Exception {
-        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
-        return HttpsClientRequest.doGet(Utils.getServiceURLHttps(basePath + resourcePath), headers);
-    }
-
-    private HttpResponse invokePost(String resourcePath, String payload, Map<String, String> headers) throws Exception {
-        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
-        return HttpsClientRequest.doPost(Utils.getServiceURLHttps(basePath + resourcePath), payload, headers);
     }
 
     private void assertOriginalClientRequestInfo(EchoResponse echoResponse) {

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apipolicy/APIPolicyTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/apipolicy/APIPolicyTestCase.java
@@ -149,6 +149,18 @@ public class APIPolicyTestCase {
         assertOriginalClientRequestInfo(echoResponse);
     }
 
+    @Test(description = "Test rewrite path API Policy with capture groups with trailing slash in path")
+    public void testRewritePathAPIPolicyWithCaptureGroupsWithTrailingSlashInPath() throws Exception {
+        // HTTP method: GET with trailing slash
+        EchoResponse echoResponse = Utils.invokeEchoGet(basePath,
+                "/echo-full/rewrite-policy-with-capture-groups/shops/shop1234.xyz/pets/pet890/orders/"
+                        + queryParams, headers, jwtTokenProd);
+
+        Assert.assertEquals(echoResponse.getMethod(), HttpMethod.PUT.name());
+        Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/pets/pet890.pets/hello-shops/abcd-shops/shop1234");
+        assertOriginalClientRequestInfo(echoResponse);
+    }
+
     @Test(description = "Test rewrite path API Policy with capture groups with invalid param")
     public void testRewritePathAPIPolicyWithCaptureGroupsInvalidParam() throws Exception {
         // HTTP method: GET
@@ -182,6 +194,17 @@ public class APIPolicyTestCase {
         Assert.assertEquals(echoResponse.getMethod(), HttpMethod.DELETE.name());
         Assert.assertEquals(echoResponse.getPath(), "/v2/echo-full/new-path2");
         Assert.assertTrue(echoResponse.getQuery().isEmpty(), "Query params has not been discarded");
+    }
+
+    @Test(description = "Test rewrite path and discard queries in rewrite path API Policies with trailing slash in path")
+    public void testRewritePathAndDiscardQueriesAPIPolicyWithTrailingSlashInPath() throws Exception {
+        // HTTP method: GET with trailing slash
+        EchoResponse echoResponse1 = Utils.invokeEchoGet(basePath, "/echo-full/rewrite-policy/discard-query-params/"
+                + queryParams, headers, jwtTokenProd);
+
+        Assert.assertEquals(echoResponse1.getMethod(), HttpMethod.DELETE.name());
+        Assert.assertEquals(echoResponse1.getPath(), "/v2/echo-full/new-path2");
+        Assert.assertTrue(echoResponse1.getQuery().isEmpty(), "Query params has not been discarded");
     }
 
     @Test(description = "Test OPA API policy - Success Validation")

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/TestConstant.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/TestConstant.java
@@ -29,6 +29,7 @@ public class TestConstant {
     public static final String HTTP_METHOD_GET = "GET";
     public static final String HTTP_METHOD_POST = "POST";
     public static final String HTTP_METHOD_PUT = "PUT";
+    public static final String HTTP_METHOD_PATCH = "PATCH";
     public static final String HTTP_METHOD_DELETE = "DELETE";
     public static final String HTTP_METHOD_OPTIONS = "OPTIONS";
     public static final String HTTP_METHOD_HEAD = "HEAD";
@@ -174,12 +175,6 @@ public class TestConstant {
 
     public static class RESOURCE_TIER {
         public static final String UNLIMITED = "Unlimited";
-        public static final String TENK_PER_MIN = "10KPerMin";
-        public static final String TWENTYK_PER_MIN = "20KPerMin";
-        public static final String FIFTYK_PER_MIN = "50KPerMin";
-        public static final int ULTIMATE_LIMIT = 20;
-        public static final int PLUS_LIMIT = 5;
-        public static final int BASIC_LIMIT = 1;
 
         public RESOURCE_TIER() {
         }
@@ -187,13 +182,6 @@ public class TestConstant {
 
     public static class API_TIER {
         public static final String UNLIMITED = "Unlimited";
-        public static final String GOLD = "Gold";
-        public static final String SILVER = "Silver";
-        public static final String BRONZE = "Bronze";
-        public static final String ASYNC_UNLIMITED = "AsyncWHUnlimited";
-        public static final int GOLD_LIMIT = 20;
-        public static final int SILVER_LIMIT = 5;
-        public static final int BRONZE_LIMIT = 1;
 
         public API_TIER() {
         }
@@ -201,14 +189,6 @@ public class TestConstant {
 
     public static final class APPLICATION_TIER {
         public static final String UNLIMITED = "Unlimited";
-        public static final String LARGE = "Large";
-        public static final String MEDIUM = "Medium";
-        public static final String SMALL = "Small";
-        public static final String TEN_PER_MIN = "10PerMin";
-        public static final int LARGE_LIMIT = 20;
-        public static final int MEDIUM_LIMIT = 5;
-        public static final int SMALL_LIMIT = 1;
-        public static final String DEFAULT_APP_POLICY_FIFTY_REQ_PER_MIN = "50PerMin";
 
         public APPLICATION_TIER() {
         }
@@ -223,12 +203,5 @@ public class TestConstant {
 
         public SUBSCRIPTION_TIER() {
         }
-    }
-
-    public static final class SRARTUP_TEST {
-        public static final String API_NAME = "ApiBeforeStartingCC";
-        public static final String API_CONTEXT = "before_starting_CC";
-        public static final String API_VERSION = "1.0.0";
-        public static final String APP_NAME = "AppBeforeStartingCC";
     }
 }

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/Utils.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/Utils.java
@@ -18,6 +18,8 @@
 
 package org.wso2.choreo.connect.tests.util;
 
+import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus;
+import com.google.gson.Gson;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import org.apache.commons.io.FileUtils;
 import org.json.JSONException;
@@ -27,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.wso2.choreo.connect.mockbackend.Constants;
+import org.wso2.choreo.connect.mockbackend.dto.EchoResponse;
 import org.wso2.choreo.connect.tests.context.CCTestException;
 import org.yaml.snakeyaml.Yaml;
 
@@ -305,7 +308,33 @@ public class Utils {
         Assert.assertEquals(responseCode, response.getResponseCode(), "Response code mismatched");
     }
 
+    public static EchoResponse invokeEchoGet(String basePath, String resourcePath, String jwtToken,
+                                             Map<String, String> headers) throws Exception {
+        HttpResponse response = invokeGet(basePath, resourcePath, jwtToken, headers);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
+        Assert.assertNotNull(response);
+        return new Gson().fromJson(response.getData(), EchoResponse.class);
+    }
 
+    public static EchoResponse invokeEchoPost(String basePath, String resourcePath, String payload, String jwtToken,
+                                              Map<String, String> headers) throws Exception {
+        HttpResponse response = invokePost(basePath, resourcePath, payload, jwtToken, headers);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
+        Assert.assertNotNull(response);
+        return new Gson().fromJson(response.getData(), EchoResponse.class);
+    }
+
+    public static HttpResponse invokeGet(String basePath, String resourcePath, String jwtToken,
+                                          Map<String, String> headers) throws Exception {
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtToken);
+        return HttpsClientRequest.doGet(Utils.getServiceURLHttps(basePath + resourcePath), headers);
+    }
+
+    public static HttpResponse invokePost(String basePath, String resourcePath, String payload, String jwtToken,
+                                           Map<String, String> headers) throws Exception {
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtToken);
+        return HttpsClientRequest.doPost(Utils.getServiceURLHttps(basePath + resourcePath), payload, headers);
+    }
 
     /**
      * Delay the program for a given time period

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/Utils.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/Utils.java
@@ -321,8 +321,8 @@ public class Utils {
     public static EchoResponse invokeEchoGet(String basePath, String resourcePath,
                                              Map<String, String> headers, String jwtToken) throws Exception {
         HttpResponse response = invokeGet(basePath, resourcePath, headers, jwtToken);
-        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
         Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
         return new Gson().fromJson(response.getData(), EchoResponse.class);
     }
 
@@ -340,13 +340,32 @@ public class Utils {
     public static EchoResponse invokeEchoPost(String basePath, String resourcePath, String payload,
                                               Map<String, String> headers, String jwtToken) throws Exception {
         HttpResponse response = invokePost(basePath, resourcePath, payload, headers, jwtToken);
-        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
         Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
         return new Gson().fromJson(response.getData(), EchoResponse.class);
     }
 
     /**
-     * Send a GET request with provided headers and an authorization bearer token
+     * Extract the HttpResponse payload received after calling the endpoint /echo-full
+     * into an EchoResponse object and return.
+     *
+     * @param response a HttpResponse
+     * @return extracted EchoResponse
+     */
+    public static EchoResponse extractToEchoResponse(HttpResponse response) {
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
+        return new Gson().fromJson(response.getData(), EchoResponse.class);
+    }
+
+    public static EchoResponse extractToEchoResponse(java.net.http.HttpResponse<String> response) {
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.statusCode(), HttpStatus.SC_OK, "Response code mismatched");
+        return new Gson().fromJson(response.body(), EchoResponse.class);
+    }
+
+    /**
+     * Send a GET request with provided headers and an authorization bearer token.
      *
      * @param basePath      Context of the API
      * @param resourcePath  Resource to be invoked
@@ -362,7 +381,7 @@ public class Utils {
     }
 
     /**
-     * Send a POST request with provided headers and an authorization bearer token
+     * Send a POST request with provided headers and an authorization bearer token.
      *
      * @param basePath      Context of the API
      * @param resourcePath  Resource to be invoked

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/Utils.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/Utils.java
@@ -308,30 +308,72 @@ public class Utils {
         Assert.assertEquals(responseCode, response.getResponseCode(), "Response code mismatched");
     }
 
-    public static EchoResponse invokeEchoGet(String basePath, String resourcePath, String jwtToken,
-                                             Map<String, String> headers) throws Exception {
-        HttpResponse response = invokeGet(basePath, resourcePath, jwtToken, headers);
+    /**
+     * Invoke with GET and return exacted response as an EchoResponse from /echo-full endpoint.
+     *
+     * @param basePath      Context of the API
+     * @param resourcePath  Resource to be invoked
+     * @param headers       Headers to include in the request
+     * @param jwtToken      Access token to include in the authorization header
+     * @return exacted response as an EchoResponse
+     * @throws Exception if an error occurs when invoking the API or extracting the response
+     */
+    public static EchoResponse invokeEchoGet(String basePath, String resourcePath,
+                                             Map<String, String> headers, String jwtToken) throws Exception {
+        HttpResponse response = invokeGet(basePath, resourcePath, headers, jwtToken);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
         Assert.assertNotNull(response);
         return new Gson().fromJson(response.getData(), EchoResponse.class);
     }
 
-    public static EchoResponse invokeEchoPost(String basePath, String resourcePath, String payload, String jwtToken,
-                                              Map<String, String> headers) throws Exception {
-        HttpResponse response = invokePost(basePath, resourcePath, payload, jwtToken, headers);
+    /**
+     * Invoke with POST and return exacted response as an EchoResponse from /echo-full endpoint.
+     *
+     * @param basePath      Context of the API
+     * @param resourcePath  Resource to be invoked
+     * @param payload       Payload for the POST request
+     * @param headers       Headers to include in the request
+     * @param jwtToken      Access token to include in the authorization header
+     * @return exacted response as an EchoResponse
+     * @throws Exception if an error occurs when invoking the API or extracting the response
+     */
+    public static EchoResponse invokeEchoPost(String basePath, String resourcePath, String payload,
+                                              Map<String, String> headers, String jwtToken) throws Exception {
+        HttpResponse response = invokePost(basePath, resourcePath, payload, headers, jwtToken);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
         Assert.assertNotNull(response);
         return new Gson().fromJson(response.getData(), EchoResponse.class);
     }
 
-    public static HttpResponse invokeGet(String basePath, String resourcePath, String jwtToken,
-                                          Map<String, String> headers) throws Exception {
+    /**
+     * Send a GET request with provided headers and an authorization bearer token
+     *
+     * @param basePath      Context of the API
+     * @param resourcePath  Resource to be invoked
+     * @param headers       Headers to include in the request
+     * @param jwtToken      Access token to include in the authorization header
+     * @return HttpResponse
+     * @throws Exception if an error occurs when invoking the API
+     */
+    public static HttpResponse invokeGet(String basePath, String resourcePath,
+                                          Map<String, String> headers, String jwtToken) throws Exception {
         headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtToken);
         return HttpsClientRequest.doGet(Utils.getServiceURLHttps(basePath + resourcePath), headers);
     }
 
-    public static HttpResponse invokePost(String basePath, String resourcePath, String payload, String jwtToken,
-                                           Map<String, String> headers) throws Exception {
+    /**
+     * Send a POST request with provided headers and an authorization bearer token
+     *
+     * @param basePath      Context of the API
+     * @param resourcePath  Resource to be invoked
+     * @param payload       Payload for the POST request
+     * @param headers       Headers to include in the request
+     * @param jwtToken      Access token to include in the authorization header
+     * @return HttpResponse
+     * @throws Exception if an error occurs when invoking the API
+     */
+    public static HttpResponse invokePost(String basePath, String resourcePath, String payload,
+                                           Map<String, String> headers, String jwtToken) throws Exception {
         headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtToken);
         return HttpsClientRequest.doPost(Utils.getServiceURLHttps(basePath + resourcePath), payload, headers);
     }

--- a/integration/test-integration/src/test/resources/openAPIs/all_http_methods_for_wildcard_openAPI.yaml
+++ b/integration/test-integration/src/test/resources/openAPIs/all_http_methods_for_wildcard_openAPI.yaml
@@ -1,0 +1,34 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Trailing Slash For Wildcard
+servers:
+  - url: http://mockBackend:2383/v2/echo-full
+x-wso2-basePath: /all_http_methods_for_wildcard
+paths:
+  /*:
+    get:
+      responses:
+        '200':
+          description: OK
+    put:
+      responses:
+        '200':
+          description: OK
+    post:
+      responses:
+        '200':
+          description: OK
+    delete:
+      responses:
+        '200':
+          description: OK
+    head:
+      responses:
+        '200':
+          description: OK
+    patch:
+      responses:
+        '200':
+          description: OK
+

--- a/integration/test-integration/src/test/resources/openAPIs/trailing_slash_openAPI.yaml
+++ b/integration/test-integration/src/test/resources/openAPIs/trailing_slash_openAPI.yaml
@@ -1,0 +1,73 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Trailing Slash
+servers:
+  - url: http://mockBackend:2383/v2
+x-wso2-basePath: /trailing-slash
+paths:
+  /echo-full/findByStatus:
+    get:
+      summary: Info for a pet
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+  /echo-full/{petId}:
+    get:
+      summary: Info for a specific pet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+  /echo-full/{id}/pet/{petId}:
+    get:
+      summary: Info for a specific pet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string

--- a/integration/test-integration/src/test/resources/openAPIs/trailing_slash_openAPI.yaml
+++ b/integration/test-integration/src/test/resources/openAPIs/trailing_slash_openAPI.yaml
@@ -6,7 +6,7 @@ servers:
   - url: http://mockBackend:2383/v2
 x-wso2-basePath: /trailing-slash
 paths:
-  /echo-full/findByStatus:
+  /echo-full/no-slash/findByStatus:
     get:
       summary: Info for a pet
       responses:
@@ -16,7 +16,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Pet"
-  /echo-full/{petId}:
+  /echo-full/no-slash/{petId}:
     get:
       summary: Info for a specific pet
       parameters:
@@ -33,7 +33,57 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Pet"
-  /echo-full/{id}/pet/{petId}:
+  /echo-full/no-slash/{id}/pet/{petId}:
+    get:
+      summary: Info for a specific pet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+  /echo-full/with-slash/findByStatus/:
+    get:
+      summary: Info for a pet
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+  /echo-full/with-slash/{petId}/:
+    get:
+      summary: Info for a specific pet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+  /echo-full/with-slash/{id}/pet/{petId}/:
     get:
       summary: Info for a specific pet
       parameters:

--- a/integration/test-integration/src/test/resources/testng-cc-standalone.xml
+++ b/integration/test-integration/src/test/resources/testng-cc-standalone.xml
@@ -41,6 +41,7 @@
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy.APiDeployViaRestTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy.APiDeployViaApictlTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy.TrailingSlashTestCase"/>
+            <class name="org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy.AllHttpMethodsForWildcardTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.endpoints.ProductionSandboxTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.endpoints.BackendSecurityTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.jwtValidator.JwtTestCase"/>
@@ -94,7 +95,6 @@
     <test name="cc-with-multiple-env" preserve-order="true" parallel="false">
         <classes>
             <class name="org.wso2.choreo.connect.tests.setup.standalone.CcWithMultipleEnv"/>
-            <class name="org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy.AllHttpMethodsForWildcardTestCase"/>
         </classes>
     </test>
     <test name="cc-with-source-control" preserve-order="true" parallel="false">

--- a/integration/test-integration/src/test/resources/testng-cc-standalone.xml
+++ b/integration/test-integration/src/test/resources/testng-cc-standalone.xml
@@ -40,6 +40,7 @@
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy.MountedAPIsTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy.APiDeployViaRestTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy.APiDeployViaApictlTestCase"/>
+            <class name="org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy.TrailingSlashTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.endpoints.ProductionSandboxTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.endpoints.BackendSecurityTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.jwtValidator.JwtTestCase"/>

--- a/integration/test-integration/src/test/resources/testng-cc-standalone.xml
+++ b/integration/test-integration/src/test/resources/testng-cc-standalone.xml
@@ -94,6 +94,7 @@
     <test name="cc-with-multiple-env" preserve-order="true" parallel="false">
         <classes>
             <class name="org.wso2.choreo.connect.tests.setup.standalone.CcWithMultipleEnv"/>
+            <class name="org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy.AllHttpMethodsForWildcardTestCase"/>
         </classes>
     </test>
     <test name="cc-with-source-control" preserve-order="true" parallel="false">


### PR DESCRIPTION
### Purpose
- A minor fix for a bug introduced when adding the change https://github.com/wso2/product-microgateway/pull/2837
- Add tests 
  - Invoking path with a trailing slash not given in the initial API definition
  - Invoke rewritten path (via API policy) with a trailing slash
  - Invoke default and non-default APIs with a trailing slash
  - Invoke `/context/*` for all methods when path is /*
  - Invoke `/context` for a few methods (get and post) when path is /*

### Issues
Related to https://github.com/wso2/product-microgateway/issues/2864

### Automation tests
 - Unit tests added: Updated
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
