### PR TITLE
Suppress x-envoy headers and cluster header being sent to the backend service

### DIFF
--- a/adapter/internal/oasparser/envoyconf/http_filters.go
+++ b/adapter/internal/oasparser/envoyconf/http_filters.go
@@ -68,7 +68,7 @@ func getRouterHTTPFilter() *hcmv3.HttpFilter {
 		DynamicStats:             nil,
 		StartChildSpan:           false,
 		UpstreamLog:              nil,
-		SuppressEnvoyHeaders:     false,
+		SuppressEnvoyHeaders:     true,
 		StrictCheckHeaders:       nil,
 		RespectExpectedRqTimeout: false,
 	}

--- a/adapter/internal/oasparser/envoyconf/listener.go
+++ b/adapter/internal/oasparser/envoyconf/listener.go
@@ -43,8 +43,9 @@ import (
 func CreateRoutesConfigForRds(vHosts []*routev3.VirtualHost) *routev3.RouteConfiguration {
 	rdsConfigName := defaultRdsConfigName
 	routeConfiguration := routev3.RouteConfiguration{
-		Name:         rdsConfigName,
-		VirtualHosts: vHosts,
+		Name:                   rdsConfigName,
+		VirtualHosts:           vHosts,
+		RequestHeadersToRemove: []string{clusterHeaderName},
 	}
 	return &routeConfiguration
 }

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -678,13 +678,11 @@ func createRoute(params *routeCreateParams) *routev3.Route {
 
 	logger.LoggerOasparser.Debug("creating a route....")
 	var (
-		router                  routev3.Route
-		action                  *routev3.Route_Route
-		match                   *routev3.RouteMatch
-		decorator               *routev3.Decorator
-		resourcePath            string
-		requestHeadersToRemove  []string
-		responseHeadersToRemove []string
+		router       routev3.Route
+		action       *routev3.Route_Route
+		match        *routev3.RouteMatch
+		decorator    *routev3.Decorator
+		resourcePath string
 	)
 	basePath := getFilteredBasePath(xWso2Basepath, endpointBasepath)
 
@@ -887,9 +885,6 @@ func createRoute(params *routeCreateParams) *routev3.Route {
 	if corsPolicy != nil {
 		action.Route.Cors = corsPolicy
 	}
-	requestHeadersToRemove = append(requestHeadersToRemove, clusterHeaderName)
-	// remove the 'x-envoy-upstream-service-time' from the response.
-	responseHeadersToRemove = append(responseHeadersToRemove, upstreamServiceTimeHeader)
 
 	logger.LoggerOasparser.Debug("adding route ", resourcePath)
 	router = routev3.Route{
@@ -902,8 +897,6 @@ func createRoute(params *routeCreateParams) *routev3.Route {
 			wellknown.HTTPExternalAuthorization: extAuthzFilter,
 			wellknown.Lua:                       luaFilter,
 		},
-		RequestHeadersToRemove:  requestHeadersToRemove,
-		ResponseHeadersToRemove: responseHeadersToRemove,
 	}
 	return &router
 }

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -683,6 +683,7 @@ func createRoute(params *routeCreateParams) *routev3.Route {
 		match                   *routev3.RouteMatch
 		decorator               *routev3.Decorator
 		resourcePath            string
+		requestHeadersToRemove  []string
 		responseHeadersToRemove []string
 	)
 	basePath := getFilteredBasePath(xWso2Basepath, endpointBasepath)
@@ -886,6 +887,7 @@ func createRoute(params *routeCreateParams) *routev3.Route {
 	if corsPolicy != nil {
 		action.Route.Cors = corsPolicy
 	}
+	requestHeadersToRemove = append(requestHeadersToRemove, clusterHeaderName)
 	// remove the 'x-envoy-upstream-service-time' from the response.
 	responseHeadersToRemove = append(responseHeadersToRemove, upstreamServiceTimeHeader)
 
@@ -900,6 +902,7 @@ func createRoute(params *routeCreateParams) *routev3.Route {
 			wellknown.HTTPExternalAuthorization: extAuthzFilter,
 			wellknown.Lua:                       luaFilter,
 		},
+		RequestHeadersToRemove:  requestHeadersToRemove,
 		ResponseHeadersToRemove: responseHeadersToRemove,
 	}
 	return &router

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/router/EnvoyHttpFilterTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/router/EnvoyHttpFilterTestCase.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.choreo.connect.tests.testcases.standalone.router;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.apache.http.HttpStatus;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.choreo.connect.tests.util.HttpResponse;
+import org.wso2.choreo.connect.tests.util.HttpsClientRequest;
+import org.wso2.choreo.connect.tests.util.TestConstant;
+import org.wso2.choreo.connect.tests.util.TokenUtil;
+import org.wso2.choreo.connect.tests.util.Utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class EnvoyHttpFilterTestCase {
+    private String jwtTokenProd;
+
+    @BeforeClass
+    void start() throws Exception {
+        jwtTokenProd = TokenUtil.getJwtForPetstore(TestConstant.KEY_TYPE_PRODUCTION, null, false);
+    }
+
+    @Test(description = "Test to invoke resource protected with scopes with correct jwt")
+    public void checkHeadersSentToBackend() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
+        HttpResponse response = HttpsClientRequest.retryGetRequestUntilDeployed(Utils.getServiceURLHttps("/v2/standard/headers"), headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
+
+        // Request headers received by the backend
+        JSONObject headersSentToBackend = new JSONObject(response.getData());
+        Assert.assertEquals(headersSentToBackend.length(), 8, "Unexpected number of headers received by the backend");
+
+        JSONObject headersToBackend = Utils.changeHeadersToLowerCase(headersSentToBackend);
+
+        Assert.assertNotNull(headersToBackend.get("x-trace-key"));
+        Assert.assertNotNull(headersToBackend.get("accept"));
+        Assert.assertNotNull(headersToBackend.get("x-request-id"));
+        Assert.assertNotNull(headersToBackend.get("x-forwarded-proto"));
+        Assert.assertNotNull(headersToBackend.get("host"));
+        Assert.assertNotNull(headersToBackend.get("pragma"));
+        Assert.assertNotNull(headersToBackend.get("user-agent"));
+        Assert.assertNotNull(headersToBackend.get("cache-control"));
+
+        Assert.assertFalse(headersToBackend.has("x-envoy-original-path"), "x-envoy-original-path not removed");
+        Assert.assertFalse(headersToBackend.has("x-wso2-cluster-header"), "x-wso2-cluster-header not removed");
+        Assert.assertFalse(headersToBackend.has("x-envoy-expected-rq-timeout-ms"), "x-envoy-expected-rq-timeout-ms not removed");
+
+        // Response headers received by the client
+        Map<String, String> headersToClient = response.getHeaders();
+        Assert.assertEquals(headersToClient.size(), 4, "Unexpected number of headers received by the client");
+
+        Assert.assertNotNull(headersToClient.get("date"));
+        Assert.assertNotNull(headersToClient.get("server"));
+        Assert.assertNotNull(headersToClient.get("content-length"));
+        Assert.assertNotNull(headersToClient.get("content-type"));
+    }
+}

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/EnvoyHttpFilterTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/EnvoyHttpFilterTestCase.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.choreo.connect.tests.testcases.withapim;
+
+import org.apache.http.HttpStatus;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.choreo.connect.tests.apim.ApimBaseTest;
+import org.wso2.choreo.connect.tests.apim.ApimResourceProcessor;
+import org.wso2.choreo.connect.tests.apim.utils.StoreUtils;
+import org.wso2.choreo.connect.tests.util.HttpResponse;
+import org.wso2.choreo.connect.tests.util.HttpsClientRequest;
+import org.wso2.choreo.connect.tests.util.TestConstant;
+import org.wso2.choreo.connect.tests.util.Utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class EnvoyHttpFilterTestCase extends ApimBaseTest {
+    private static final String API_CONTEXT = "envoy_http_filter_api";
+    private static final String API_VERSION = "1.0.0";
+    private static final String APP_NAME = "CommonApp";
+    String accessTokenProd;
+
+    @BeforeClass(alwaysRun = true, description = "initialize setup")
+    void setup() throws Exception {
+        super.initWithSuperTenant();
+        String applicationId = ApimResourceProcessor.applicationNameToId.get(APP_NAME);
+        accessTokenProd = StoreUtils.generateUserAccessTokenProduction(apimServiceURLHttps, applicationId,
+                user, storeRestClient);
+    }
+
+    @Test(description = "Check the headers sent to the backend")
+    public void checkHeadersSentToBackend() throws Exception {
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(TestConstant.AUTHORIZATION_HEADER, "Bearer " + accessTokenProd);
+
+        String endpoint = Utils.getServiceURLHttps(API_CONTEXT + "/" + API_VERSION + "/headers");
+        HttpResponse response = HttpsClientRequest.retryGetRequestUntilDeployed(endpoint, headers);
+        Assert.assertNotNull(response, "Error occurred while invoking the endpoint " + endpoint + " HttpResponse ");
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK,
+                "Status code mismatched. Endpoint:" + endpoint + " HttpResponse ");
+
+        // Request headers received by the backend
+        JSONObject headersSentToBackend = new JSONObject(response.getData());
+        Assert.assertEquals(headersSentToBackend.length(), 9, "Unexpected number of headers received by the backend");
+
+        JSONObject headersToBackend = Utils.changeHeadersToLowerCase(headersSentToBackend);
+
+        Assert.assertNotNull(headersToBackend.get("x-trace-key"));
+        Assert.assertNotNull(headersToBackend.get("accept"));
+        Assert.assertNotNull(headersToBackend.get("x-request-id"));
+        Assert.assertNotNull(headersToBackend.get("x-jwt-assertion"));
+        Assert.assertNotNull(headersToBackend.get("x-forwarded-proto"));
+        Assert.assertNotNull(headersToBackend.get("host"));
+        Assert.assertNotNull(headersToBackend.get("pragma"));
+        Assert.assertNotNull(headersToBackend.get("user-agent"));
+        Assert.assertNotNull(headersToBackend.get("cache-control"));
+
+        Assert.assertFalse(headersToBackend.has("x-envoy-original-path"), "x-envoy-original-path not removed");
+        Assert.assertFalse(headersToBackend.has("x-wso2-cluster-header"), "x-wso2-cluster-header not removed");
+        Assert.assertFalse(headersToBackend.has("x-envoy-expected-rq-timeout-ms"), "x-envoy-expected-rq-timeout-ms not removed");
+
+        // Response headers received by the client
+        Map<String, String> headersToClient = response.getHeaders();
+        Assert.assertEquals(headersToClient.size(), 4, "Unexpected number of headers received by the client");
+
+        Assert.assertNotNull(headersToClient.get("date"));
+        Assert.assertNotNull(headersToClient.get("server"));
+        Assert.assertNotNull(headersToClient.get("content-length"));
+        Assert.assertNotNull(headersToClient.get("content-type"));
+    }
+}

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/Utils.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/Utils.java
@@ -41,6 +41,7 @@ import java.net.Socket;
 import java.net.URL;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -501,5 +502,17 @@ public class Utils {
 
     public static String getAPIMServiceURLHttp(String servicePath) throws MalformedURLException {
         return new URL(new URL("http://localhost:" + TestConstant.APIM_SERVLET_TRP_HTTP_PORT), servicePath).toString();
+    }
+
+    public static JSONObject changeHeadersToLowerCase(JSONObject headers) {
+        JSONObject headersCaseInsensitive = new JSONObject();
+        Iterator it = headers.keys();
+
+        while (it.hasNext()) {
+            String keyRaw = (String) it.next();
+            String key = keyRaw.toLowerCase();
+            headersCaseInsensitive.put(key, headers.get(keyRaw));
+        }
+        return headersCaseInsensitive;
     }
 }

--- a/integration/test-integration/src/test/resources/apimApisAppsSubs/apis.json
+++ b/integration/test-integration/src/test/resources/apimApisAppsSubs/apis.json
@@ -102,5 +102,17 @@
         "throttlingPolicy": "Unlimited"
       }
     ]
