### PR TITLE
Fix error downloading apictl in Mac M1 for integration tests

### DIFF
--- a/integration/test-integration/pom.xml
+++ b/integration/test-integration/pom.xml
@@ -292,7 +292,7 @@
 
     <profiles>
         <profile>
-            <id>mac-x64</id>
+            <id>mac-amd64</id>
             <activation>
                 <os>
                     <family>mac</family>
@@ -301,6 +301,18 @@
             </activation>
             <properties>
                 <apictl.package>apictl-${apictl.version}-macosx-x64.tar.gz</apictl.package>
+            </properties>
+        </profile>
+        <profile>
+            <id>mac-arm64</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <apictl.package>apictl-${apictl.version}-macosx-x64.tar.gz</apictl.package> <!-- Use same amd64 distribution until arm64 available -->
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
Signed-off-by: Renuka Fernando <renukapiyumal@gmail.com>

### Purpose
Getting the following error when running integration tests in Mac M1.

```log
[WARNING] Ignoring download failure.
[INFO] Downloading: https://github.com/wso2/product-apim-tooling/releases/download/v4.1.0/default-package-to-be-overridden



[ERROR] Failed to execute goal com.googlecode.maven-download-plugin:download-maven-plugin:1.6.3:wget (download-apictl) on project test-integration: IO Error: Error while expanding /Users/renuka/git/product-microgateway/integration/test-integration/target/default-package-to-be-overridden: Archive is not a ZIP archive
```

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
