### PR TITLE
Fix scope parsing error when multiple scopes provided in an array

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/validator/JWTValidator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/validator/JWTValidator.java
@@ -42,6 +42,7 @@ import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -168,8 +169,13 @@ public class JWTValidator {
         jwtValidationInfo.setUser(jwtClaimsSet.getSubject());
         jwtValidationInfo.setJti(jwtClaimsSet.getJWTID());
         if (jwtClaimsSet.getClaim(APIConstants.JwtTokenConstants.SCOPE) != null) {
-            jwtValidationInfo.setScopes(Arrays.asList(jwtClaimsSet.getStringClaim(APIConstants.JwtTokenConstants.SCOPE)
-                    .split(APIConstants.JwtTokenConstants.SCOPE_DELIMITER)));
+            if (jwtClaimsSet.getClaim(APIConstants.JwtTokenConstants.SCOPE) instanceof List) {
+                jwtValidationInfo.setScopes(jwtClaimsSet.getStringListClaim(APIConstants.JwtTokenConstants.SCOPE));
+            } else {
+                jwtValidationInfo.setScopes(Arrays.asList(
+                        jwtClaimsSet.getStringClaim(APIConstants.JwtTokenConstants.SCOPE)
+                                .split(APIConstants.JwtTokenConstants.SCOPE_DELIMITER)));
+            }
         }
     }
 

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/jwtValidator/ScopesAsArrayTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/jwtValidator/ScopesAsArrayTestCase.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.choreo.connect.tests.testcases.standalone.jwtValidator;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.apache.http.HttpStatus;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.choreo.connect.tests.common.model.API;
+import org.wso2.choreo.connect.tests.common.model.ApplicationDTO;
+import org.wso2.choreo.connect.tests.util.HttpsClientRequest;
+import org.wso2.choreo.connect.tests.util.HttpResponse;
+import org.wso2.choreo.connect.tests.util.TestConstant;
+import org.wso2.choreo.connect.tests.util.TokenUtil;
+import org.wso2.choreo.connect.tests.util.Utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ScopesAsArrayTestCase {
+    private String jwtWithEmptyArrayScope;
+    private String jwtWithInvalidScope;
+    private String jwtWithAPIScope;
+    private String jwtWithOneResourceScope;
+    private String jwtWithMultipleResourceScopes;
+    private String jwtWithMultipleInvalidScopes;
+
+    @BeforeClass(description = "initialise the setup")
+    void start() throws Exception {
+        API api = new API();
+        ApplicationDTO application = new ApplicationDTO();
+        jwtWithEmptyArrayScope = createJwtWithScopesArray(api, application, new String[]{});
+        jwtWithInvalidScope = createJwtWithScopesArray(api, application, new String[]{"write:other"});
+        jwtWithAPIScope = createJwtWithScopesArray(api, application, new String[]{"write:scopes"});
+        jwtWithOneResourceScope = createJwtWithScopesArray(api, application, new String[]{"read:scopes"});
+        jwtWithMultipleResourceScopes = createJwtWithScopesArray(api, application, new String[]{"write:scopes", "read:scopes"});
+        jwtWithMultipleInvalidScopes = createJwtWithScopesArray(api, application, new String[]{"foo", "bar"});
+
+    }
+
+    @Test
+    public void testEmptyScopesArray() throws Exception {
+        invokeWithToken(jwtWithEmptyArrayScope, "/scopes/v2/pet/findByStatus", HttpStatus.SC_FORBIDDEN);
+    }
+
+    @Test
+    public void testInvalidScopeInArray() throws Exception {
+        invokeWithToken(jwtWithInvalidScope, "/scopes/v2/pet/findByStatus", HttpStatus.SC_FORBIDDEN);
+    }
+
+    @Test
+    public void testApiLevelScopeInArray() throws Exception {
+        invokeWithToken(jwtWithAPIScope, "/scopes/v2/pet/findByStatus", HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void testOneResourceLevelScopeInArray() throws Exception {
+        invokeWithToken(jwtWithOneResourceScope, "/scopes/v2/pets/findByTags", HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void testMultipleResourceLevelScopesInArray() throws Exception {
+        invokeWithToken(jwtWithMultipleResourceScopes, "/scopes/v2/pet/findByStatus", HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void testMultipleInvalidScopesInArray() throws Exception {
+        invokeWithToken(jwtWithMultipleInvalidScopes, "/scopes/v2/pet/findByStatus", HttpStatus.SC_FORBIDDEN);
+    }
+
+    private static void invokeWithToken(String token, String path, int responseCode) throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + token);
+        HttpResponse response = HttpsClientRequest.retryGetRequestUntilDeployed(Utils.getServiceURLHttps(
+                path), headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), responseCode, "Response code mismatched");
+    }
+
+    private static String createJwtWithScopesArray(API api, ApplicationDTO application, String[] scopes)
+            throws Exception {
+        JSONObject specificClaims = new JSONObject();
+        specificClaims.put("scope", scopes);
+        return TokenUtil.getJWT(api, application, "Unlimited", TestConstant.KEY_TYPE_PRODUCTION,
+                3600, specificClaims);
+    }
+}

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/throttle/SubscriptionThrottlingTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/throttle/SubscriptionThrottlingTestCase.java
@@ -122,8 +122,9 @@ public class SubscriptionThrottlingTestCase extends ThrottlingBaseTestCase {
         JSONObject jwtTokenInfo = new JSONObject();
         // In apim mode, we use the port 9444 since 9443 is already used by Rancher
         jwtTokenInfo.put("iss", "https://localhost:9444/oauth2/token");
+        jwtTokenInfo.put("scope", "write:pets");
         String jwtToken = TokenUtil.getJWT(api, application, "15PerMin", TestConstant.KEY_TYPE_PRODUCTION,
-                3600, "write:pets", false, jwtTokenInfo);
+                3600, jwtTokenInfo);
 
         Map<String, String> requestHeaders = new HashMap<>();
         requestHeaders.put(TestConstant.AUTHORIZATION_HEADER, "Bearer " + jwtToken);

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/TokenUtil.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/TokenUtil.java
@@ -18,6 +18,7 @@
 
 package org.wso2.choreo.connect.tests.util;
 
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.wso2.choreo.connect.tests.common.model.API;
@@ -31,11 +32,7 @@ import java.security.Key;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.Signature;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -43,15 +40,19 @@ import java.util.concurrent.TimeUnit;
  */
 public class TokenUtil {
 
-    public static String getBasicJWT(ApplicationDTO applicationDTO, JSONObject overridingJwtInfo, String keyType,
-            int validityPeriod, String scopes) throws Exception {
+    public static String getBasicJWT(ApplicationDTO applicationDTO, String keyType,
+                                     int validityPeriod, JSONObject specificClaims) throws Exception {
+        JSONObject jwtTokenInfo = populateBasicPayloadForToken(applicationDTO, keyType, validityPeriod,
+                specificClaims);
 
+        return createOauthToken(jwtTokenInfo);
+    }
+
+    private static JSONObject populateBasicPayloadForToken(ApplicationDTO applicationDTO, String keyType,
+                                                           int validityPeriod, JSONObject specificClaims) {
         JSONObject jwtTokenInfo = new JSONObject();
         jwtTokenInfo.put("aud", "http://org.wso2.apimgt/gateway");
         jwtTokenInfo.put("sub", "admin");
-        if (scopes != null) {
-            jwtTokenInfo.put("scope", scopes);
-        }
         jwtTokenInfo.put("application", new JSONObject(applicationDTO));
         jwtTokenInfo.put("iss", "https://localhost:9443/oauth2/token");
         jwtTokenInfo.put("keytype", keyType);
@@ -59,42 +60,22 @@ public class TokenUtil {
         jwtTokenInfo.put("exp", (int) TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()) + validityPeriod);
         jwtTokenInfo.put("jti", UUID.randomUUID());
 
-        for (Iterator it = overridingJwtInfo.keys(); it.hasNext(); ) {
+        for (Iterator it = specificClaims.keys(); it.hasNext(); ) {
             String overriddenKey = (String) it.next();
-            jwtTokenInfo.put(overriddenKey, overridingJwtInfo.get(overriddenKey));
+            jwtTokenInfo.put(overriddenKey, specificClaims.get(overriddenKey));
         }
+        return jwtTokenInfo;
+    }
 
-        String payload = jwtTokenInfo.toString();
-
+    private static String createOauthToken(JSONObject payloadJson) throws Exception {
         JSONObject head = new JSONObject();
         head.put("typ", "JWT");
         head.put("alg", "RS256");
         head.put("x5t", "UB_BQy2HFV3EMTgq64Q-1VitYbE");
         String header = head.toString();
+        String payload = payloadJson.toString();
 
-        String base64UrlEncodedHeader = Base64.getUrlEncoder()
-                .encodeToString(header.getBytes(Charset.defaultCharset()));
-        String base64UrlEncodedBody = Base64.getUrlEncoder().encodeToString(payload.getBytes(Charset.defaultCharset()));
-
-        Signature signature = Signature.getInstance("SHA256withRSA");
-        String jksPath = TokenUtil.class.getClassLoader().getResource("keystore/wso2carbon.jks").getPath();
-        FileInputStream is = new FileInputStream(jksPath);
-        KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
-        keystore.load(is, "wso2carbon".toCharArray());
-        String alias = "wso2carbon";
-        Key key = keystore.getKey(alias, "wso2carbon".toCharArray());
-        Key privateKey = null;
-        if (key instanceof PrivateKey) {
-            privateKey = key;
-        }
-        signature.initSign((PrivateKey) privateKey);
-        String assertion = base64UrlEncodedHeader + "." + base64UrlEncodedBody;
-        byte[] dataInBytes = assertion.getBytes(StandardCharsets.UTF_8);
-        signature.update(dataInBytes);
-        //sign the assertion and return the signature
-        byte[] signedAssertion = signature.sign();
-        String base64UrlEncodedAssertion = Base64.getUrlEncoder().encodeToString(signedAssertion);
-        return base64UrlEncodedHeader + '.' + base64UrlEncodedBody + '.' + base64UrlEncodedAssertion;
+        return createJWT(header, payload);
     }
 
     public static String getInternalKey(JSONObject jwtTokenInfo, String keyType, int validityPeriod) throws Exception {
@@ -112,22 +93,18 @@ public class TokenUtil {
         head.put("kid", "gateway_certificate_alias");
 
         String header = head.toString();
+        return createJWT(header, payload);
+    }
+
+    private static String createJWT(String header, String payload) throws Exception {
+        Key privateKey = loadPrivateKey("keystore/wso2carbon.jks", "wso2carbon", "wso2carbon");
+
+        Signature signature = Signature.getInstance("SHA256withRSA");
+        signature.initSign((PrivateKey) privateKey);
+
         String base64UrlEncodedHeader = Base64.getUrlEncoder()
                 .encodeToString(header.getBytes(Charset.defaultCharset()));
         String base64UrlEncodedBody = Base64.getUrlEncoder().encodeToString(payload.getBytes(Charset.defaultCharset()));
-
-        Signature signature = Signature.getInstance("SHA256withRSA");
-        String jksPath = TokenUtil.class.getClassLoader().getResource("keystore/wso2carbon.jks").getPath();
-        FileInputStream is = new FileInputStream(jksPath);
-        KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
-        keystore.load(is, "wso2carbon".toCharArray());
-        String alias = "wso2carbon";
-        Key key = keystore.getKey(alias, "wso2carbon".toCharArray());
-        Key privateKey = null;
-        if (key instanceof PrivateKey) {
-            privateKey = key;
-        }
-        signature.initSign((PrivateKey) privateKey);
         String assertion = base64UrlEncodedHeader + "." + base64UrlEncodedBody;
         byte[] dataInBytes = assertion.getBytes(StandardCharsets.UTF_8);
         signature.update(dataInBytes);
@@ -137,58 +114,73 @@ public class TokenUtil {
         return base64UrlEncodedHeader + '.' + base64UrlEncodedBody + '.' + base64UrlEncodedAssertion;
     }
 
-    public static String getJwtWithCustomClaims(ApplicationDTO applicationDTO, JSONObject jwtTokenInfo, String keyType, int validityPeriod, Map<String, String > claims)
-            throws Exception {
-        for(Map.Entry<String, String> entry : claims.entrySet()) {
-            jwtTokenInfo.put(entry.getKey(), entry.getValue());
+    private static Key loadPrivateKey(String keystorePath, String alias, String password) throws Exception {
+        String jksPath = TokenUtil.class.getClassLoader().getResource(keystorePath).getPath();
+        FileInputStream is = new FileInputStream(jksPath);
+        KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
+        keystore.load(is, password.toCharArray());
+        Key key = keystore.getKey(alias, password.toCharArray());
+        Key privateKey = null;
+        if (key instanceof PrivateKey) {
+            privateKey = key;
         }
-        return getBasicJWT(applicationDTO, jwtTokenInfo, keyType, validityPeriod, null);
-    }
-
-    public static String getJwtWithCustomClaimsTransformer(ApplicationDTO applicationDTO, JSONObject jwtTokenInfo,
-                                                           String keyType, int validityPeriod,
-                                                           Map<String, Object > claims)
-            throws Exception {
-        for(Map.Entry<String, Object> entry : claims.entrySet()) {
-            jwtTokenInfo.put(entry.getKey(), entry.getValue());
-        }
-        return getBasicJWT(applicationDTO, jwtTokenInfo, keyType, validityPeriod, null);
+        return privateKey;
     }
 
     /**
-     * get a jwt token.
+     * Get an OAuth JWT token.
      *
-     * @param api            api
-     * @param applicationDTO application dto
-     * @param tier           tier
-     * @param keyType        keytype
-     * @param validityPeriod validityPeriod
-     * @throws Exception
-     * @return JWT
+     * @param api            API info to include in subscribed API section
+     * @param applicationDTO Application info
+     * @param tier           Subscription tier to include in tierInfo
+     * @param keyType        key type as PRODUCTION or SANDBOX
+     * @param validityPeriod validity period
+     * @param scopes         one or more scopes as space separated single string
+     * @param isInternalKey  whether to create an InternalKey
+     * @throws Exception     if an error occurs while loading keystore
+     * @return               OAuth JWT token
      */
     public static String getJWT(API api, ApplicationDTO applicationDTO, String tier, String keyType,
                                 int validityPeriod, String scopes, boolean isInternalKey) throws Exception {
-        JSONObject jwtTokenInfo = new JSONObject();
-        return getJWT(api, applicationDTO, tier, keyType, validityPeriod, scopes, isInternalKey, jwtTokenInfo);
+
+        JSONObject specificClaims = new JSONObject();
+        specificClaims.put("subscribedAPIs", new JSONArray(Arrays.asList(getSubscribedApiDTO(api, tier))));
+        specificClaims.put("tierInfo", tierInfoJSONObject(tier));
+        if (scopes != null) {
+            specificClaims.put("scope", scopes);
+        }
+
+        if (isInternalKey) {
+            return TokenUtil.getInternalKey(specificClaims, keyType, validityPeriod);
+        }
+        return TokenUtil.getBasicJWT(applicationDTO, keyType, validityPeriod, specificClaims);
     }
 
     /**
-     * Get a self-contained JWT using an already populated jwtInfo JSONObject.
+     * Get an OAuth JWT token with scopes as an array of strings.
      *
-     * @param api            API info to include in the JWT
-     * @param applicationDTO Application info to include in the JWT
-     * @param tier           Subscription tier info to include in the JWT
-     * @param keyType        whether Production or Sandbox
+     * @param api            API info to include in subscribed API section
+     * @param applicationDTO Application info
+     * @param tier           Subscription tier to include in tierInfo
+     * @param keyType        key type as PRODUCTION or SANDBOX
      * @param validityPeriod validity period
-     * @param jwtTokenInfo   JSON object containing values to override the default
-     * @throws Exception if an error occurs while signing the JWT
-     * @return a self-contained JWT
+     * @param specificClaims non default or updated claims to include in the final JWT
+     * @throws Exception     if an error occurs while loading keystore
+     * @return               OAuth JWT token
      */
     public static String getJWT(API api, ApplicationDTO applicationDTO, String tier, String keyType,
-                                int validityPeriod, String scopes, boolean isInternalKey, JSONObject jwtTokenInfo)
-            throws Exception {
+                                int validityPeriod, JSONObject specificClaims) throws Exception {
+        JSONObject jwtClaims;
+        jwtClaims = Objects.requireNonNullElseGet(specificClaims, JSONObject::new);
+        jwtClaims.put("subscribedAPIs", new JSONArray(Arrays.asList(getSubscribedApiDTO(api, tier))));
+        jwtClaims.put("tierInfo", tierInfoJSONObject(tier));
+
+        return TokenUtil.getBasicJWT(applicationDTO, keyType, validityPeriod, jwtClaims);
+    }
+
+    private static SubscribedApiDTO getSubscribedApiDTO(API api, String tier) {
         SubscribedApiDTO subscribedApiDTO = new SubscribedApiDTO();
-        if (!api.getContext().startsWith("/")) {
+        if (!StringUtils.startsWith(api.getContext(), "/")) {
             api.setContext("/" + api.getContext());
         }
         subscribedApiDTO.setContext(api.getContext());
@@ -198,19 +190,15 @@ public class TokenUtil {
 
         subscribedApiDTO.setSubscriptionTier(tier);
         subscribedApiDTO.setSubscriberTenantDomain("carbon.super");
+        return subscribedApiDTO;
+    }
 
+    private static JSONObject tierInfoJSONObject(String tier) {
+        JSONObject tierInfoDTO = new JSONObject();
         JSONObject tierDTO = new JSONObject();
         tierDTO.put("stopOnQuotaReach", true);
-        JSONObject tierInfoDTO = new JSONObject();
         tierInfoDTO.put(tier, tierDTO);
-
-        jwtTokenInfo.put("subscribedAPIs", new JSONArray(Arrays.asList(subscribedApiDTO)));
-        jwtTokenInfo.put("tierInfo", tierInfoDTO);
-
-        if (isInternalKey) {
-            return TokenUtil.getInternalKey(jwtTokenInfo, keyType, validityPeriod);
-        }
-        return TokenUtil.getBasicJWT(applicationDTO, jwtTokenInfo, keyType, validityPeriod, scopes);
+        return tierInfoDTO;
     }
 
     public static String getJwtForPetstore(String keyType, String scopes, boolean isInternalKey) throws Exception {

--- a/integration/test-integration/src/test/resources/openAPIs/scopes_openAPI.yaml
+++ b/integration/test-integration/src/test/resources/openAPIs/scopes_openAPI.yaml
@@ -1,14 +1,7 @@
 swagger: '2.0'
 info:
-  description: 'This is a sample server Petstore server.'
   version: 1.0.5
   title: SwaggerPetstoreScopes
-  termsOfService: 'http://swagger.io/terms/'
-  contact:
-    email: apiteam@swagger.io
-  license:
-    name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 security:
   - petstore_auth:
       - 'write:scopes'
@@ -26,46 +19,14 @@ x-wso2-production-endpoints:
   urls:
     - 'http://mockBackend:2383/v2'
 x-wso2-basePath: /scopes/v2
-tags:
-  - name: pet
-    description: Everything about your Pets
-    externalDocs:
-      description: Find out more
-      url: 'http://swagger.io'
-  - name: store
-    description: Access to Petstore orders
-  - name: user
-    description: Operations about user
-    externalDocs:
-      description: Find out more about our store
-      url: 'http://swagger.io'
 schemes:
   - http
 paths:
   /pet/findByStatus:
     get:
-      tags:
-        - pet
       summary: Finds Pets by status
-      description: Multiple status values can be provided with comma separated strings
-      operationId: findPetsByStatus
       produces:
         - application/json
-        - application/xml
-      parameters:
-        - name: status
-          in: query
-          description: Status values that need to be considered for filter
-          required: true
-          type: array
-          items:
-            type: string
-            enum:
-              - available
-              - pending
-              - sold
-            default: available
-          collectionFormat: multi
       responses:
         '200':
           description: successful operation
@@ -73,18 +34,11 @@ paths:
             type: array
             items:
               $ref: '#/definitions/Pet'
-        '400':
-          description: Invalid status value
   '/pet/{petId}':
     get:
-      tags:
-        - pet
       summary: Find pet by ID
-      description: Returns a single pet
-      operationId: getPetById
       produces:
         - application/json
-        - application/xml
       parameters:
         - name: petId
           in: path
@@ -97,31 +51,15 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/Pet'
-        '400':
-          description: Invalid ID supplied
         '404':
           description: Pet not found
       security:
         - petstore_auth: []
   '/pets/findByTags':
     get:
-      tags:
-        - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
-      operationId: findPetsByTags
       produces:
         - application/json
-        - application/xml
-      parameters:
-        - name: tags
-          in: query
-          description: Tags to filter by
-          required: true
-          type: array
-          items:
-            type: string
-          collectionFormat: multi
       responses:
         '200':
           description: successful operation
@@ -129,8 +67,6 @@ paths:
             type: array
             items:
               $ref: '#/definitions/Pet'
-        '400':
-          description: Invalid tag value
       security:
         - petstore_auth:
             - 'write:scopes'
@@ -149,56 +85,17 @@ securityDefinitions:
       'read:scopes': read your pets
       'write:scopes': modify pets in your account
 definitions:
-  ApiResponse:
-    type: object
-    properties:
-      code:
-        type: integer
-        format: int32
-      type:
-        type: string
-      message:
-        type: string
-  Category:
-    type: object
-    properties:
-      id:
-        type: integer
-        format: int64
-      name:
-        type: string
-    xml:
-      name: Category
   Pet:
     type: object
     required:
       - name
-      - photoUrls
     properties:
       id:
         type: integer
         format: int64
-      category:
-        $ref: '#/definitions/Category'
       name:
         type: string
         example: doggie
-      photoUrls:
-        type: array
-        xml:
-          wrapped: true
-        items:
-          type: string
-          xml:
-            name: photoUrl
-      tags:
-        type: array
-        xml:
-          wrapped: true
-        items:
-          xml:
-            name: tag
-          $ref: '#/definitions/Tag'
       status:
         type: string
         description: pet status in the store
@@ -206,15 +103,3 @@ definitions:
           - available
           - pending
           - sold
-    xml:
-      name: Pet
-  Tag:
-    type: object
-    properties:
-      id:
-        type: integer
-        format: int64
-      name:
-        type: string
-    xml:
-      name: Tag

--- a/integration/test-integration/src/test/resources/testng-cc-standalone.xml
+++ b/integration/test-integration/src/test/resources/testng-cc-standalone.xml
@@ -48,6 +48,7 @@
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.endpoints.BackendSecurityTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.jwtValidator.JwtTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.jwtValidator.ScopeTest"/>
+            <class name="org.wso2.choreo.connect.tests.testcases.standalone.jwtValidator.ScopesAsArrayTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.jwtValidator.InternalKeyTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.jwtValidator.CustomAuthHeaderTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.apiDeploy.QSGAndSwaggerTestCase"/>


### PR DESCRIPTION
### Purpose
- Fix scope parsing error when multiple scopes provided in an array
  - Currently the jwt parser expects multiple scopes as a space separated single string. ex: "scope": "write:pet read:pet"
With this change the jwt scope field can also have an array of strings. "scope": [ "write:pet", "read:pet"]

Test Changes - standalone mode
- Test when jwt has multiple scopes provided in an array. Refactor and update TokenUtil to reuse code to provide scopes as array.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/3057

### Automation tests
 - Unit tests added: No
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
