### PR TITLE
Adapter does not start if APIM responds with 204 status code

### DIFF
--- a/adapter/internal/adapter/adapter.go
+++ b/adapter/internal/adapter/adapter.go
@@ -358,6 +358,10 @@ func fetchAPIsOnStartUp(conf *config.Config, apiUUIDList []string) {
 				})
 			}
 			health.SetControlPlaneRestAPIStatus(err == nil)
+		} else if data.ErrorCode == 204 {
+          			logger.LoggerMgw.Infof("No API Artifacts are available in the control plane for the envionments :%s",
+          				strings.Join(envs, ", "))
+          			health.SetControlPlaneRestAPIStatus(true)
 		} else if data.ErrorCode >= 400 && data.ErrorCode < 500 {
 			logger.LoggerMgw.ErrorC(logging.ErrorDetails{
 				Message:   fmt.Sprintf("Error occurred when retrieving APIs from control plane(unrecoverable error): %v", data.Err.Error()),

--- a/adapter/pkg/synchronizer/apis_fetcher.go
+++ b/adapter/pkg/synchronizer/apis_fetcher.go
@@ -155,7 +155,7 @@ func FetchAPIs(id *string, gwLabel []string, c chan SyncAPIResponse, serviceURL 
 		req.Header.Set("Content-Type", "application/json")
 	}
 	// Make the request
-	logger.LoggerSync.Debug("Sending the controle plane request")
+	logger.LoggerSync.Debug("Sending the control plane request")
 	resp, err = client.Do(req)
 	// In the event of a connection error, the error would not be nil, then return the error
 	// If the error is not null, proceed
@@ -188,7 +188,6 @@ func FetchAPIs(id *string, gwLabel []string, c chan SyncAPIResponse, serviceURL 
 	}
 	// If the response is not successful, create a new error with the response and log it and return
 	// Ex: for 401 scenarios, 403 scenarios.
-	logger.LoggerSync.Errorf("Failure response: %v", string(respBytes))
 	respSyncAPI.Err = errors.New(string(respBytes))
 	respSyncAPI.Resp = nil
 	respSyncAPI.ErrorCode = resp.StatusCode


### PR DESCRIPTION

### Purpose

Bug fix: If APIM responds with 204 where there are no artifacts, adapter does not start. (it was only reacting to 404 status code earlier)

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2935

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
