### PR TITLE
[main] Dependency version upgrades

### DIFF
--- a/enforcer-parent/enforcer/pom.xml
+++ b/enforcer-parent/enforcer/pom.xml
@@ -436,10 +436,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.json.wso2</groupId>
             <artifactId>json</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
                 <version>${dependency.check.maven.version}</version>
                 <configuration>
                     <failBuildOnCVSS>${dependency.check.cvss.threshold.value}</failBuildOnCVSS>
-                    <suppressionFiles>/home/ubuntu/owasp/owasp-suppressions.xml</suppressionFiles>
+                    <suppressionFiles>/Users/lahirud/Desktop/ProdAPIMForRateLimit/wso2am-4.0.0-SNAPSHOT/repository/conf/supressions.xml</suppressionFiles>
                     <ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
                     <ossindexAnalyzerUseCache>false</ossindexAnalyzerUseCache>
                     <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
@@ -664,7 +664,7 @@
         <io.fabric8.docker.plugin.version>0.34.1</io.fabric8.docker.plugin.version>
         <io.netty.version>4.1.77.Final</io.netty.version>
         <jaeger.exporter.version>1.6.0</jaeger.exporter.version>
-        <apache.tomcat.dependency.version>10.0.23</apache.tomcat.dependency.version>
+        <apache.tomcat.dependency.version>10.1.4</apache.tomcat.dependency.version>
         <java.websocket.version>1.5.3</java.websocket.version>
         <slf4j.api.version>1.7.30</slf4j.api.version>
         <json.smart.version>2.4.7</json.smart.version>
@@ -697,7 +697,7 @@
         <analytics.publisher.client.version>1.0.10</analytics.publisher.client.version>
         <awaitility.version>3.1.2</awaitility.version>
         <apache.httpcomponents.version>4.5.13</apache.httpcomponents.version>
-        <jackson.databind.version>2.14.0-rc1</jackson.databind.version>
+        <jackson.databind.version>2.14.1</jackson.databind.version>
         <snakeyaml.version>1.32</snakeyaml.version>
         <exec.maven.plugin.version>3.0.0</exec.maven.plugin.version>
         <googlecode.download.plugin.version>1.6.3</googlecode.download.plugin.version>
@@ -712,12 +712,12 @@
         <directory.maven.plugin.version>1.0</directory.maven.plugin.version>
 
         <!-- Enforcer metrics, tracing related dependencies -->
-        <jackson.annotations.version>2.14.0-rc1</jackson.annotations.version>
+        <jackson.annotations.version>2.14.1</jackson.annotations.version>
         <applicationinsights.core.version>2.6.3</applicationinsights.core.version>
         <azure.monitor.opentelemetry.exporter.version>1.0.0-beta.5</azure.monitor.opentelemetry.exporter.version>
         <azure.core.http.okhttp.version>1.3.3</azure.core.http.okhttp.version>
         <!-- dependency check plugin properties -->
-        <dependency.check.maven.version>7.1.1</dependency.check.maven.version>
+        <dependency.check.maven.version>7.4.1</dependency.check.maven.version>
         <dependency.check.cvss.threshold.value>4</dependency.check.cvss.threshold.value>
         <!-- -code coverage related properties -->
         <maven.failsafe.plugin.version>2.15</maven.failsafe.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
                 <version>${dependency.check.maven.version}</version>
                 <configuration>
                     <failBuildOnCVSS>${dependency.check.cvss.threshold.value}</failBuildOnCVSS>
-                    <suppressionFiles>/Users/lahirud/Desktop/ProdAPIMForRateLimit/wso2am-4.0.0-SNAPSHOT/repository/conf/supressions.xml</suppressionFiles>
+                    <suppressionFiles>/home/ubuntu/owasp/owasp-suppressions.xml</suppressionFiles>
                     <ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
                     <ossindexAnalyzerUseCache>false</ossindexAnalyzerUseCache>
                     <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
@@ -662,7 +662,7 @@
         <gson.version>2.8.9</gson.version>
         <guava.version>30.0-jre</guava.version>
         <io.fabric8.docker.plugin.version>0.34.1</io.fabric8.docker.plugin.version>
-        <io.netty.version>4.1.77.Final</io.netty.version>
+        <io.netty.version>4.1.86.Final</io.netty.version>
         <jaeger.exporter.version>1.6.0</jaeger.exporter.version>
         <apache.tomcat.dependency.version>10.1.4</apache.tomcat.dependency.version>
         <java.websocket.version>1.5.3</java.websocket.version>
@@ -717,7 +717,7 @@
         <azure.monitor.opentelemetry.exporter.version>1.0.0-beta.5</azure.monitor.opentelemetry.exporter.version>
         <azure.core.http.okhttp.version>1.3.3</azure.core.http.okhttp.version>
         <!-- dependency check plugin properties -->
-        <dependency.check.maven.version>7.4.1</dependency.check.maven.version>
+        <dependency.check.maven.version>7.4.4</dependency.check.maven.version>
         <dependency.check.cvss.threshold.value>4</dependency.check.cvss.threshold.value>
         <!-- -code coverage related properties -->
         <maven.failsafe.plugin.version>2.15</maven.failsafe.plugin.version>


### PR DESCRIPTION
### Purpose
Updates below dependencies,

- tomcat-embed-core v10.0.27 to v10.1.4
- graphql-java v19.2 to v20.0
- jackson-databind 2.13.4.2 to v2.14.1

Removes snakeyaml dependency from the Enforcer

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
