### PR TITLE
Match kid properties between JWT and JWKS generators

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/config/ConfigHolder.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/config/ConfigHolder.java
@@ -505,6 +505,7 @@ public class ConfigHolder {
         backendJWKSDto.setJwks(jwks);
         config.setBackendJWKSDto(backendJWKSDto);
     }
+    // TODO: Move this to carbon-apimgt common package
     private String getJWKSThumbprint(Certificate publicCert) throws CertificateEncodingException,
             NoSuchAlgorithmException {
         MessageDigest digestValue;

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/jwtGenerator/JwtGeneratorTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/jwtGenerator/JwtGeneratorTestCase.java
@@ -173,8 +173,6 @@ public class JwtGeneratorTestCase {
         Assert.assertEquals(jwk.getKeyUse().toString(), "sig", "Incorrect key use set on JWKS");
         Assert.assertEquals(jwk.getAlgorithm().toString(), "RS256", "Incorrect algorithm set on JWKS");
 
-
-
         JWSVerifier verifier = new RSASSAVerifier(jwk.toRSAPublicKey());
         Assert.assertTrue(jwsObject.verify(verifier),"JWT failed to validate with JWKS response");
     }


### PR DESCRIPTION
### Purpose

Use the same hashing between the backend JWTGenerator and the JWKS endpoint to allow for  keys to be matched for verification.

Updated Integration test for JWKS


### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
