### PR TITLE
[main] Prevent x-envoy headers being sent to the backend

### DIFF
--- a/adapter/internal/oasparser/envoyconf/http_filters.go
+++ b/adapter/internal/oasparser/envoyconf/http_filters.go
@@ -68,7 +68,7 @@ func getRouterHTTPFilter() *hcmv3.HttpFilter {
 		DynamicStats:             nil,
 		StartChildSpan:           false,
 		UpstreamLog:              nil,
-		SuppressEnvoyHeaders:     false,
+		SuppressEnvoyHeaders:     true,
 		StrictCheckHeaders:       nil,
 		RespectExpectedRqTimeout: false,
 	}

--- a/adapter/internal/oasparser/envoyconf/listener.go
+++ b/adapter/internal/oasparser/envoyconf/listener.go
@@ -43,8 +43,9 @@ import (
 func CreateRoutesConfigForRds(vHosts []*routev3.VirtualHost) *routev3.RouteConfiguration {
 	rdsConfigName := defaultRdsConfigName
 	routeConfiguration := routev3.RouteConfiguration{
-		Name:         rdsConfigName,
-		VirtualHosts: vHosts,
+		Name:                   rdsConfigName,
+		VirtualHosts:           vHosts,
+		RequestHeadersToRemove: []string{clusterHeaderName},
 	}
 	return &routeConfiguration
 }

--- a/adapter/internal/oasparser/envoyconf/routes_configs.go
+++ b/adapter/internal/oasparser/envoyconf/routes_configs.go
@@ -45,20 +45,16 @@ func generateRouteConfig(routeName string, match *routev3.RouteMatch, action *ro
 	requestHeadersToAdd []*corev3.HeaderValueOption, requestHeadersToRemove []string,
 	responseHeadersToAdd []*corev3.HeaderValueOption, responseHeadersToRemove []string) *routev3.Route {
 
-	// headers removed from the request (from router to backend)
-	requestHeadersToRemove = append(requestHeadersToRemove,
-		clusterHeaderName, "x-envoy-expected-rq-timeout-ms", "X-envoy-original-path")
-
-	// headers removed from the response (from router to client).
-	responseHeadersToRemove = append(responseHeadersToRemove, upstreamServiceTimeHeader)
-
 	route := &routev3.Route{
-		Name:                    routeName,
-		Match:                   match,
-		Action:                  action,
-		Metadata:                metadata,
-		Decorator:               decorator,
-		TypedPerFilterConfig:    typedPerFilterConfig,
+		Name:                 routeName,
+		Match:                match,
+		Action:               action,
+		Metadata:             metadata,
+		Decorator:            decorator,
+		TypedPerFilterConfig: typedPerFilterConfig,
+
+		// headers common to all routes are removed at the Route Configuration level in listener.go
+		// x-envoy headers are removed using the SuppressEnvoyHeaders param in http_filters.go
 		RequestHeadersToAdd:     requestHeadersToAdd,
 		RequestHeadersToRemove:  requestHeadersToRemove,
 		ResponseHeadersToAdd:    responseHeadersToAdd,

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/router/EnvoyHttpFilterTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/router/EnvoyHttpFilterTestCase.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.choreo.connect.tests.testcases.standalone.router;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.apache.http.HttpStatus;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.choreo.connect.tests.util.HttpsClientRequest;
+import org.wso2.choreo.connect.tests.util.HttpResponse;
+import org.wso2.choreo.connect.tests.util.TestConstant;
+import org.wso2.choreo.connect.tests.util.TokenUtil;
+import org.wso2.choreo.connect.tests.util.Utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class EnvoyHttpFilterTestCase {
+    private String jwtTokenProd;
+
+    @BeforeClass
+    void start() throws Exception {
+        jwtTokenProd = TokenUtil.getJwtForPetstore(TestConstant.KEY_TYPE_PRODUCTION, null, false);
+    }
+
+    @Test(description = "Test to invoke resource protected with scopes with correct jwt")
+    public void checkHeadersSentToBackend() throws Exception {
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
+        HttpResponse response = HttpsClientRequest.retryGetRequestUntilDeployed(
+                Utils.getServiceURLHttps("/v2/standard/headers"), headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
+
+        // Request headers received by the backend
+        JSONObject headersSentToBackend = new JSONObject(response.getData());
+        Assert.assertEquals(headersSentToBackend.length(), 8, "Unexpected number of headers received by the backend");
+
+        JSONObject headersToBackend = Utils.changeHeadersToLowerCase(headersSentToBackend);
+
+        Assert.assertNotNull(headersToBackend.get("x-trace-key"));
+        Assert.assertNotNull(headersToBackend.get("accept"));
+        Assert.assertNotNull(headersToBackend.get("x-request-id"));
+        Assert.assertNotNull(headersToBackend.get("x-forwarded-proto"));
+        Assert.assertNotNull(headersToBackend.get("host"));
+        Assert.assertNotNull(headersToBackend.get("pragma"));
+        Assert.assertNotNull(headersToBackend.get("user-agent"));
+        Assert.assertNotNull(headersToBackend.get("cache-control"));
+
+        Assert.assertFalse(headersToBackend.has("x-envoy-original-path"), "x-envoy-original-path not removed");
+        Assert.assertFalse(headersToBackend.has("x-wso2-cluster-header"), "x-wso2-cluster-header not removed");
+        Assert.assertFalse(headersToBackend.has("x-envoy-expected-rq-timeout-ms"), "x-envoy-expected-rq-timeout-ms not removed");
+
+        // Response headers received by the client
+        Map<String, String> headersToClient = response.getHeaders();
+        Assert.assertEquals(headersToClient.size(), 4, "Unexpected number of headers received by the client");
+
+        Assert.assertNotNull(headersToClient.get("date"));      // = Fri, 15 Apr 2022 05:10:41 GMT
+        Assert.assertNotNull(headersToClient.get("server"));    // = envoy
+        Assert.assertNotNull(headersToClient.get("content-length"));
+        Assert.assertNotNull(headersToClient.get("content-type"));
+    }
+}

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/EnvoyHttpFilterTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/EnvoyHttpFilterTestCase.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.choreo.connect.tests.testcases.withapim;
+
+import org.apache.http.HttpStatus;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.choreo.connect.tests.apim.ApimBaseTest;
+import org.wso2.choreo.connect.tests.apim.ApimResourceProcessor;
+import org.wso2.choreo.connect.tests.apim.utils.StoreUtils;
+import org.wso2.choreo.connect.tests.util.HttpResponse;
+import org.wso2.choreo.connect.tests.util.HttpsClientRequest;
+import org.wso2.choreo.connect.tests.util.TestConstant;
+import org.wso2.choreo.connect.tests.util.Utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class EnvoyHttpFilterTestCase extends ApimBaseTest {
+    private static final String API_CONTEXT = "envoy_http_filter_api";
+    private static final String API_VERSION = "1.0.0";
+    private static final String APP_NAME = "EnvoyHttpFilterApp";
+    String accessTokenProd;
+
+    @BeforeClass(alwaysRun = true, description = "initialize setup")
+    void setup() throws Exception {
+        super.initWithSuperTenant();
+        String applicationId = ApimResourceProcessor.applicationNameToId.get(APP_NAME);
+        accessTokenProd = StoreUtils.generateUserAccessTokenProduction(apimServiceURLHttps, applicationId,
+                user, storeRestClient);
+    }
+
+    @Test(description = "Check the headers sent to the backend")
+    public void checkHeadersSentToBackend() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(TestConstant.AUTHORIZATION_HEADER, "Bearer " + accessTokenProd);
+
+        String endpoint = Utils.getServiceURLHttps(API_CONTEXT + "/" + API_VERSION + "/headers");
+        HttpResponse response = HttpsClientRequest.retryGetRequestUntilDeployed(endpoint, headers);
+        Assert.assertNotNull(response, "Error occurred while invoking the endpoint " + endpoint + " HttpResponse ");
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK,
+                "Status code mismatched. Endpoint:" + endpoint + " HttpResponse ");
+
+        // Request headers received by the backend
+        JSONObject headersSentToBackend = new JSONObject(response.getData());
+        Assert.assertEquals(headersSentToBackend.length(), 9, "Unexpected number of headers received by the backend");
+
+        JSONObject headersToBackend = Utils.changeHeadersToLowerCase(headersSentToBackend);
+
+        Assert.assertNotNull(headersToBackend.get("x-trace-key"));
+        Assert.assertNotNull(headersToBackend.get("accept"));
+        Assert.assertNotNull(headersToBackend.get("x-request-id"));
+        Assert.assertNotNull(headersToBackend.get("x-jwt-assertion"));
+        Assert.assertNotNull(headersToBackend.get("x-forwarded-proto"));
+        Assert.assertNotNull(headersToBackend.get("host"));
+        Assert.assertNotNull(headersToBackend.get("pragma"));
+        Assert.assertNotNull(headersToBackend.get("user-agent"));
+        Assert.assertNotNull(headersToBackend.get("cache-control"));
+
+        Assert.assertFalse(headersToBackend.has("x-envoy-original-path"), "x-envoy-original-path not removed");
+        Assert.assertFalse(headersToBackend.has("x-wso2-cluster-header"), "x-wso2-cluster-header not removed");
+        Assert.assertFalse(headersToBackend.has("x-envoy-expected-rq-timeout-ms"), "x-envoy-expected-rq-timeout-ms not removed");
+
+        // Response headers received by the client
+        Map<String, String> headersToClient = response.getHeaders();
+        Assert.assertEquals(headersToClient.size(), 4, "Unexpected number of headers received by the client");
+
+        Assert.assertNotNull(headersToClient.get("date"));      // = Fri, 15 Apr 2022 05:10:41 GMT
+        Assert.assertNotNull(headersToClient.get("server"));    // = envoy
+        Assert.assertNotNull(headersToClient.get("content-length"));
+        Assert.assertNotNull(headersToClient.get("content-type"));
+    }
+}

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/ExistingApiTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/ExistingApiTestCase.java
@@ -17,17 +17,14 @@
  */
 package org.wso2.choreo.connect.tests.testcases.withapim;
 
-import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus;
 import io.netty.handler.codec.http.HttpHeaderNames;
-import org.json.JSONObject;
+import org.apache.http.HttpStatus;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.choreo.connect.mockbackend.ResponseConstants;
 import org.wso2.choreo.connect.tests.apim.ApimBaseTest;
 import org.wso2.choreo.connect.tests.apim.ApimResourceProcessor;
 import org.wso2.choreo.connect.tests.apim.utils.StoreUtils;
-import org.wso2.choreo.connect.tests.context.CCTestException;
 import org.wso2.choreo.connect.tests.util.HttpResponse;
 import org.wso2.choreo.connect.tests.util.HttpsClientRequest;
 import org.wso2.choreo.connect.tests.util.TestConstant;
@@ -60,7 +57,7 @@ public class ExistingApiTestCase extends ApimBaseTest {
         String endpoint = Utils.getServiceURLHttps(API_CONTEXT + "/1.0.0/pet/findByStatus");
         HttpResponse response = HttpsClientRequest.retryGetRequestUntilDeployed(endpoint, headers);
         Assert.assertNotNull(response, "Error occurred while invoking the endpoint " + endpoint + " HttpResponse ");
-        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_SUCCESS,
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK,
                 "Status code mismatched. Endpoint:" + endpoint + " HttpResponse ");
     }
 
@@ -76,7 +73,7 @@ public class ExistingApiTestCase extends ApimBaseTest {
         String endpoint = Utils.getServiceURLHttps(API_CONTEXT + "/1.0.0/pet/findByStatus");
         HttpResponse response = HttpsClientRequest.retryGetRequestUntilDeployed(endpoint, headers);
         Assert.assertNotNull(response, "Error occurred while invoking the endpoint " + endpoint + " HttpResponse ");
-        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_SUCCESS,
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK,
                 "Status code mismatched. Endpoint:" + endpoint + " HttpResponse ");
     }
 
