### PR TITLE
int-test: Confirm the case change done to headers by envoy

### DIFF
--- a/integration/mock-backend-server/src/main/java/org/wso2/choreo/connect/mockbackend/MockBackendProd.java
+++ b/integration/mock-backend-server/src/main/java/org/wso2/choreo/connect/mockbackend/MockBackendProd.java
@@ -28,6 +28,8 @@ import org.slf4j.LoggerFactory;
 
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
@@ -301,6 +303,14 @@ public class MockBackendProd extends Thread {
                 });
                 byte[] response = responseJSON.toString().getBytes();
                 Utils.respondWithBodyAndClose(HttpURLConnection.HTTP_OK, response, exchange);
+            });
+            httpServer.createContext(context + "/headers-from-backend", exchange -> {
+                Map<String,String> headers = new HashMap<>();
+                headers.put("X-Header-One", "X-Header-One-Value");
+                headers.put("x-header-two", "x-header-two-value");
+                headers.put("X-HEADER-THREE", "X-HEADER-THREE-VALUE");
+                byte[] response = ResponseConstants.RESPONSE_BODY.getBytes();
+                Utils.send200OK(exchange, response, headers);
             });
 
             // the context "/echo" is used for "/echo-request", "/echo-response" as well in interceptor & request body passing tests.

--- a/integration/mock-backend-server/src/main/java/org/wso2/choreo/connect/mockbackend/Utils.java
+++ b/integration/mock-backend-server/src/main/java/org/wso2/choreo/connect/mockbackend/Utils.java
@@ -137,6 +137,16 @@ public class Utils {
         exchange.getResponseBody().write(response);
     }
 
