### PR TITLE
Made MGW default cache expiry time as a configurable property from MGW level

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/micro_gw_conf_defaults.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/micro_gw_conf_defaults.bal
@@ -67,6 +67,7 @@ public const boolean DEFAULT_JWT_REMOTE_USER_CLAIM_RETRIEVAL_ENABLED = false;
 
 public const boolean DEFAULT_CACHING_ENABLED = true;
 public const int DEFAULT_TOKEN_CACHE_EXPIRY = 900000;
+public const int DEFAULT_TOKEN_EXPIRY = 3600;
 public const int DEFAULT_TOKEN_CACHE_CAPACITY = 10000;
 public const float DEFAULT_TOKEN_CACHE_EVICTION_FACTOR = 0.25;
 

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/utils.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/utils.bal
@@ -904,10 +904,12 @@ public function initAuthHandlers() {
     string keymanagerContext = getConfigValue(KM_CONF_INSTANCE_ID, KM_TOKEN_CONTEXT, DEFAULT_KM_TOKEN_CONTEXT);
     introspectURL = (introspectURL.endsWith(PATH_SEPERATOR)) ? introspectURL + keymanagerContext : introspectURL + PATH_SEPERATOR + keymanagerContext;
     introspectURL = (introspectURL.endsWith(PATH_SEPERATOR)) ? introspectURL + INTROSPECT_CONTEXT : introspectURL + PATH_SEPERATOR + INTROSPECT_CONTEXT;
+    int cacheExpiryTime = getConfigIntValue(CACHING_ID, TOKEN_CACHE_EXPIRY, DEFAULT_TOKEN_EXPIRY);
     oauth2:IntrospectionServerConfig introspectionServerConfig = {
         url: introspectURL,
         oauth2Cache: introspectCache,
-        clientConfig: clientConfig
+        clientConfig: clientConfig,
+        defaultTokenExpTimeInSeconds: cacheExpiryTime
     };
     OAuth2KeyValidationProvider oauth2KeyValidationProvider = new (keyValidationConfig);
     oauth2:InboundOAuth2Provider introspectionProvider = new (introspectionServerConfig);


### PR DESCRIPTION
## Purpose
Make MGW default cache expiry time as a configurable property from MGW level. Related to public git issue, https://github.com/wso2/api-manager/issues/691.

## Approach
- Added token expiry time from the micro-gw.conf configuration to `IntrospectionServerConfig` section. 
- In case of the absence of configuration, default configuration will be loaded from micro gateway default constant file. The default configuration is `DEFAULT_TOKEN_EXPIRY`.