### PR TITLE
Changed deployedTimestamp type from string to int64

### DIFF
--- a/adapter/pkg/synchronizer/types.go
+++ b/adapter/pkg/synchronizer/types.go
@@ -63,7 +63,7 @@ type APIDeployment struct {
 type GatewayLabel struct {
 	Name              string `json:"name"`
 	Vhost             string `json:"vhost"`
-	DeployedTimeStamp string `json:"deployedTimeStamp"`
+	DeployedTimeStamp int64  `json:"deployedTimeStamp"`
 }
 
 // APIConfigs represents env properties belongs to the API


### PR DESCRIPTION
### Purpose
Changed deployedTimestamp type in GatewayLabel struct from string to int64 due to the change of deployedTimestamp in `deployment.json` from string to long. 

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
OS: macOS Monterey 12.4
Env (Docker/K8s): Docker 20.10.16 on Rancher Desktop 1.4.1

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