+  },
+  {
+    "name": "EnvoyHttpFilterAPI",
+    "version": "1.0.0",
+    "context": "envoy_http_filter_api",
+    "operationsDTOS": [
+      {
+        "verb": "GET",
+        "target": "/headers",
+        "throttlingPolicy": "Unlimited"
+      }
+    ]
   }
 ]

--- a/integration/test-integration/src/test/resources/apimApisAppsSubs/applications.json
+++ b/integration/test-integration/src/test/resources/apimApisAppsSubs/applications.json
@@ -26,5 +26,9 @@
   {
     "appName": "EndpointWithTrailingSlashApiApp",
     "throttleTier": "Unlimited"
+  },
+  {
+    "appName": "CommonApp",
+    "throttleTier": "Unlimited"
   }
 ]

--- a/integration/test-integration/src/test/resources/apimApisAppsSubs/subscriptions.json
+++ b/integration/test-integration/src/test/resources/apimApisAppsSubs/subscriptions.json
@@ -28,5 +28,10 @@
     "apiName": "EndpointWithTrailingSlashAPI",
     "appName": "EndpointWithTrailingSlashApiApp",
     "tier": "Unlimited"
+  },
+  {
+    "apiName": "EnvoyHttpFilterAPI",
+    "appName": "CommonApp",
+    "tier": "Unlimited"
   }
 ]

