### PR TITLE
CC not starting with WSL issue fixed

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/util/JWTUtils.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/util/JWTUtils.java
@@ -154,10 +154,7 @@ public class JWTUtils {
             Path keyPath = Paths.get(filePath);
             String key = Files.readString(keyPath, Charset.defaultCharset());
             String lineSeparator = System.lineSeparator();
-            // Change the lineSeparator to \r\n if it runs on WSL
-            if (System.getProperty("os.version").toLowerCase().contains("wsl")) {
-                lineSeparator = "\r\n";
-            }
+            
             strKeyPEM = key
                     .replace(Constants.BEGINING_OF_PRIVATE_KEY, "")
                     .replaceAll(lineSeparator, "")


### PR DESCRIPTION
### Purpose
Choreo Connect does not start in Windows 10 with Docker WSL issue fixing. 

### Issues
Fixes #2918

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
Windows 11 - WSL2 - Ubuntu 20.04

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