@@ -88,34 +85,7 @@ public class ExistingApiTestCase extends ApimBaseTest {
         String endpoint = Utils.getServiceURLHttps(API_CONTEXT + "/1.0.0/headers");
         HttpResponse response = HttpsClientRequest.retryGetRequestUntilDeployed(endpoint, headers);
         Assert.assertNotNull(response, "Error occurred while invoking the endpoint " + endpoint + " HttpResponse ");
-        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_SUCCESS,
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK,
                 "Status code mismatched. Endpoint:" + endpoint + " HttpResponse ");
-
-        // Request headers received by the backend
-        JSONObject headersToBackend = new JSONObject(response.getData());
-        Assert.assertEquals(headersToBackend.length(), 10, "Unexpected number of headers received by the backend");
-
-        Assert.assertNotNull(headersToBackend.get("X-trace-key"));
-        Assert.assertNotNull(headersToBackend.get("Accept"));
-        Assert.assertNotNull(headersToBackend.get("X-request-id"));
-        Assert.assertNotNull(headersToBackend.get("X-jwt-assertion"));
-        Assert.assertNotNull(headersToBackend.get("X-forwarded-proto"));
-        Assert.assertNotNull(headersToBackend.get("Host"));
-        Assert.assertNotNull(headersToBackend.get("Pragma"));
-        Assert.assertNotNull(headersToBackend.get("X-envoy-original-path"));
-        Assert.assertNotNull(headersToBackend.get("User-agent"));
-        Assert.assertNotNull(headersToBackend.get("Cache-control"));
-
-        Assert.assertFalse(headersToBackend.has("x-wso2-cluster-header"));
-        Assert.assertFalse(headersToBackend.has("x-envoy-expected-rq-timeout-ms"));
-
-        // Response headers received by the client
-        Map<String, String> headersToClient = response.getHeaders();
-        Assert.assertEquals(headersToClient.size(), 4, "Unexpected number of headers received by the client");
-
-        Assert.assertNotNull(headersToClient.get("date"));      // = Fri, 15 Apr 2022 05:10:41 GMT
-        Assert.assertNotNull(headersToClient.get("server"));    // = envoy
-        Assert.assertNotNull(headersToClient.get("content-length"));
-        Assert.assertNotNull(headersToClient.get("content-type"));
     }
 }

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/Utils.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/Utils.java
@@ -46,6 +46,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -492,6 +493,18 @@ public class Utils {
         Yaml yaml= new Yaml();
         Object obj = yaml.load(yamlString);
         return JSONValue.toJSONString(obj);
+    }
+
+    public static JSONObject changeHeadersToLowerCase(JSONObject headers) {
+        JSONObject headersCaseInsensitive = new JSONObject();
+        Iterator it = headers.keys();
+
+        while (it.hasNext()) {
+            String keyRaw = (String) it.next();
+            String key = keyRaw.toLowerCase();
+            headersCaseInsensitive.put(key, headers.get(keyRaw));
+        }
+        return headersCaseInsensitive;
     }
 
     public static String getTargetDirPath() {

--- a/integration/test-integration/src/test/resources/apim/1/apis/EnvoyHttpFilterAPI.json
+++ b/integration/test-integration/src/test/resources/apim/1/apis/EnvoyHttpFilterAPI.json
@@ -1,0 +1,23 @@
+{
+  "name": "EnvoyHttpFilterAPI",
+  "version": "1.0.0",
+  "context": "envoy_http_filter_api",
+  "type": "HTTP",
+  "tiersCollection": "Unlimited",
+  "operationsDTOS": [
+    {
+      "verb": "GET",
+      "target": "/headers",
+      "throttlingPolicy": "Unlimited"
+    }
+  ],
+  "endpoint": {
+    "endpoint_type": "http",
+    "production_endpoints": {
+      "url": "http://mockBackend:2383/v2"
+    },
+    "sandbox_endpoints": {
+      "url": "http://mockBackend:2383/v2"
+    }
+  }
+}

--- a/integration/test-integration/src/test/resources/apim/1/apps/applications.json
+++ b/integration/test-integration/src/test/resources/apim/1/apps/applications.json
@@ -20,6 +20,18 @@
     "throttleTier": "Unlimited"
   },
   {
+    "appName": "EndpointWithTrailingSlashApiApp",
+    "throttleTier": "Unlimited"
+  },
+  {
+    "appName": "EnvoyHttpFilterApp",
+    "throttleTier": "Unlimited"
+  },
+  {
+    "appName": "ExistingApiApp",
+    "throttleTier": "Unlimited"
+  },
+  {
     "appName": "Http2SecuredAPIApp",
     "throttleTier": "Unlimited"
   },
