### PR TITLE
Exclude sources and javadoc jars in enforcer container

### DIFF
--- a/enforcer-parent/enforcer/src/main/assembly/assembly.xml
+++ b/enforcer-parent/enforcer/src/main/assembly/assembly.xml
@@ -36,8 +36,8 @@
             <outputDirectory>lib</outputDirectory>
             <excludes>
                 <exclude>original*.jar</exclude>
-                <exclude>sources.jar</exclude>
-                <exclude>javadoc.jar</exclude>
+                <exclude>*sources.jar</exclude>
+                <exclude>*javadoc.jar</exclude>
             </excludes>
             <includes>
                 <include>*.jar</include>


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
This is to exclude following jars that are not required to run enforcer container. It was already excluded and had to correct the pattern for that.

- org.wso2.choreo.connect.enforcer-1.x.x-javadoc.jar
- org.wso2.choreo.connect.enforcer-1.x.x-sources.jar

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
OS: Darwin
Env: Docker

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
