### PR TITLE
Notify CC chat when nightly build failed

### DIFF
--- a/.github/workflows/nightly-integration-test.yml
+++ b/.github/workflows/nightly-integration-test.yml
@@ -131,3 +131,10 @@ jobs:
 
           # error if one of trivy scan failed
           exit $EXIT_CODE
+      - name: Choreo Connect Chat Notification
+        uses: Co-qn/google-chat-notification@v1
+        with:
+          name: Choreo Connect Ubuntu Nighly Build
+          url: ${{ secrets.NIGHT_BUILD_GCHAT_WEBHOOK }}
+          status: ${{ job.status }}
+        if: ${{ failure() }}


### PR DESCRIPTION
Signed-off-by: Renuka Fernando <renukapiyumal@gmail.com>

### Purpose
Notify the chat, when nighly build has failed.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