@@ -29,14 +41,6 @@
   },
   {
     "appName": "Http1APIApp",
-    "throttleTier": "Unlimited"
-  },
-  {
-    "appName": "EndpointWithTrailingSlashApiApp",
-    "throttleTier": "Unlimited"
-  },
-  {
-    "appName": "ExistingApiApp",
     "throttleTier": "Unlimited"
   },
   {

--- a/integration/test-integration/src/test/resources/apim/1/subscriptions/subscriptions.json
+++ b/integration/test-integration/src/test/resources/apim/1/subscriptions/subscriptions.json
@@ -25,13 +25,13 @@
     "tier": "Unlimited"
   },
   {
-    "apiName": "Http2ClearTextAPI",
-    "appName": "Http2ClearTextAPIApp",
+    "apiName": "EnvoyHttpFilterAPI",
+    "appName": "EnvoyHttpFilterApp",
     "tier": "Unlimited"
   },
   {
-    "apiName": "Http2SecuredAPI",
-    "appName": "Http2SecuredAPIApp",
+    "apiName": "ExistingAPI",
+    "appName": "ExistingApiApp",
     "tier": "Unlimited"
   },
   {
@@ -40,8 +40,13 @@
     "tier": "Unlimited"
   },
   {
-    "apiName": "ExistingAPI",
-    "appName": "ExistingApiApp",
+    "apiName": "Http2ClearTextAPI",
+    "appName": "Http2ClearTextAPIApp",
+    "tier": "Unlimited"
+  },
+  {
+    "apiName": "Http2SecuredAPI",
+    "appName": "Http2SecuredAPIApp",
     "tier": "Unlimited"
   },
   {

--- a/integration/test-integration/src/test/resources/testng-cc-standalone.xml
+++ b/integration/test-integration/src/test/resources/testng-cc-standalone.xml
@@ -37,11 +37,13 @@
     <test name="cc-with-default-config" preserve-order="true" parallel="false">
         <classes>
             <class name="org.wso2.choreo.connect.tests.setup.standalone.CcWithDefaultConf"/>
+
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy.MountedAPIsTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy.APiDeployViaRestTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy.APiDeployViaApictlTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy.TrailingSlashTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy.AllHttpMethodsForWildcardTestCase"/>
+            <class name="org.wso2.choreo.connect.tests.testcases.standalone.router.EnvoyHttpFilterTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.endpoints.ProductionSandboxTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.endpoints.BackendSecurityTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.jwtValidator.JwtTestCase"/>
@@ -64,6 +66,7 @@
     <test name="cc-with-backend-tls-with-opa-server" preserve-order="true" parallel="false">
         <classes>
             <class name="org.wso2.choreo.connect.tests.setup.standalone.CcWithBackendTlsAndCorsDisabledWithOPA"/>
+
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.mtls.MtlsFromRouterToBackendTestcase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.security.CorsTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.security.APIKeyTestCase"/>
@@ -82,6 +85,7 @@
     <test name="cc-with-jwt-config" preserve-order="true" parallel="false">
         <classes>
             <class name="org.wso2.choreo.connect.tests.setup.standalone.CcWithJwtConfig"/>
+
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.security.CorsTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.jwtGenerator.JwtGeneratorTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.jwtGenerator.JwtTransformerTestCase"/>
@@ -91,6 +95,7 @@
     <test name="cc-with-jwt-config-and-transformer" preserve-order="true" parallel="false">
         <classes>
             <class name="org.wso2.choreo.connect.tests.setup.standalone.CcWithJwtConfigAndTransformer"/>
+
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.jwtGenerator.CustomJwtTransformerTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.filter.CustomFilterTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.filter.BodyPassDisabledTestCase"/>

--- a/integration/test-integration/src/test/resources/testng-cc-with-apim.xml
+++ b/integration/test-integration/src/test/resources/testng-cc-with-apim.xml
@@ -73,6 +73,7 @@
        <classes>
            <class name="org.wso2.choreo.connect.tests.testcases.withapim.BasicEventsTestCase"/>
            <class name="org.wso2.choreo.connect.tests.testcases.withapim.ExistingApiTestCase"/>
+           <class name="org.wso2.choreo.connect.tests.testcases.withapim.EnvoyHttpFilterTestCase"/>
            <class name="org.wso2.choreo.connect.tests.testcases.withapim.BackendSecurityTestCase"/>
            <class name="org.wso2.choreo.connect.tests.testcases.withapim.jwtValidator.JwtAndScopeTestCase"/>
            <class name="org.wso2.choreo.connect.tests.testcases.withapim.apikey.APIKeyTestCase"/>


### PR DESCRIPTION
### Purpose
Prevent x-envoy headers `X-envoy-original-path` and `x-envoy-expected-rq-timeout-ms` being sent to the backend.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/2986

### Automation tests
 - Unit tests added: No
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
