### PR TITLE
Testkey handler flushes channel after writing response

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/issuer/HttpTokenServerHandler.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/issuer/HttpTokenServerHandler.java
@@ -165,7 +165,7 @@ public class HttpTokenServerHandler extends SimpleChannelInboundHandler<HttpObje
                 // Tell the client we're going to close the connection.
                 response.headers().set(CONNECTION, CLOSE);
             }
-            ChannelFuture f = ctx.write(response);
+            ChannelFuture f = ctx.writeAndFlush(response);
             if (!keepAlive) {
                 f.addListener(ChannelFutureListener.CLOSE);
             }


### PR DESCRIPTION
### Purpose

TestKey endpoint wasn't working when JWKS was enabled. This is to fix that.

Testkey handler now flushes the netty channel after providing the response.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #


### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
