### PR TITLE
[MGW] [3.2.x] Add gson dependency to micro-gateway-tools

### DIFF
--- a/components/micro-gateway-tools/pom.xml
+++ b/components/micro-gateway-tools/pom.xml
@@ -17,6 +17,11 @@
             <groupId>com.moandjiezana.toml</groupId>
             <artifactId>toml4j</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.9</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
### Purpose

Need to upgrade the gson version used within the org.wso2.micro.gateway.tools-3.2.0.jar of Microgateway Runtime. The currently used gson version is 2.8.1, and it gets added as a transitive dependency of toml4j. We need to bump this vulnerable version to a non-vulnerable version.

This PR adds json 2.8.9 as that is the latest release for the 2.8.x series.

- Related Issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/426
<!-- Short description of the issue you are going to solve with this PR. -->

