### PR TITLE
Add OpenTelemetry OTLP exporter support for publishing traces

### DIFF
--- a/enforcer-parent/enforcer/pom.xml
+++ b/enforcer-parent/enforcer/pom.xml
@@ -482,6 +482,10 @@
             <artifactId>opentelemetry-extension-trace-propagators</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.choreo.connect</groupId>
             <artifactId>org.wso2.choreo.connect.enforcer.commons</artifactId>
             <version>${project.parent.version}</version>

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/TracerFactory.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/TracerFactory.java
@@ -29,6 +29,7 @@ import org.wso2.choreo.connect.enforcer.config.dto.TracingDTO;
 import org.wso2.choreo.connect.enforcer.server.AuthServer;
 import org.wso2.choreo.connect.enforcer.tracing.exporters.AzureExporter;
 import org.wso2.choreo.connect.enforcer.tracing.exporters.JaegerExporter;
+import org.wso2.choreo.connect.enforcer.tracing.exporters.OTLPExporter;
 import org.wso2.choreo.connect.enforcer.tracing.exporters.ZipkinExporter;
 
 import java.util.HashMap;
@@ -81,6 +82,8 @@ public class TracerFactory {
             sdk = JaegerExporter.getInstance().initSdk(properties);
         } else if (TracingConstants.ZIPKIN_TRACE_EXPORTER.equalsIgnoreCase(exporterType)) {
             sdk = ZipkinExporter.getInstance().initSdk(properties);
+        } else if (TracingConstants.OTLP_TRACE_EXPORTER.equalsIgnoreCase(exporterType)) {
+            sdk = OTLPExporter.getInstance().initSdk(properties);
         } else {
             throw new TracingException("Tracer exporter type: " + exporterType + "not found!");
         }

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/TracingConstants.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/TracingConstants.java
@@ -71,7 +71,6 @@ public class TracingConstants {
     public static final String CONF_PORT = "port";
     public static final String CONF_AUTH_HEADER_NAME = "authHeaderName";
     public static final String CONF_AUTH_HEADER_VALUE = "authHeaderValue";
-    public static final String CONF_REMOTE_URL = "remoteUrl";
     public static final int DEFAULT_MAX_TRACES_PER_SEC = 2;
     public static final String DEFAULT_INSTRUMENTATION_NAME = "CHOREO-CONNECT";
     public static final long DEFAULT_TRACING_READ_TIMEOUT = 15;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/TracingConstants.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/TracingConstants.java
@@ -27,6 +27,7 @@ public class TracingConstants {
     public static final String AZURE_TRACE_EXPORTER = "azure";
     public static final String JAEGER_TRACE_EXPORTER = "jaeger";
     public static final String ZIPKIN_TRACE_EXPORTER = "zipkin";
+    public static final String OTLP_TRACE_EXPORTER = "otlp";
     public static final String DO_THROTTLE_SPAN = "ThrottleFilter:doThrottle():Throttling function";
     public static final String ENFORCER_START_SPAN = "Enforcer:Starting request verification";
     public static final String PUBLISH_THROTTLE_EVENT_SPAN = "ThrottleFilter:handleRequest():Publish non " +

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/TracingConstants.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/TracingConstants.java
@@ -69,6 +69,9 @@ public class TracingConstants {
     public static final String CONF_ENDPOINT = "endpoint";
     public static final String CONF_HOST = "host";
     public static final String CONF_PORT = "port";
+    public static final String CONF_AUTH_HEADER_NAME = "authHeaderName";
+    public static final String CONF_AUTH_HEADER_VALUE = "authHeaderValue";
+    public static final String CONF_REMOTE_URL = "remoteUrl";
     public static final int DEFAULT_MAX_TRACES_PER_SEC = 2;
     public static final String DEFAULT_INSTRUMENTATION_NAME = "CHOREO-CONNECT";
     public static final long DEFAULT_TRACING_READ_TIMEOUT = 15;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/AzureExporter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/AzureExporter.java
@@ -65,9 +65,6 @@ public class AzureExporter implements TracerBuilder {
         String maxTracesPerSecondString = properties.get(TracingConstants.CONF_MAX_TRACES_PER_SEC);
         int maxTracesPerSecond = StringUtils.isEmpty(maxTracesPerSecondString) ?
                 TracingConstants.DEFAULT_MAX_TRACES_PER_SEC : Integer.parseInt(maxTracesPerSecondString);
-        String instrumentName = properties.get(TracingConstants.CONF_INSTRUMENTATION_NAME);
-        String instrumentationName = StringUtils.isEmpty(instrumentName) ?
-                TracingConstants.DEFAULT_INSTRUMENTATION_NAME : instrumentName;
 
         AzureMonitorTraceExporter exporter = new AzureMonitorExporterBuilder()
                 .connectionString(connectionString).buildTraceExporter();

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/JaegerExporter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/JaegerExporter.java
@@ -81,9 +81,6 @@ public class JaegerExporter implements TracerBuilder {
         String maxTracesPerSecondString = properties.get(TracingConstants.CONF_MAX_TRACES_PER_SEC);
         int maxTracesPerSecond = StringUtils.isEmpty(maxTracesPerSecondString) ?
                 TracingConstants.DEFAULT_MAX_TRACES_PER_SEC : Integer.parseInt(maxTracesPerSecondString);
-        String instrumentName = properties.get(TracingConstants.CONF_INSTRUMENTATION_NAME);
-        String instrumentationName = StringUtils.isEmpty(instrumentName) ?
-                TracingConstants.DEFAULT_INSTRUMENTATION_NAME : instrumentName;
 
         // Set to process the spans by the Jaeger Exporter
         SdkTracerProvider provider = SdkTracerProvider.builder()

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/OTLPExporter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/OTLPExporter.java
@@ -90,7 +90,8 @@ public class OTLPExporter implements TracerBuilder {
 
         // Optional auth header for Saas providers and other telemetry backends that supports token/key based
         // authentication.
-        if (authHeaderName != null && authHeaderValue != null) {
+        if (authHeaderName != null && authHeaderValue != null &&
+                (!"".equals(authHeaderName)) && (!"".equals(authHeaderValue))) {
             otlpGrpcSpanExporterBuilder.addHeader(authHeaderName, authHeaderValue);
         }
 

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/OTLPExporter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/OTLPExporter.java
@@ -90,8 +90,7 @@ public class OTLPExporter implements TracerBuilder {
 
         // Optional auth header for Saas providers and other telemetry backends that supports token/key based
         // authentication.
-        if (authHeaderName != null && authHeaderValue != null &&
-                (!"".equals(authHeaderName)) && (!"".equals(authHeaderValue))) {
+        if (!StringUtils.isBlank(authHeaderName) && !StringUtils.isBlank(authHeaderValue)) {
             otlpGrpcSpanExporterBuilder.addHeader(authHeaderName, authHeaderValue);
         }
 

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/OTLPExporter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/OTLPExporter.java
@@ -66,12 +66,12 @@ public class OTLPExporter implements TracerBuilder {
         String host = properties.get(TracingConstants.CONF_HOST);
         String authHeaderName = properties.get(TracingConstants.CONF_AUTH_HEADER_NAME);
         String authHeaderValue = properties.get(TracingConstants.CONF_AUTH_HEADER_VALUE);
-        String remoteUrl = properties.get(TracingConstants.CONF_REMOTE_URL);
+        String connectionString = properties.get(TracingConstants.CONF_CONNECTION_STRING);
         ConfigHolder conf = ConfigHolder.getInstance();
         OtlpGrpcSpanExporterBuilder otlpGrpcSpanExporterBuilder = OtlpGrpcSpanExporter.builder();
 
-        if (remoteUrl != null) {
-            otlpGrpcSpanExporterBuilder.setEndpoint(remoteUrl);
+        if (connectionString != null) {
+            otlpGrpcSpanExporterBuilder.setEndpoint(connectionString);
         } else {
             try {
                 int port = Integer.parseInt(properties.get(TracingConstants.CONF_PORT));

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/OTLPExporter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/OTLPExporter.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.choreo.connect.enforcer.tracing.exporters;
 
 import io.opentelemetry.api.common.Attributes;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/OTLPExporter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/OTLPExporter.java
@@ -1,0 +1,74 @@
+package org.wso2.choreo.connect.enforcer.tracing.exporters;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.wso2.choreo.connect.enforcer.config.ConfigHolder;
+import org.wso2.choreo.connect.enforcer.tracing.RateLimitingSampler;
+import org.wso2.choreo.connect.enforcer.tracing.TracerBuilder;
+import org.wso2.choreo.connect.enforcer.tracing.TracingConstants;
+import org.wso2.choreo.connect.enforcer.tracing.TracingException;
+
+import java.util.Map;
+
+/**
+ * Trace Exporter for Open Telemetry Protocol
+ */
+public class OTLPExporter implements TracerBuilder {
+
+    private static final Logger LOGGER = LogManager.getLogger(OTLPExporter.class);
+
+    private static OTLPExporter exporter;
+
+    public static OTLPExporter getInstance() {
+        if (exporter == null) {
+            synchronized (new Object()) {
+                if (exporter == null) {
+                    exporter = new OTLPExporter();
+                }
+            }
+        }
+        return exporter;
+    }
+
+    @Override
+    public OpenTelemetrySdk initSdk(Map<String, String> properties) throws TracingException {
+        String host = properties.get(TracingConstants.CONF_HOST);
+        // String path = properties.get(TracingConstants.CONF_ENDPOINT);
+        String endpoint;
+        ConfigHolder conf = ConfigHolder.getInstance();
+//        try {
+//            int port = Integer.parseInt(properties.get(TracingConstants.CONF_PORT));
+//            endpoint = new URL("http", host, port).toString();
+//        } catch (MalformedURLException e) {
+//            throw new TracingException("Couldn't initialize the OTLP exporter. Invalid endpoint definition", e);
+//        }
+
+        OtlpGrpcSpanExporter otlpGrpcSpanExporter = OtlpGrpcSpanExporter.builder().setEndpoint("http://jaeger:4317")
+                .build();
+        String serviceName = TracingConstants.SERVICE_NAME_PREFIX + '-' + conf.getEnvVarConfig().getEnforcerLabel();
+        Resource serviceNameResource = Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, serviceName));
+        String maxTracesPerSecondString = properties.get(TracingConstants.CONF_MAX_TRACES_PER_SEC);
+        int maxTracesPerSecond = StringUtils.isEmpty(maxTracesPerSecondString) ?
+                TracingConstants.DEFAULT_MAX_TRACES_PER_SEC : Integer.parseInt(maxTracesPerSecondString);
+        String instrumentName = properties.get(TracingConstants.CONF_INSTRUMENTATION_NAME);
+
+        SdkTracerProvider provider = SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor
+                        .create(otlpGrpcSpanExporter)).setSampler(new RateLimitingSampler(maxTracesPerSecond))
+                        .setResource(Resource.getDefault().merge(serviceNameResource)).build();
+        OpenTelemetrySdk openTelemetrySdk = OpenTelemetrySdk.builder().setTracerProvider(provider)
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                .buildAndRegisterGlobal();
+        LOGGER.info("Trace SDK successfully initialized with OTLP Trace Exporter");
+        return openTelemetrySdk;
+    }
+}

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/ZipkinExporter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/tracing/exporters/ZipkinExporter.java
@@ -87,9 +87,6 @@ public class ZipkinExporter implements TracerBuilder {
         String maxTracesPerSecondString = properties.get(TracingConstants.CONF_MAX_TRACES_PER_SEC);
         int maxTracesPerSecond = StringUtils.isEmpty(maxTracesPerSecondString) ?
                 TracingConstants.DEFAULT_MAX_TRACES_PER_SEC : Integer.parseInt(maxTracesPerSecondString);
-        String instrumentName = properties.get(TracingConstants.CONF_INSTRUMENTATION_NAME);
-        String instrumentationName = StringUtils.isEmpty(instrumentName) ?
-                TracingConstants.DEFAULT_INSTRUMENTATION_NAME : instrumentName;
 
         // Set to process the spans by the zipkin Exporter
         SdkTracerProvider provider = SdkTracerProvider.builder()

--- a/pom.xml
+++ b/pom.xml
@@ -591,9 +591,9 @@
         <nimbus.jose.jwt.version>7.9</nimbus.jose.jwt.version>
         <org.json.version>3.0.0.wso2v1</org.json.version>
         <os.mvn.plugin.version>1.6.2</os.mvn.plugin.version>
-        <otel.alpha.version>1.16.0-alpha</otel.alpha.version>
-        <otel.version>1.16.0</otel.version>
-        <otel.otlp.version>1.16.0</otel.otlp.version>
+        <otel.alpha.version>1.18.0-alpha</otel.alpha.version>
+        <otel.version>1.18.0</otel.version>
+        <otel.otlp.version>1.18.0</otel.otlp.version>
         <shade.plugin.version>3.2.4</shade.plugin.version>
         <slf4j.version>1.7.21</slf4j.version>
         <swagger.v3.models.version>2.0.8</swagger.v3.models.version>

--- a/pom.xml
+++ b/pom.xml
@@ -519,6 +519,11 @@
                 <version>${otel.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-exporter-otlp</artifactId>
+                <version>${otel.otlp.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-messaging-eventhubs</artifactId>
                 <version>${azure.messaging.eventhubs.version}</version>
@@ -586,8 +591,9 @@
         <nimbus.jose.jwt.version>7.9</nimbus.jose.jwt.version>
         <org.json.version>3.0.0.wso2v1</org.json.version>
         <os.mvn.plugin.version>1.6.2</os.mvn.plugin.version>
-        <otel.alpha.version>1.6.0-alpha</otel.alpha.version>
-        <otel.version>1.6.0</otel.version>
+        <otel.alpha.version>1.16.0-alpha</otel.alpha.version>
+        <otel.version>1.16.0</otel.version>
+        <otel.otlp.version>1.16.0</otel.otlp.version>
         <shade.plugin.version>3.2.4</shade.plugin.version>
         <slf4j.version>1.7.21</slf4j.version>
         <swagger.v3.models.version>2.0.8</swagger.v3.models.version>

--- a/resources/conf/config.toml.template
+++ b/resources/conf/config.toml.template
@@ -616,3 +616,18 @@ enabled = true
   #   instrumentationName = "CHOREO-CONNECT"
   #   # Maximum number of sampled traces per second string
   #   maximumTracesPerSecond = "2"
+
+  # type = "otlp"
+  # [tracing.configProperties]
+  #   # maximum length of the request path to extract and include in the HttpUrl tag.
+  #   maxPathLength = "256"
+  #   # remote url for publishing traces. i.e - New Relic otlp url.
+  #   connectionString = "https://otlp.nr-data.net"
+  #   # auth header name
+  #   authHeaderName = "api-key"
+  #   # auth header value
+  #   authHeaderValue = "845e16b6cfba0ea5e95e3NRALe8f478ae6d3c97f"
+  #   # library Name to be tagged in traces (`otel.library.name`).
+  #   instrumentationName = "CHOREO-CONNECT"
+  #   # Maximum number of sampled traces per second string
+  #   maximumTracesPerSecond = "2"


### PR DESCRIPTION
### Purpose
Currently WSO2 Choreo Connect supports distributed tracing with Jaeger, Zipkin and Azure Application Insights using the OpenTelemetry SDK and relevant exporters. With this PR, support for publishing traces via native OTLP protocol is added. OTLP is a vendor agnostic general purpose telemetry data delivery protocol which is considered as the standard protocol for publishing telemetry data. 

### Publishing OTLP traces to jaeger gRPC OTLP collector

1. Enable OTLP collector in jaeger. (jaeger version has to be >= 1.35)

```yaml
jaeger:
    image: jaegertracing/all-in-one:1.37
    environment:
      - COLLECTOR_OTLP_ENABLED=true
    ports:
      - "16686:16686"
      - "4317:4317"
``` 

2. Enable tracing in `config.toml` and add relevant tracing config.

```toml
[tracing]
  # Enable/Disable tracing in Choreo Connect
  enabled = true
  # Type of tracer exporter (e.g: azure, zipkin). Use zipkin type for Jaeger as well.
  type = "otlp"
  # configurations for zipkin tracer type
  [tracing.configProperties]
    # maximum length of the request path to extract and include in the HttpUrl tag.
    maxPathLength = "256"
    # jaeger host
    host = "jaeger"
    # jaeger port
    port = "4317"
    # library Name to be tagged in traces (`otel.library.name`).
    instrumentationName = "CHOREO-CONNECT"
    # Maximum number of sampled traces per second string
    maximumTracesPerSecond = "2"
```

### Publishing OTLP traces to New Relic gRPC OTLP collector

New Relic is a SaaS provider for application observability and metrics and support native OTLP support for publishing traces.

1. Create an account in New Relic portal and generate a license key to publish traces. (https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup/)
2.  Enable tracing and add the relevant configuration.

```toml
[tracing]
  # Enable/Disable tracing in Choreo Connect
  enabled = true
  # Type of tracer exporter (e.g: azure, zipkin). Use zipkin type for Jaeger as well.
  type = "otlp"
  # configurations for zipkin tracer type
  [tracing.configProperties]
    # maximum length of the request path to extract and include in the HttpUrl tag.
    maxPathLength = "256"
    # remote url for publishing traces
    remoteUrl = "https://otlp.nr-data.net"
    # auth header name
    authHeaderName = "api-key"
    # auth header value
    authHeaderValue = "e8f478ae6d3c97f845e16b6cfba0ea5e95e3NRAL"
    # library Name to be tagged in traces (`otel.library.name`).
    instrumentationName = "CHOREO-CONNECT"
    # Maximum number of sampled traces per second string
    maximumTracesPerSecond = "2"
``` 
Similarly other tracing backends also can be configured using the `authHeaderName` and `authHeaderValue` fields in the configuration. `authHeaderName` will depend on the vendor. For example,

#### New Relic
authHeaderName - `api-key`
authHeaderValue - `<license key>`

#### Elastic APM
authHeaderName - `Authorization`
authHeaderValue - `Bearer apm_secret_token` or `ApiKey api_key`

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #3036

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
OS: macOS Monterey 12.4
Env (Docker/K8s): Docker 20.10.16 on Rancher Desktop 1.4.1

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
