### PR TITLE
Base image change in Adapter and Enforcer

### DIFF
--- a/adapter/src/main/resources/Dockerfile
+++ b/adapter/src/main/resources/Dockerfile
@@ -14,11 +14,11 @@
 # limitations under the License.
 # -----------------------------------------------------------------------
 
-FROM alpine:3.15.4
+FROM alpine:3.16.2
 LABEL maintainer="WSO2 Docker Maintainers <wso2.com>"
 
 RUN apk update && apk upgrade --no-cache
-RUN apk add  --no-cache tzdata
+RUN apk add --no-cache tzdata
 
 ENV LANG=C.UTF-8
 

--- a/enforcer-parent/enforcer/src/main/resources/Dockerfile
+++ b/enforcer-parent/enforcer/src/main/resources/Dockerfile
@@ -14,11 +14,11 @@
 # limitations under the License.
 # -----------------------------------------------------------------------
 
-FROM adoptopenjdk/openjdk11:jre-11.0.14.1_1-alpine
+FROM adoptopenjdk/openjdk11:jre-11.0.16.1_1
 LABEL maintainer="WSO2 Docker Maintainers <wso2.com>"
 
 RUN apk update && apk upgrade --no-cache
-RUN apk add  --no-cache tzdata
+RUN apk add --no-cache tzdata
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" 
 

--- a/enforcer-parent/enforcer/src/main/resources/Dockerfile
+++ b/enforcer-parent/enforcer/src/main/resources/Dockerfile
@@ -14,15 +14,21 @@
 # limitations under the License.
 # -----------------------------------------------------------------------
 
-FROM adoptopenjdk/openjdk11:jre-11.0.16.1_1
-LABEL maintainer="WSO2 Docker Maintainers <wso2.com>"
-
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y tzdata
-
-LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" 
+FROM alpine:3.16.2
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
 
 ENV LANG=C.UTF-8
+
+RUN apk update && apk upgrade --no-cache
+RUN apk add --no-cache tzdata
+
+ENV JAVA_VERSION 11
+
+# install OpenJDK
+RUN apk update && apk fetch openjdk${JAVA_VERSION} && apk add openjdk${JAVA_VERSION}
+
+ENV JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}-openjdk
+ENV PATH="$JAVA_HOME/bin:${PATH}"
 
 ARG MG_USER=wso2
 ARG MG_USER_ID=10500
@@ -55,8 +61,8 @@ ARG MOTD="\n\
  Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
 
 RUN \
-    groupadd --system -g ${MG_USER_GROUP_ID} ${MG_USER_GROUP} \
-    && useradd --system --create-home --home-dir ${MG_USER_HOME} --no-log-init -g ${MG_USER_GROUP_ID} -u ${MG_USER_ID} ${MG_USER} \
+    addgroup -S -g ${MG_USER_GROUP_ID} ${MG_USER_GROUP} \
+    && adduser -S -u ${MG_USER_ID} -h ${MG_USER_HOME} -G ${MG_USER_GROUP} ${MG_USER} \
     && mkdir ${MG_USER_HOME}/logs && mkdir -p ${MG_USER_HOME}/lib/dropins \
     && chown -R ${MG_USER}:${MG_USER_GROUP} ${MG_USER_HOME} \
     && echo '[ ! -z "${TERM}" -a -r /etc/motd ] && cat /etc/motd' >> /etc/bash.bashrc; echo "${MOTD}" > /etc/motd

--- a/enforcer-parent/enforcer/src/main/resources/Dockerfile
+++ b/enforcer-parent/enforcer/src/main/resources/Dockerfile
@@ -20,9 +20,13 @@ LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
 ENV LANG=C.UTF-8
 
 RUN apk update && apk upgrade --no-cache
-RUN apk add --no-cache tzdata
+RUN apk add --no-cache tzdata wget ca-certificates
 
 ENV JAVA_VERSION 11
+
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-2.35-r0.apk && \
+    apk add --force-overwrite glibc-2.35-r0.apk
 
 # install OpenJDK
 RUN apk update && apk fetch openjdk${JAVA_VERSION} && apk add openjdk${JAVA_VERSION}

--- a/enforcer-parent/enforcer/src/main/resources/Dockerfile
+++ b/enforcer-parent/enforcer/src/main/resources/Dockerfile
@@ -17,8 +17,8 @@
 FROM adoptopenjdk/openjdk11:jre-11.0.16.1_1
 LABEL maintainer="WSO2 Docker Maintainers <wso2.com>"
 
-RUN apk update && apk upgrade --no-cache
-RUN apk add --no-cache tzdata
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y tzdata
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" 
 
@@ -55,8 +55,8 @@ ARG MOTD="\n\
  Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
 
 RUN \
-    addgroup -S -g ${MG_USER_GROUP_ID} ${MG_USER_GROUP} \
-    && adduser -S -u ${MG_USER_ID} -h ${MG_USER_HOME} -G ${MG_USER_GROUP} ${MG_USER} \
+    groupadd --system -g ${MG_USER_GROUP_ID} ${MG_USER_GROUP} \
+    && useradd --system --create-home --home-dir ${MG_USER_HOME} --no-log-init -g ${MG_USER_GROUP_ID} -u ${MG_USER_ID} ${MG_USER} \
     && mkdir ${MG_USER_HOME}/logs && mkdir -p ${MG_USER_HOME}/lib/dropins \
     && chown -R ${MG_USER}:${MG_USER_GROUP} ${MG_USER_HOME} \
     && echo '[ ! -z "${TERM}" -a -r /etc/motd ] && cat /etc/motd' >> /etc/bash.bashrc; echo "${MOTD}" > /etc/motd


### PR DESCRIPTION
### Purpose
Changes the base image in adapter and Enforcer.
Due to this change,
- Macs with Apple silicon processors will be able to run IT tests without doing any changes to the adapter and enforcer.

Relevant links:
[Alpine Image](https://hub.docker.com/_/alpine/tags?page=1)
[adoptopenjdk Image](https://hub.docker.com/r/adoptopenjdk/openjdk11/tags?page=2&name=jre-11.0.16.1_1)

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes # https://github.com/wso2/product-microgateway/issues/3114

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
