### PR TITLE
Upgrade grpc_health_probe from 0.3.7 (non-existent) to 0.4.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -526,7 +526,7 @@
         <download.maven.plugin.version>1.6.1</download.maven.plugin.version>
         <apictl.version>4.0.0</apictl.version>
         <apim.version>4.0.0</apim.version>
-        <grpc.healthProbe.version>0.3.7</grpc.healthProbe.version>
+        <grpc.healthProbe.version>0.4.11</grpc.healthProbe.version>
         <analytics.publisher.client.version>1.0.4</analytics.publisher.client.version>
         <awaitility.version>3.1.2</awaitility.version>
         <apache.httpcomponents.version>4.5.13</apache.httpcomponents.version>


### PR DESCRIPTION
### Purpose
Bug fix:
grpc_health_probe 0.3.7 version does not exist. Hence the kubernetes deployment fails.  0.3.7 was introduced in https://github.com/wso2/product-microgateway/pull/2899

Relates to:
https://github.com/wso2/product-microgateway/pull/2930

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
