### PR TITLE
Edge proxy mode configuration added

### DIFF
--- a/adapter/config/default_config.go
+++ b/adapter/config/default_config.go
@@ -73,6 +73,7 @@ var defaultConfig = &Config{
 		SecuredListenerPort:              9095,
 		ClusterTimeoutInSeconds:          20,
 		EnforcerResponseTimeoutInSeconds: 20,
+		EdgeProxyMode:                    false,
 		KeyStore: keystore{
 			KeyPath:  "/home/wso2/security/keystore/mg.key",
 			CertPath: "/home/wso2/security/keystore/mg.pem",

--- a/adapter/config/default_config.go
+++ b/adapter/config/default_config.go
@@ -73,7 +73,7 @@ var defaultConfig = &Config{
 		SecuredListenerPort:              9095,
 		ClusterTimeoutInSeconds:          20,
 		EnforcerResponseTimeoutInSeconds: 20,
-		EdgeProxyMode:                    false,
+		UseRemoteAddress:                 false,
 		KeyStore: keystore{
 			KeyPath:  "/home/wso2/security/keystore/mg.key",
 			CertPath: "/home/wso2/security/keystore/mg.pem",

--- a/adapter/config/types.go
+++ b/adapter/config/types.go
@@ -111,7 +111,7 @@ type envoy struct {
 	Upstream                         envoyUpstream
 	Connection                       connection
 	PayloadPassingToEnforcer         payloadPassingToEnforcer
-	EdgeProxyMode                    bool
+	UseRemoteAddress                 bool
 }
 
 type connectionTimeouts struct {

--- a/adapter/config/types.go
+++ b/adapter/config/types.go
@@ -111,6 +111,7 @@ type envoy struct {
 	Upstream                         envoyUpstream
 	Connection                       connection
 	PayloadPassingToEnforcer         payloadPassingToEnforcer
+	EdgeProxyMode                    bool
 }
 
 type connectionTimeouts struct {

--- a/adapter/internal/oasparser/envoyconf/listener.go
+++ b/adapter/internal/oasparser/envoyconf/listener.go
@@ -113,6 +113,7 @@ func createListeners(conf *config.Config) []*listenerv3.Listener {
 		HttpProtocolOptions: &corev3.Http1ProtocolOptions{
 			EnableTrailers: config.GetWireLogConfig().LogTrailersEnabled,
 		},
+		UseRemoteAddress: &wrappers.BoolValue{Value: conf.Envoy.EdgeProxyMode},
 	}
 
 	if len(accessLogs) > 0 {

--- a/adapter/internal/oasparser/envoyconf/listener.go
+++ b/adapter/internal/oasparser/envoyconf/listener.go
@@ -113,7 +113,7 @@ func createListeners(conf *config.Config) []*listenerv3.Listener {
 		HttpProtocolOptions: &corev3.Http1ProtocolOptions{
 			EnableTrailers: config.GetWireLogConfig().LogTrailersEnabled,
 		},
-		UseRemoteAddress: &wrappers.BoolValue{Value: conf.Envoy.EdgeProxyMode},
+		UseRemoteAddress: &wrappers.BoolValue{Value: conf.Envoy.UseRemoteAddress},
 	}
 
 	if len(accessLogs) > 0 {

--- a/resources/conf/config-for-eventhub.toml
+++ b/resources/conf/config-for-eventhub.toml
@@ -10,6 +10,7 @@
   listenerPort = 9090
   securedListenerPort = 9095
   systemHost = "localhost"
+  edgeProxyMode = false
 
 [router.keystore]
   certPath = "/home/wso2/security/keystore/mg.pem"

--- a/resources/conf/config-for-eventhub.toml
+++ b/resources/conf/config-for-eventhub.toml
@@ -10,7 +10,7 @@
   listenerPort = 9090
   securedListenerPort = 9095
   systemHost = "localhost"
-  edgeProxyMode = false
+  useRemoteAddress = false
 
 [router.keystore]
   certPath = "/home/wso2/security/keystore/mg.pem"

--- a/resources/conf/config.toml
+++ b/resources/conf/config.toml
@@ -18,7 +18,7 @@
   listenerPort = 9090
   securedListenerPort = 9095
   systemHost = "localhost"
-  edgeProxyMode = false
+  useRemoteAddress = false
 
 [router.keystore]
   certPath = "/home/wso2/security/keystore/mg.pem"

--- a/resources/conf/config.toml
+++ b/resources/conf/config.toml
@@ -18,6 +18,7 @@
   listenerPort = 9090
   securedListenerPort = 9095
   systemHost = "localhost"
+  edgeProxyMode = false
 
 [router.keystore]
   certPath = "/home/wso2/security/keystore/mg.pem"

--- a/resources/conf/config.toml.template
+++ b/resources/conf/config.toml.template
@@ -105,6 +105,8 @@ artifactsDirectory = "/home/wso2/artifacts"
   enforcerResponseTimeoutInSeconds = 20
   # System hostname for system API resources (eg: /testkey and /health)
   systemHost = "localhost"
+  # Set this to true if the router is used as an edge proxy
+  edgeProxyMode = false
 
 # Configurations of key store used in Choreo Connect Router
 [router.keystore]

--- a/resources/conf/config.toml.template
+++ b/resources/conf/config.toml.template
@@ -105,8 +105,8 @@ artifactsDirectory = "/home/wso2/artifacts"
   enforcerResponseTimeoutInSeconds = 20
   # System hostname for system API resources (eg: /testkey and /health)
   systemHost = "localhost"
-  # Set this to true if the router is used as an edge proxy
-  edgeProxyMode = false
+  # If configured true, router appends the immediate downstream ip address to the x-forward-for header
+  useRemoteAddress = false
 
 # Configurations of key store used in Choreo Connect Router
 [router.keystore]

--- a/resources/k8s-artifacts/choreo-connect/config-toml-configmap-for-eventhub.yaml
+++ b/resources/k8s-artifacts/choreo-connect/config-toml-configmap-for-eventhub.yaml
@@ -38,6 +38,7 @@ data:
       listenerPort = 9090
       securedListenerPort = 9095
       systemHost = "gw.wso2.com"
+      useRemoteAddress = false
 
     [router.keystore]
       certPath = "/home/wso2/security/keystore/mg.pem"

--- a/resources/k8s-artifacts/choreo-connect/config-toml-configmap.yaml
+++ b/resources/k8s-artifacts/choreo-connect/config-toml-configmap.yaml
@@ -47,6 +47,7 @@ data:
       listenerPort = 9090
       securedListenerPort = 9095
       systemHost = "gw.wso2.com"
+      useRemoteAddress = false
 
     [router.keystore]
       certPath = "/home/wso2/security/keystore/mg.pem"


### PR DESCRIPTION
### Purpose
Envoy by default passes the x-forwarded-for to the upstream, so the upstream services can process the header and get information about the originating ip address, network hops etc. But when the router is used as an edge proxy, it has to append the ip address of the immediate downstream which is typically a load balancer. This is not added by the default configuration.

- `UseRemoteAddress = true` appends the ip address of the immediate downstream of the router to the `x-forward-for` header. Typically in edge proxy deployment, ip address of the load balancer will be added.
- `UseRemoteAddress = false` (default) passes the `x-forward-for` header to the upstream without appending the immediate downstream node ip address. 

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #2957 

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Mac OS Monterey 12.3.1
Openjdk version 11.0.15
Docker

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
