### PR TITLE
Stop copying certs to /home/wso2/security directory in enforcer image

### DIFF
--- a/enforcer-parent/enforcer/src/main/assembly/assembly.xml
+++ b/enforcer-parent/enforcer/src/main/assembly/assembly.xml
@@ -48,11 +48,15 @@
     <files>
         <file>
             <source>../../resources/security/mg.key</source>
-            <outputDirectory>security</outputDirectory>
+            <outputDirectory>security/keystore</outputDirectory>
         </file>
         <file>
             <source>../../resources/security/mg.pem</source>
-            <outputDirectory>security</outputDirectory>
+            <outputDirectory>security/keystore</outputDirectory>
+        </file>
+        <file>
+            <source>../../resources/security/mg.pem</source>
+            <outputDirectory>security/truststore</outputDirectory>
         </file>
         <file>
             <source>src/main/resources/check_health.sh</source>


### PR DESCRIPTION
### Purpose
$subject due to trivy scan failure.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
