### PR TITLE
[CORS] Support providing origins with wildcard subdomains.

### DIFF
--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -1231,6 +1231,11 @@ func getCorsPolicy(corsConfig *model.CorsConfig) *routev3.CorsPolicy {
 
 	stringMatcherArray := []*envoy_type_matcherv3.StringMatcher{}
 	for _, origin := range corsConfig.AccessControlAllowOrigins {
+
+		// * is considered to be the wild card
+		formattedString := regexp.QuoteMeta(origin)
+		formattedString = strings.ReplaceAll(formattedString, regexp.QuoteMeta("*"), ".*")
+
 		regexMatcher := &envoy_type_matcherv3.StringMatcher{
 			MatchPattern: &envoy_type_matcherv3.StringMatcher_SafeRegex{
 				SafeRegex: &envoy_type_matcherv3.RegexMatcher{
@@ -1239,8 +1244,7 @@ func getCorsPolicy(corsConfig *model.CorsConfig) *routev3.CorsPolicy {
 							MaxProgramSize: nil,
 						},
 					},
-					// adds escape character when necessary
-					Regex: regexp.QuoteMeta(origin),
+					Regex: formattedString,
 				},
 			},
 		}

--- a/integration/test-integration/src/test/resources/configs/jwt-generator-config.toml
+++ b/integration/test-integration/src/test/resources/configs/jwt-generator-config.toml
@@ -1,6 +1,6 @@
 [router]
 [router.cors]
-  allowOrigins = ["http://test1.com", "http://test2.com"]
+  allowOrigins = ["http://test1.com", "http://test2.com", "http://*.wildcard.com"]
   allowMethods = ["GET","PUT","POST"]
   allowHeaders = ["Authorization","X-PINGOTHER"]
   exposeHeaders = ["X-Custom-Header"]

--- a/integration/test-integration/src/test/resources/openAPIs/cors_openAPI.yaml
+++ b/integration/test-integration/src/test/resources/openAPIs/cors_openAPI.yaml
@@ -13,6 +13,7 @@ x-wso2-cors:
   accessControlAllowOrigins:
     - http://test1.com
     - http://test2.com
+    - http://*.wildcard.com
   accessControlAllowHeaders:
     - Authorization
     - X-PINGOTHER


### PR DESCRIPTION
### Purpose

If the user provides the origin to be *`.foo.com`, the `*`considered to be a wild card. 

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #3006 

### Automation tests
 - Unit tests added: No
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
