### PR TITLE
Enable security for prototyped APIs

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/AuthFilter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/AuthFilter.java
@@ -120,17 +120,6 @@ public class AuthFilter implements Filter {
 
     @Override
     public boolean handleRequest(RequestContext requestContext) {
-
-        // It is required to skip the auth Filter if the lifecycle status is prototype
-        if (APIConstants.PROTOTYPED_LIFE_CYCLE_STATUS.equals(
-                requestContext.getMatchedAPI().getApiLifeCycleState())) {
-            // For prototyped endpoints, only the production endpoints could be available.
-            requestContext.addOrModifyHeaders(AdapterConstants.CLUSTER_HEADER,
-                    requestContext.getProdClusterHeader());
-            requestContext.getRemoveHeaders().remove(AdapterConstants.CLUSTER_HEADER);
-            return true;
-        }
-
         boolean canAuthenticated = false;
         for (Authenticator authenticator : authenticators) {
             if (authenticator.canAuthenticate(requestContext)) {

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/PrototypedAPITestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/PrototypedAPITestCase.java
@@ -91,6 +91,6 @@ public class PrototypedAPITestCase extends ApimBaseTest {
                         Utils.getServiceURLHttps("/petstore-prototype/1.0.0/pet/findByStatus"), headers);
 
         Assert.assertNotNull(response);
-        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK,"Response code mismatched");
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_UNAUTHORIZED,"Response code mismatched");
     }
 }

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/PrototypedAPITestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/withapim/PrototypedAPITestCase.java
@@ -25,7 +25,9 @@ import net.minidev.json.parser.JSONParser;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.am.integration.clients.publisher.api.ApiResponse;
 import org.wso2.am.integration.clients.publisher.api.v1.dto.APIDTO;
+import org.wso2.am.integration.clients.publisher.api.v1.dto.APIKeyDTO;
 import org.wso2.am.integration.clients.publisher.api.v1.dto.WorkflowResponseDTO;
 import org.wso2.am.integration.test.utils.bean.APILifeCycleAction;
 import org.wso2.am.integration.test.utils.bean.APIRequest;
@@ -83,7 +85,7 @@ public class PrototypedAPITestCase extends ApimBaseTest {
     }
 
     @Test(description = "Test to check the PrototypedAPI is working")
-    public void invokePrototypeAPISuccessTest() throws Exception {
+    public void invokePrototypeAPITest() throws Exception {
         // Set header
         Map<String, String> headers = new HashMap<>();
         org.wso2.choreo.connect.tests.util.HttpResponse response =
@@ -92,5 +94,13 @@ public class PrototypedAPITestCase extends ApimBaseTest {
 
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_UNAUTHORIZED,"Response code mismatched");
+        ApiResponse<APIKeyDTO> internalApiKeyDTO =
+                publisherRestClient.generateInternalApiKey(apiId);
+
+        String internalKey = internalApiKeyDTO.getData().getApikey();
+        headers.put("apikey", internalKey);
+        response = HttpsClientRequest.doGet(
+                        Utils.getServiceURLHttps("/petstore-prototype/1.0.0/pet/findByStatus"), headers);
+        Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK,"Response code mismatched");
     }
 }


### PR DESCRIPTION
### Purpose

$subject. 

Prototyped APIs should be validated using a valid token in order to access the API.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #3118

### Automation tests
 - Unit tests added: No
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