--- a/integration/test-integration/src/test/resources/testng-cc-standalone.xml
+++ b/integration/test-integration/src/test/resources/testng-cc-standalone.xml
@@ -56,6 +56,7 @@
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.circuitBreakers.CircuitBreakersTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.interceptor.InterceptorServiceNotAvailableTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.extensions.DisableSecurityTestCase"/>
+            <class name="org.wso2.choreo.connect.tests.testcases.standalone.router.EnvoyHttpFilterTestCase"/>
         </classes>
     </test>
     <test name="cc-with-backend-tls" preserve-order="true" parallel="false">

--- a/integration/test-integration/src/test/resources/testng-cc-with-apim.xml
+++ b/integration/test-integration/src/test/resources/testng-cc-with-apim.xml
@@ -64,6 +64,7 @@
            <class name="org.wso2.choreo.connect.tests.testcases.withapim.apikey.APIKeyAppLevelThrottleTestCase"/>
            <class name="org.wso2.choreo.connect.tests.testcases.withapim.apikey.APIKeySubLevelThrottleTestCase"/>
            <class name="org.wso2.choreo.connect.tests.testcases.withapim.RetryAndTimeoutTestCase"/>
+           <class name="org.wso2.choreo.connect.tests.testcases.withapim.EnvoyHttpFilterTestCase"/>
        </classes>
    </test>
     <test name="all-events-received-via-eventhub" parallel="false">


### PR DESCRIPTION
### Purpose
Prevent x-envoy headers `x-envoy-original-path` and `x-envoy-expected-rq-timeout-ms` being sent to the backend
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/2986

### Automation tests
 - Unit tests added: No
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
OS: macOS Monterey 12.4
Env (Docker/K8s): Docker 20.10.16 on Rancher Desktop 1.4.1

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
