### PR TITLE
Enforcer ca truststore should trust ca certs

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/config/ConfigHolder.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/config/ConfigHolder.java
@@ -390,18 +390,17 @@ public class ConfigHolder {
             Arrays.stream(trustedCerts)
                     .forEach(cert -> {
                         try {
-                            trustStore.setCertificateEntry(RandomStringUtils.random(10, true, false), cert);
+                            trustStore.setCertificateEntry(RandomStringUtils.random(10, true, false),
+                                    cert);
                         } catch (KeyStoreException e) {
-                            // TODO Auto-generated catch block
-                            logger.error("Error while adding default trusted cert", e);
+                            logger.error("Error while adding default trusted ca cert", e);
                         }
                     });
 
             String truststoreFilePath = getEnvVarConfig().getTrustedAdapterCertsPath();
             TLSUtils.addCertsToTruststore(trustStore, truststoreFilePath);
-            // trustManagerFactory =
-            // TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-            tmf.init(trustStore);
+            trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(trustStore);
 
         } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException e) {
             logger.error("Error in loading certs to the trust store.", e);

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/config/ConfigHolder.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/config/ConfigHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.choreo.connect.enforcer.config;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -80,6 +81,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -87,7 +89,9 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 
 /**
  * Configuration holder class for Microgateway.
@@ -362,12 +366,43 @@ public class ConfigHolder {
 
     private void loadTrustStore() {
         try {
+
+            TrustManagerFactory tmf = TrustManagerFactory
+                    .getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            // Using null here initialises the TMF with the default trust store.
+            tmf.init((KeyStore) null);
+
+            // Get hold of the default trust manager
+            X509TrustManager defaultTm = null;
+            for (TrustManager tm : tmf.getTrustManagers()) {
+                if (tm instanceof X509TrustManager) {
+                    defaultTm = (X509TrustManager) tm;
+                    break;
+                }
+            }
+
             trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
             trustStore.load(null);
+
+            // Wrap it in your own class.
+            // final X509TrustManager finalDefaultTm = defaultTm;
+            X509Certificate[] trustedCerts = defaultTm.getAcceptedIssuers();
+            Arrays.stream(trustedCerts)
+                    .forEach(cert -> {
+                        try {
+                            trustStore.setCertificateEntry(RandomStringUtils.random(10, true, false), cert);
+                        } catch (KeyStoreException e) {
+                            // TODO Auto-generated catch block
+                            logger.error("Error while adding default trusted cert", e);
+                        }
+                    });
+
             String truststoreFilePath = getEnvVarConfig().getTrustedAdapterCertsPath();
             TLSUtils.addCertsToTruststore(trustStore, truststoreFilePath);
-            trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-            trustManagerFactory.init(trustStore);
+            // trustManagerFactory =
+            // TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            tmf.init(trustStore);
+
         } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException e) {
             logger.error("Error in loading certs to the trust store.", e);
         }

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/config/ConfigHolder.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/config/ConfigHolder.java
@@ -370,7 +370,8 @@ public class ConfigHolder {
             trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
             trustStore.load(null);
 
-            // TODO: enable these with a config
+            // TODO: enable these with a config, got error when accessing configHolder
+            // properties since we call loadTrustStore method in ConfigHolder constructor
             loadTrustedCertsToTrustStore();
             loadDefaultCertsToTrustStore();
 


### PR DESCRIPTION
### Purpose
Added a method to load the trusted root certificates in the `<javahome>/lib/security/cacerts` to the existing truststore.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
