### PR TITLE
Fix apikey failure when header key is in uppercase

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/GraphQLAPI.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/GraphQLAPI.java
@@ -21,6 +21,7 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import graphql.schema.idl.UnExecutableSchemaGenerator;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.wso2.choreo.connect.discovery.api.Api;
@@ -41,10 +42,8 @@ import org.wso2.choreo.connect.enforcer.commons.model.RequestContext;
 import org.wso2.choreo.connect.enforcer.commons.model.ResourceConfig;
 import org.wso2.choreo.connect.enforcer.commons.model.SecuritySchemaConfig;
 import org.wso2.choreo.connect.enforcer.config.ConfigHolder;
-import org.wso2.choreo.connect.enforcer.config.dto.AuthHeaderDto;
 import org.wso2.choreo.connect.enforcer.config.dto.FilterDTO;
 import org.wso2.choreo.connect.enforcer.constants.APIConstants;
-import org.wso2.choreo.connect.enforcer.constants.AdapterConstants;
 import org.wso2.choreo.connect.enforcer.constants.HttpConstants;
 import org.wso2.choreo.connect.enforcer.cors.CorsFilter;
 import org.wso2.choreo.connect.enforcer.graphql.GraphQLQueryAnalysisFilter;
@@ -260,8 +259,9 @@ public class GraphQLAPI implements API {
             SecuritySchemaConfig schema = entry.getValue();
             if (APIConstants.SWAGGER_API_KEY_AUTH_TYPE_NAME.equalsIgnoreCase(schema.getType())) {
                 if (APIConstants.SWAGGER_API_KEY_IN_HEADER.equals(schema.getIn())) {
-                    requestContext.getProtectedHeaders().add(schema.getName());
-                    requestContext.getRemoveHeaders().add(schema.getName());
+                    String header = StringUtils.lowerCase(schema.getName());
+                    requestContext.getProtectedHeaders().add(header);
+                    requestContext.getRemoveHeaders().add(header);
                     continue;
                 }
                 if (APIConstants.SWAGGER_API_KEY_IN_QUERY.equals(schema.getIn())) {
@@ -270,25 +270,7 @@ public class GraphQLAPI implements API {
             }
         }
 
-        // Internal-Key credential is considered to be protected headers, such that the header would not be sent
-        // to backend and traffic manager.
-        String internalKeyHeader = ConfigHolder.getInstance().getConfig().getAuthHeader()
-                .getTestConsoleHeaderName().toLowerCase();
-        requestContext.getRemoveHeaders().add(internalKeyHeader);
-        // Avoid internal key being published to the Traffic Manager
-        requestContext.getProtectedHeaders().add(internalKeyHeader);
-
-        // Remove Authorization Header
-        AuthHeaderDto authHeader = ConfigHolder.getInstance().getConfig().getAuthHeader();
-        String authHeaderName = FilterUtils.getAuthHeaderName(requestContext);
-        if (!authHeader.isEnableOutboundAuthHeader()) {
-            requestContext.getRemoveHeaders().add(authHeaderName);
-        }
-        // Authorization Header should not be included in the throttle publishing event.
-        requestContext.getProtectedHeaders().add(authHeaderName);
-
-        // not allow clients to set cluster header manually
-        requestContext.getRemoveHeaders().add(AdapterConstants.CLUSTER_HEADER);
+        Utils.removeCommonAuthHeaders(requestContext);
     }
 
     private void loadCustomFilters(APIConfig apiConfig) {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/RestAPI.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/RestAPI.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.choreo.connect.enforcer.api;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.wso2.choreo.connect.discovery.api.Api;
@@ -39,11 +40,9 @@ import org.wso2.choreo.connect.enforcer.commons.model.RequestContext;
 import org.wso2.choreo.connect.enforcer.commons.model.ResourceConfig;
 import org.wso2.choreo.connect.enforcer.commons.model.SecuritySchemaConfig;
 import org.wso2.choreo.connect.enforcer.config.ConfigHolder;
-import org.wso2.choreo.connect.enforcer.config.dto.AuthHeaderDto;
 import org.wso2.choreo.connect.enforcer.config.dto.FilterDTO;
 import org.wso2.choreo.connect.enforcer.config.dto.MutualSSLDto;
 import org.wso2.choreo.connect.enforcer.constants.APIConstants;
-import org.wso2.choreo.connect.enforcer.constants.AdapterConstants;
 import org.wso2.choreo.connect.enforcer.constants.HttpConstants;
 import org.wso2.choreo.connect.enforcer.cors.CorsFilter;
 import org.wso2.choreo.connect.enforcer.interceptor.MediationPolicyFilter;
@@ -356,8 +355,9 @@ public class RestAPI implements API {
             SecuritySchemaConfig schema = entry.getValue();
             if (APIConstants.SWAGGER_API_KEY_AUTH_TYPE_NAME.equalsIgnoreCase(schema.getType())) {
                 if (APIConstants.SWAGGER_API_KEY_IN_HEADER.equals(schema.getIn())) {
-                    requestContext.getProtectedHeaders().add(schema.getName());
-                    requestContext.getRemoveHeaders().add(schema.getName());
+                    String header = StringUtils.lowerCase(schema.getName());
+                    requestContext.getProtectedHeaders().add(header);
+                    requestContext.getRemoveHeaders().add(header);
                     continue;
                 }
                 if (APIConstants.SWAGGER_API_KEY_IN_QUERY.equals(schema.getIn())) {
@@ -366,25 +366,7 @@ public class RestAPI implements API {
             }
         }
 
-        // Internal-Key credential is considered to be protected headers, such that the header would not be sent
-        // to backend and traffic manager.
-        String internalKeyHeader = ConfigHolder.getInstance().getConfig().getAuthHeader()
-                .getTestConsoleHeaderName().toLowerCase();
-        requestContext.getRemoveHeaders().add(internalKeyHeader);
-        // Avoid internal key being published to the Traffic Manager
-        requestContext.getProtectedHeaders().add(internalKeyHeader);
-
-        // Remove Authorization Header
-        AuthHeaderDto authHeader = ConfigHolder.getInstance().getConfig().getAuthHeader();
-        String authHeaderName = FilterUtils.getAuthHeaderName(requestContext);
-        if (!authHeader.isEnableOutboundAuthHeader()) {
-            requestContext.getRemoveHeaders().add(authHeaderName);
-        }
-        // Authorization Header should not be included in the throttle publishing event.
-        requestContext.getProtectedHeaders().add(authHeaderName);
-
-        // not allow clients to set cluster header manually
-        requestContext.getRemoveHeaders().add(AdapterConstants.CLUSTER_HEADER);
+        Utils.removeCommonAuthHeaders(requestContext);
 
         // Remove mTLS certificate header
         MutualSSLDto mtlsInfo = ConfigHolder.getInstance().getConfig().getMtlsInfo();

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/WebSocketAPI.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/WebSocketAPI.java
@@ -154,6 +154,7 @@ public class WebSocketAPI implements API {
         ResponseObject responseObject = new ResponseObject();
         responseObject.setRequestPath(requestContext.getRequestPath());
         boolean analyticsEnabled = ConfigHolder.getInstance().getConfig().getAnalyticsConfig().isEnabled();
+        Utils.removeCommonAuthHeaders(requestContext);
         if (executeFilterChain(requestContext)) {
             if (analyticsEnabled) {
                 AnalyticsFilter.getInstance().handleSuccessRequest(requestContext);

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/interceptor/MediationPolicyFilter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/interceptor/MediationPolicyFilter.java
@@ -181,7 +181,8 @@ public class MediationPolicyFilter implements Filter {
         try {
             boolean isValid = OPAClient.getInstance().validateRequest(requestContext, policyAttrib);
             if (!isValid) {
-                log.error("OPA validation failed for the request: " + requestContext.getRequestPath(),
+                log.error("OPA validation failed for the request: {} {}",
+                        requestContext.getRequestPathTemplate(),
                         ErrorDetails.errorLog(LoggingConstants.Severity.MINOR, 6101));
                 FilterUtils.setErrorToContext(requestContext, APISecurityConstants.OPA_AUTH_FORBIDDEN,
                         APIConstants.StatusCodes.UNAUTHORIZED.getCode(),
@@ -190,8 +191,8 @@ public class MediationPolicyFilter implements Filter {
             return isValid;
         } catch (OPASecurityException e) {
             log.error("Error while validating the OPA policy for the request: {} {} {}",
-                    requestContext.getRequestPath(),
-                    ErrorDetails.errorLog(LoggingConstants.Severity.MINOR, 6101), e);
+                    requestContext.getRequestPathTemplate(),
+                    ErrorDetails.errorLog(LoggingConstants.Severity.MINOR, 6101), e.getMessage());
             FilterUtils.setErrorToContext(requestContext, e);
             return false;
         }

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyAuthenticator.java
@@ -122,8 +122,9 @@ public class APIKeyAuthenticator extends APIKeyHandler {
                     // If Defined in openAPI definition (when not enabled at APIM App level),
                     // key must exist in specified location
                     if (APIConstants.SWAGGER_API_KEY_IN_HEADER.equalsIgnoreCase(securitySchemaDefinition.getIn())) {
-                        if (requestContext.getHeaders().containsKey(securitySchemaDefinition.getName())) {
-                            return requestContext.getHeaders().get(securitySchemaDefinition.getName());
+                        String header = StringUtils.lowerCase(securitySchemaDefinition.getName());
+                        if (requestContext.getHeaders().containsKey(header)) {
+                            return requestContext.getHeaders().get(header);
                         }
                     }
                     if (APIConstants.SWAGGER_API_KEY_IN_QUERY.equalsIgnoreCase(securitySchemaDefinition.getIn())) {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/throttle/ThrottleDataHolder.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/throttle/ThrottleDataHolder.java
@@ -501,7 +501,7 @@ public class ThrottleDataHolder {
 
         for (Map.Entry<String, String> entry : conditions.getValues().entrySet()) {
             if (headers != null) {
-                String value = headers.get(entry.getKey());
+                String value = headers.get(StringUtils.lowerCase(entry.getKey()));
 
                 if (StringUtils.isEmpty(value)) {
                     status = false;

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/security/APIKeyTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/security/APIKeyTestCase.java
@@ -34,6 +34,9 @@ import org.wso2.choreo.connect.tests.util.Utils;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * This test case runs twice with issuer "APIM Publisher" and issuer "APIM APIkey".
+ */
 public class APIKeyTestCase extends ApimBaseTest {
     private String testAPIKey =
             "eyJ4NXQiOiJOMkpqTWpOaU0yRXhZalJrTnpaalptWTFZVEF4Tm1GbE5qZzRPV1UxWVdRMll6YzFObVk1TlE9PS" +
@@ -92,6 +95,30 @@ public class APIKeyTestCase extends ApimBaseTest {
                 Utils.getServiceURLHttps("/v2/pet/1"), headers);
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_FORBIDDEN, "Response code mismatched");
+    }
+
+    @Test(description = "Test to invoke with an APIKey of uppercase")
+    public void invokeWithAnApiKeyOfUppercaseInHeader() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("X-APIKEY", testAPIKey);
+        HttpResponse response = HttpsClientRequest.doGet(
+                Utils.getServiceURLHttps("/apiKey/1.0.0/pet/1"), headers);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
+    }
+
+    @Test(description = "Test to invoke with an APIKey of uppercase")
+    public void invokeWithAnApiKeyOfUppercaseInQuery() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        HttpResponse response1 = HttpsClientRequest.doGet(
+                Utils.getServiceURLHttps("/apiKey/1.0.0/pet/1?X-ApiKey-Q=" + testAPIKey), headers);
+        Assert.assertNotNull(response1);
+        Assert.assertEquals(response1.getResponseCode(), HttpStatus.SC_OK, "Response code mismatched");
+
+        HttpResponse response2 = HttpsClientRequest.doGet(
+                Utils.getServiceURLHttps("/apiKey/1.0.0/pet/1?x-apikey-q=" + testAPIKey), headers);
+        Assert.assertNotNull(response2);
+        Assert.assertEquals(response2.getResponseCode(), HttpStatus.SC_UNAUTHORIZED, "Response code mismatched");
     }
 
     @Test(description = "Test to check the API Key fails for only oauth2 secured resource")

--- a/integration/test-integration/src/test/resources/openAPIs/api_key_swagger_security_openAPI.yaml
+++ b/integration/test-integration/src/test/resources/openAPIs/api_key_swagger_security_openAPI.yaml
@@ -35,6 +35,8 @@ paths:
           description: Pet not found
       security:
         - APIKeyAuth: []
+        - APIKeyAuth2: []
+        - APIKeyAuth3: []
   '/pet/findByTags':
     get:
       summary: Finds one pet by tags
@@ -123,6 +125,14 @@ securityDefinitions:
     scopes:
       'read:pets2': read your pets
       'write:pets2': modify pets in your account
+  APIKeyAuth2:
+    type: apiKey
+    name: X-APIKEY
+    in: header
+  APIKeyAuth3:
+    type: apiKey
+    name: X-ApiKey-Q
+    in: query
 definitions:
   Pet:
     type: object


### PR DESCRIPTION
### Purpose
Fix apikey failure when header key is in uppercase and prevent common auth headers reaching websocket backends.
- Use lowercase header key when accessing header map in request context in APIKeyAuthenticator. (Router automatically converts header keys to lowercase when sending to enforcer. This has been already handled for access token and internal key)
- Use lowercase header key when adding headers to protectedHeaders map and removeHeaders array since they are accessed in other parts of the enforcer.
- Move auth header removal to a cmmon util method
- Prevent common auth headers reaching websocket backends

Integration Tests
- Test apikey with uppercase header name. 
- Access token and internal key tests already include the respective header with first letter uppercase.

### Issues
Fix https://github.com/wso2/product-microgateway/issues/3071

### Automation tests
 - Unit tests added: No
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
