### PR TITLE
Remove trivy ignore entry for adapter health probe

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,0 @@
-# vulnerability related golang.org/x/sys dependency in gRPC health probe.
-CVE-2022-29526


### PR DESCRIPTION
### Purpose
Remove trivy ignore entry for adapter health probe

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
