### PR TITLE
[int-tests] Avoid creating more than 25 APIs in a single run of ApimPreparer

### DIFF
--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/withapim/ApimStartupExecutor.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/withapim/ApimStartupExecutor.java
@@ -34,7 +34,7 @@ public class ApimStartupExecutor {
     void startAPIM() throws Exception {
         apimInstance = ApimInstance.createNewInstance();
         apimInstance.startAPIM();
-        Awaitility.await().pollDelay(2, TimeUnit.MINUTES).pollInterval(15, TimeUnit.SECONDS)
+        Awaitility.await().pollDelay(1, TimeUnit.MINUTES).pollInterval(10, TimeUnit.SECONDS)
                 .atMost(4, TimeUnit.MINUTES).until(isAPIMServerStarted());
     }
 


### PR DESCRIPTION
### Purpose
In integration tests for CC with APIM, the test class ApimPreparer runs multiple times creating and deploying different sets of APIs. The set of API to deploy is given by the apimArtifactsIndex. This PR is to limit the number of APIs per set. This,

- prevents test dubugging becoming difficult
- prevents having to increase the default limit of getAllAPIs in the API-M Publisher REST API (used to delete created APIs in the later runs)

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/3098

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
