### PR TITLE
Parse JWT payload with JSON parser during JWT based throttle validations

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/throttle/ThrottleDataHolder.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/throttle/ThrottleDataHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.choreo.connect.enforcer.throttle;
 
+import net.minidev.json.JSONObject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -365,7 +366,7 @@ public class ThrottleDataHolder {
             }
             if (conf.isJwtClaimConditionsEnabled()
                     && (claimConditions != null && !claimConditions.getValues().isEmpty())) {
-                Map<String, String> c = ThrottleUtils.getJWTClaims(req.getAuthenticationContext().getCallerToken());
+                JSONObject c = ThrottleUtils.getJWTClaims(req.getAuthenticationContext().getCallerToken());
                 if (c == null || !isJwtClaimPresent(c, claimConditions)) {
                     isThrottled = false;
                 }
@@ -521,11 +522,11 @@ public class ThrottleDataHolder {
         return status;
     }
 
-    private boolean isJwtClaimPresent(Map<String, String> claims, ThrottleCondition.JWTClaimConditions conditions) {
+    private boolean isJwtClaimPresent(JSONObject claims, ThrottleCondition.JWTClaimConditions conditions) {
         boolean status = true;
 
         for (Map.Entry<String, String> jwtClaim : conditions.getValues().entrySet()) {
-            String value = claims.get(jwtClaim.getKey());
+            String value = claims.getAsString(jwtClaim.getKey());
             if (value == null) {
                 status = false;
                 break;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/throttle/ThrottleFilter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/throttle/ThrottleFilter.java
@@ -498,7 +498,7 @@ public class ThrottleFilter implements Filter {
 
         String callerToken = requestContext.getAuthenticationContext().getCallerToken();
         if (config.isJwtClaimConditionsEnabled() && callerToken != null) {
-            Map<String, String> claims = ThrottleUtils.getJWTClaims(callerToken);
+            net.minidev.json.JSONObject claims = ThrottleUtils.getJWTClaims(callerToken);
             for (String key : claims.keySet()) {
                 jsonObMap.put(key, claims.get(key));
             }

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/websocket/WebSocketThrottleFilter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/websocket/WebSocketThrottleFilter.java
@@ -284,7 +284,7 @@ public class WebSocketThrottleFilter implements Filter {
 
         String callerToken = requestContext.getAuthenticationContext().getCallerToken();
         if (config.isJwtClaimConditionsEnabled() && callerToken != null) {
-            Map<String, String> claims = ThrottleUtils.getJWTClaims(callerToken);
+            net.minidev.json.JSONObject claims = ThrottleUtils.getJWTClaims(callerToken);
             for (String key : claims.keySet()) {
                 jsonObMap.put(key, claims.get(key));
             }


### PR DESCRIPTION
### Purpose
When throttling based on JWT claims, we parsed the payload of the JWT similar to a SWT until now. This was a direct transition from the json to a Map<String, String>. This did not require initializing a JSON parser and upto now we only had come accross use cases where the claim value was a string, and not an object. Recently, an update has been released for API-M 4.1.0 where the access token generated from developer portal includes the claim "realm" with a value that is an object (Ex. {\n "signing_tenant": "carbon.super" \n}). Hence, the payload must be considered as an actual JWT token which may include an JSON object as the claim value.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/3129

### Automation tests
 - Unit tests added: No
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
