### PR TITLE
[main] Fix error when auth header has bearer twice

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
@@ -89,7 +89,15 @@ public class JWTAuthenticator implements Authenticator {
     public boolean canAuthenticate(RequestContext requestContext) {
         if (isJWTEnabled(requestContext)) {
             String authHeaderValue = retrieveAuthHeaderValue(requestContext);
-            return authHeaderValue != null &&
+
+            // Check keyword bearer in header to prevent conflicts with custom authentication
+            // (that maybe added with custom filters / interceptors / opa)
+            // which also includes a jwt in the auth header yet with a scheme other than 'bearer'.
+            //
+            // StringUtils.startsWithIgnoreCase(null, "bearer")         = false
+            // StringUtils.startsWithIgnoreCase("abc", "bearer")        = false
+            // StringUtils.startsWithIgnoreCase("Bearer abc", "bearer") = true
+            return StringUtils.startsWithIgnoreCase(authHeaderValue, JWTConstants.BEARER) &&
                     authHeaderValue.trim().split("\\s+").length == 2 &&
                     authHeaderValue.split("\\.").length == 3;
         }
@@ -134,10 +142,6 @@ public class JWTAuthenticator implements Authenticator {
                         ThreadContext.get(APIConstants.LOG_TRACE_ID));
             }
             String jwtToken = retrieveAuthHeaderValue(requestContext);
-            if (jwtToken == null || !jwtToken.toLowerCase().contains(JWTConstants.BEARER)) {
-                throw new APISecurityException(APIConstants.StatusCodes.UNAUTHENTICATED.getCode(),
-                        APISecurityConstants.API_AUTH_MISSING_CREDENTIALS, "Missing Credentials");
-            }
             String[] splitToken = jwtToken.split("\\s");
             // Extract the token when it is sent as bearer token. i.e Authorization: Bearer <token>
             if (splitToken.length > 1) {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
@@ -88,8 +88,10 @@ public class JWTAuthenticator implements Authenticator {
     @Override
     public boolean canAuthenticate(RequestContext requestContext) {
         if (isJWTEnabled(requestContext)) {
-            String jwt = retrieveAuthHeaderValue(requestContext);
-            return jwt != null && jwt.split("\\.").length == 3;
+            String authHeaderValue = retrieveAuthHeaderValue(requestContext);
+            return authHeaderValue != null &&
+                    authHeaderValue.trim().split("\\s+").length == 2 &&
+                    authHeaderValue.split("\\.").length == 3;
         }
         return false;
     }
@@ -157,7 +159,7 @@ public class JWTAuthenticator implements Authenticator {
                 }
                 signedJWTInfo = JWTUtils.getSignedJwt(jwtToken);
             } catch (ParseException | IllegalArgumentException e) {
-                log.error("Failed to decode the token header", e);
+                log.error("Failed to decode the token header. {}", e.getMessage());
                 throw new APISecurityException(APIConstants.StatusCodes.UNAUTHENTICATED.getCode(),
                         APISecurityConstants.API_AUTH_INVALID_CREDENTIALS,
                         "Not a JWT token. Failed to decode the token header", e);

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/jwtValidator/JwtTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/jwtValidator/JwtTestCase.java
@@ -123,4 +123,22 @@ public class JwtTestCase {
         Assert.assertTrue(response.getHeaders().containsKey("www-authenticate"),
                 "\"www-authenticate\" is not available");
     }
+
+    @Test(description = "Test to check with JWT where the JWT header cannot be parsed")
+    public void invokeJWTHeaderInvalidBearerFormatTest() throws Exception {
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer Bearer " + jwtWithoutScope);
+        HttpResponse response = HttpsClientRequest.doGet(Utils.getServiceURLHttps(
+                "/v2/standard/pet/2") , headers);
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_UNAUTHORIZED,
+                "Response code mismatched");
+        Assert.assertEquals(response.getData(), "{\"error_message\":\"Invalid Credentials\"," +
+                        "\"code\":\"900901\",\"error_description\":" +
+                        "\"Make sure you have provided the correct security credentials\"}",
+                "Response message mismatched");
+        Assert.assertTrue(response.getHeaders().containsKey("www-authenticate"),
+                "\"www-authenticate\" is not available");
+    }
 }


### PR DESCRIPTION
### Purpose
Check auth header bearer format during canAuthenticate. Reduce token parse error log length.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/2993

### Automation tests
 - Unit tests added: No
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
