### PR TITLE
[3.2.x] Upgrade ballerina version to 1.2.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -569,7 +569,7 @@
     </build>
 
     <properties>
-        <ballerina.platform.version>1.2.29</ballerina.platform.version>
+        <ballerina.platform.version>1.2.33</ballerina.platform.version>
         <broker.version>0.970.5</broker.version>
         <assembly.plugin.version>3.1.1</assembly.plugin.version>
         <compiler.plugin.version>3.7.0</compiler.plugin.version>


### PR DESCRIPTION
### Purpose
This PR upgrades the Ballerina version to 1.2.33 for some third party dependency upgrades.

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
OS - Ubuntu 20.04
JDK - OpenJDK 1.8.0_342

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