+    public static void send200OK(HttpExchange exchange, byte[] response, Map<String, String> headers) throws IOException {
+        exchange.getResponseHeaders().set(Constants.CONTENT_TYPE, Constants.CONTENT_TYPE_APPLICATION_JSON);
+        headers.forEach(
+                (key, value) -> exchange.getResponseHeaders().set(key, value)
+        );
+        exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length);
+        exchange.getResponseBody().write(response);
+        exchange.close();
+    }
+
     public static TrustManager[] getTrustManagers() throws Exception {
         InputStream inputStream = Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream("mg.pem");

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/router/EnvoyHttpFilterTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/router/EnvoyHttpFilterTestCase.java
@@ -24,6 +24,7 @@ import org.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.choreo.connect.mockbackend.dto.EchoResponse;
 import org.wso2.choreo.connect.tests.util.HttpsClientRequest;
 import org.wso2.choreo.connect.tests.util.HttpResponse;
 import org.wso2.choreo.connect.tests.util.TestConstant;
@@ -43,10 +44,7 @@ public class EnvoyHttpFilterTestCase {
 
     @Test(description = "Test to invoke resource protected with scopes with correct jwt")
     public void checkHeadersSentToBackend() throws Exception {
-        Map<String, String> headers = new HashMap<String, String>();
-        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
-        HttpResponse response = HttpsClientRequest.retryGetRequestUntilDeployed(
-                Utils.getServiceURLHttps("/v2/standard/headers"), headers);
+        HttpResponse response = Utils.invokeApi(jwtTokenProd,"/v2/standard/headers");
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
 
@@ -76,5 +74,100 @@ public class EnvoyHttpFilterTestCase {
         Assert.assertNotNull(headersToClient.get("server"));    // = envoy
         Assert.assertNotNull(headersToClient.get("content-length"));
         Assert.assertNotNull(headersToClient.get("content-type"));
+    }
+
+    /*
+     * Related to https://github.com/wso2/product-microgateway/issues/3009
+     */
+    @Test(description = "Confirm header case change - router to backend")
+    public void confirmHeaderCaseChange_RouterToBackend() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwtTokenProd);
+
+        // Add custom headers
+        headers.put("X-Header-One", "X-Header-One-Value");
+        headers.put("x-header-two", "x-header-two-value");
+        headers.put("X-HEADER-THREE", "X-HEADER-THREE-VALUE");
+
+        HttpResponse response = HttpsClientRequest.retryGetRequestUntilDeployed(
+                Utils.getServiceURLHttps("/v2/standard/headers"), headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
+
+        JSONObject headersSentToBackend = new JSONObject(response.getData());
+        // Headers that were originally sent by the client
+        Assert.assertFalse(headersSentToBackend.has("X-Header-One"), "X-Header-One sent to the backend");
+        Assert.assertFalse(headersSentToBackend.has("x-header-two"), "x-header-two sent to the backend");
+        Assert.assertFalse(headersSentToBackend.has("X-HEADER-THREE"), "X-HEADER-THREE sent to the backend");
+
+        // Headers received by the backend
+        // Has got converted to first letter upper case, remaining letters lowercase
+        Assert.assertTrue(headersSentToBackend.has("X-header-one"), "X-header-one not sent to the backend");
+        Assert.assertTrue(headersSentToBackend.has("X-header-two"), "X-header-two not sent to the backend");
+        Assert.assertTrue(headersSentToBackend.has("X-header-three"), "X-header-three not sent to the backend");
+
+        // Case of the value has not changed
+        Assert.assertEquals(headersSentToBackend.get("X-header-one"), "X-Header-One-Value",
+                "X-header-one header value has changed");
+        Assert.assertEquals(headersSentToBackend.get("X-header-two"), "x-header-two-value",
+                "X-header-two header value has changed");
+        Assert.assertEquals(headersSentToBackend.get("X-header-three"), "X-HEADER-THREE-VALUE",
+                "X-header-three header value has changed");
+    }
+
+    /*
+     * Related to https://github.com/wso2/product-microgateway/issues/3009
+     */
+    @Test(description = "Confirm header case change - backend to client")
+    public void confirmHeaderCaseChange_BackendToClient() throws Exception {
+        HttpResponse response = Utils.invokeApi(jwtTokenProd, "/v2/standard/headers-from-backend");
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
+
+        Map<String, String> headersToClient = response.getHeaders();
+        // Headers that were originally sent by the backend
+        Assert.assertFalse(headersToClient.containsKey("X-Header-One"), "X-Header-One sent to the client");
+        Assert.assertTrue(headersToClient.containsKey("x-header-two"), "x-header-two not sent to the client");
+        Assert.assertFalse(headersToClient.containsKey("X-HEADER-THREE"), "X-HEADER-THREE sent to the client");
+
+        // Headers received by the client
+        // Has got converted to all lowercase letters
+        Assert.assertTrue(headersToClient.containsKey("x-header-one"), "x-header-one not sent to the client");
+        Assert.assertTrue(headersToClient.containsKey("x-header-two"), "x-header-two not sent to the client");
+        Assert.assertTrue(headersToClient.containsKey("x-header-three"), "x-header-three not sent to the client");
+
+        // Case of the value has not changed
+        Assert.assertEquals(headersToClient.get("x-header-one"), "X-Header-One-Value",
+                "X-header-one header value has changed");
+        Assert.assertEquals(headersToClient.get("x-header-two"), "x-header-two-value",
+                "X-header-two header value has changed");
+        Assert.assertEquals(headersToClient.get("x-header-three"), "X-HEADER-THREE-VALUE",
+                "X-header-three header value has changed");
+    }
+
+    @Test(description = "Confirm that the case of the query parameters have not changed - router to backend")
+    public void confirmQueryParamCaseUnchanged() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        EchoResponse response = Utils.invokeEchoGet("/v2/standard", "/echo-full?"
+                        + "param1=value1&"
+                        + "PARAM2=VALUE2&"
+                        + "QueryParam3=QueryValue3",
+                headers, jwtTokenProd);
+
+        // Query params received by the backend
+        Map<String, String> queryParams = response.getQuery();
+        Assert.assertNotEquals(queryParams.size(), 0);
+
+        // Case not changed
+        Assert.assertTrue(queryParams.containsKey("param1"), "param1 not sent to the client");
+        Assert.assertTrue(queryParams.containsKey("PARAM2"), "PARAM2 not sent to the client");
+        Assert.assertTrue(queryParams.containsKey("QueryParam3"), "QueryParam3 not sent to the client");
+
+        Assert.assertEquals(queryParams.get("param1"), "value1",
+                "param1 value has changed");
+        Assert.assertEquals(queryParams.get("PARAM2"), "VALUE2",
+                "PARAM2 value has changed");
+        Assert.assertEquals(queryParams.get("QueryParam3"), "QueryValue3",
+                "QueryParam3 value has changed");
     }
 }

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/Utils.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/util/Utils.java
@@ -304,11 +304,9 @@ public class Utils {
      */
     public static HttpResponse invokeApi(String token, String requestUrl) throws Exception {
         Map<String, String> headers = new HashMap<>();
-        //invoke api with token
         headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + token);
-        HttpResponse response = HttpClientRequest
-                .doGet(requestUrl, headers);
-        return response;
+        return HttpClientRequest.retryGetRequestUntilDeployed(
+                Utils.getServiceURLHttps(requestUrl), headers);
     }
 
     /**

--- a/integration/test-integration/src/test/resources/openAPIs/openAPI.yaml
+++ b/integration/test-integration/src/test/resources/openAPIs/openAPI.yaml
@@ -650,6 +650,14 @@ paths:
           description: successful operation
       security:
         - petstore_auth: [ ]
+  /echo-full:
+    get:
+      security:
+        - petstore_auth: [ ]
+  /headers-from-backend:
+    get:
+      security:
+        - petstore_auth: [ ]
 securityDefinitions:
   api_key:
     type: apiKey


### PR DESCRIPTION
### Purpose
Confirm the case change done to headers by envoy and confirm that it does not affect the query params.

router to backend - Header keys gets converted to first letter upper case, remaining letters lowercase
backend to client - Header keys gets converted to all lowercase letters

header values and query params - unchanged

### Issues
Fixes https://github.com/wso2/product-microgateway/issues/3075

### Related issues 
- https://github.com/wso2/product-microgateway/issues/3009
- https://github.com/wso2/product-microgateway/issues/3071 (enforcer receives the case similar to the client receiving the response header)

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
