### PR TITLE
Enforcer truststore should trust ca root certs

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/config/ConfigHolder.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/config/ConfigHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.choreo.connect.enforcer.config;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -75,6 +76,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -82,7 +84,9 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 
 /**
  * Configuration holder class for Microgateway.
@@ -337,12 +341,51 @@ public class ConfigHolder {
         try {
             trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
             trustStore.load(null);
-            String truststoreFilePath = getEnvVarConfig().getTrustedAdapterCertsPath();
-            TLSUtils.addCertsToTruststore(trustStore, truststoreFilePath);
+
+            if (getEnvVarConfig().isTrustDefaultCerts()) {
+                loadDefaultCertsToTrustStore();
+            }
+            loadTrustedCertsToTrustStore();
+
             trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
             trustManagerFactory.init(trustStore);
         } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException e) {
             logger.error("Error in loading certs to the trust store.", e);
+        }
+    }
+
+    private void loadTrustedCertsToTrustStore() throws IOException {
+        String truststoreFilePath = getEnvVarConfig().getTrustedAdapterCertsPath();
+        TLSUtils.addCertsToTruststore(trustStore, truststoreFilePath);
+    }
+
+    private void loadDefaultCertsToTrustStore() throws NoSuchAlgorithmException, KeyStoreException {
+        TrustManagerFactory tmf = TrustManagerFactory
+                .getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        // Using null here initialises the TMF with the default trust store.
+        tmf.init((KeyStore) null);
+
+        // Get hold of the default trust manager
+        X509TrustManager defaultTm = null;
+        for (TrustManager tm : tmf.getTrustManagers()) {
+            if (tm instanceof X509TrustManager) {
+                defaultTm = (X509TrustManager) tm;
+                break;
+            }
+        }
+
+        // Get the certs from defaultTm and add them to our trustStore
+        if (defaultTm != null) {
+            X509Certificate[] trustedCerts = defaultTm.getAcceptedIssuers();
+            Arrays.stream(trustedCerts)
+                    .forEach(cert -> {
+                        try {
+                            trustStore.setCertificateEntry(RandomStringUtils.random(10, true, false),
+                                    cert);
+                        } catch (KeyStoreException e) {
+                            logger.error("Error while adding default trusted ca cert", e);
+                        }
+                    });
         }
     }
 

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/config/EnvVarConfig.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/config/EnvVarConfig.java
@@ -26,6 +26,7 @@ import org.wso2.choreo.connect.enforcer.constants.Constants;
  */
 public class EnvVarConfig {
     private static final String TRUSTED_CA_CERTS_PATH = "TRUSTED_CA_CERTS_PATH";
+    private static final String TRUST_DEFAULT_CERTS = "TRUST_DEFAULT_CERTS";
     private static final String ADAPTER_HOST_NAME = "ADAPTER_HOST_NAME";
     private static final String ENFORCER_PRIVATE_KEY_PATH = "ENFORCER_PRIVATE_KEY_PATH";
     private static final String ENFORCER_PUBLIC_CERT_PATH = "ENFORCER_PUBLIC_CERT_PATH";
@@ -40,6 +41,7 @@ public class EnvVarConfig {
 
     // Since the container is running in linux container, path separator is not needed.
     private static final String DEFAULT_TRUSTED_CA_CERTS_PATH = "/home/wso2/security/truststore";
+    private static final String DEFAULT_TRUST_DEFAULT_CERTS = "true";
     private static final String DEFAULT_ADAPTER_HOST_NAME = "adapter";
     private static final String DEFAULT_ENFORCER_PRIVATE_KEY_PATH = "/home/wso2/security/keystore/mg.key";
     private static final String DEFAULT_ENFORCER_PUBLIC_CERT_PATH = "/home/wso2/security/keystore/mg.pem";
@@ -54,6 +56,7 @@ public class EnvVarConfig {
 
     private static EnvVarConfig instance;
     private final String trustedAdapterCertsPath;
+    private final String trustDefaultCerts;
     private final String enforcerPrivateKeyPath;
     private final String enforcerPublicKeyPath;
     private final String adapterHost;
@@ -71,6 +74,8 @@ public class EnvVarConfig {
     private EnvVarConfig() {
         trustedAdapterCertsPath = retrieveEnvVarOrDefault(TRUSTED_CA_CERTS_PATH,
                 DEFAULT_TRUSTED_CA_CERTS_PATH);
+        trustDefaultCerts = retrieveEnvVarOrDefault(TRUST_DEFAULT_CERTS,
+                DEFAULT_TRUST_DEFAULT_CERTS);
         enforcerPrivateKeyPath = retrieveEnvVarOrDefault(ENFORCER_PRIVATE_KEY_PATH,
                 DEFAULT_ENFORCER_PRIVATE_KEY_PATH);
         enforcerPublicKeyPath = retrieveEnvVarOrDefault(ENFORCER_PUBLIC_CERT_PATH,
@@ -109,6 +114,10 @@ public class EnvVarConfig {
 
     public String getTrustedAdapterCertsPath() {
         return trustedAdapterCertsPath;
+    }
+
+    public boolean isTrustDefaultCerts() {
+        return Boolean.valueOf(trustDefaultCerts);
     }
 
     public String getEnforcerPrivateKeyPath() {


### PR DESCRIPTION
### Purpose
Added a method to load the trusted root certificates in the `<javahome>/lib/security/cacerts` location to the existing truststore.

Made cert trusting method configurable via env config 

| env variable name | values | default value|
|--|--|--|
|TRUST_DEFAULT_CERTS | **true** / **false**  | **true**| 

Ex:
Docker compose config:
```
enforcer:
    hostname: enforcer
    image: wso2/choreo-connect-enforcer:1.2.0-m1-SNAPSHOT
    ...
    ...
    environment:
      ...
      ...
      - TRUSTED_CA_CERTS_PATH=/home/wso2/security/truststore
      - TRUST_DEFAULT_CERTS=false
      ...
```

k8s config:
```
...
spec:
      containers:
        - name: choreo-connect-enforcer
          ...
          image: wso2/choreo-connect-enforcer:1.2.0-m1-SNAPSHOT
         ...
          env:
            ...
            ...
            - name: TRUSTED_CA_CERTS_PATH
              value: "/home/wso2/security/truststore"
            - name: TRUST_DEFAULT_CERTS
              value: "false"
            ...
```


### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)