### PR TITLE
Enable kid property on JWT header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -509,7 +509,7 @@
         <andes.client.version>3.3.12</andes.client.version>
         <azure.messaging.eventhubs.version>5.6.0</azure.messaging.eventhubs.version>
         <woodstox-core.version>6.4.0</woodstox-core.version>
-        <carbon.apimgt.version>9.0.369.1</carbon.apimgt.version>
+        <carbon.apimgt.version>9.0.369.2</carbon.apimgt.version>
         <build.helper.plugin.version>3.2.0</build.helper.plugin.version>
         <commons.version>3.9</commons.version>
         <commons.io.version>2.7</commons.io.version>


### PR DESCRIPTION
### Purpose
Increment the version of APIMGT common gateway dependency to start using kid instead of x5t to identify which certificate to use for validation.


### Automation tests
 no

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
