### PR TITLE
Adding a Proxy Server to Local Adapter

### DIFF
--- a/adapter/config/default_config.go
+++ b/adapter/config/default_config.go
@@ -420,6 +420,11 @@ var defaultConfig = &Config{
 			"endpoint":               "/api/v2/spans",
 		},
 	},
+	MoesifMicroservice: moesifMicroservice{
+		ServiceURL: "https://moesifms:8000",
+		Username:   "admin",
+		Password:   "admin",
+	},
 	LAProxyServer: laProxyServer{
 		Host:     "0.0.0.0",
 		Port:     "9740",

--- a/adapter/config/default_config.go
+++ b/adapter/config/default_config.go
@@ -368,6 +368,8 @@ var defaultConfig = &Config{
 		Enabled:              false,
 		ServiceURL:           "global-adapter:18000",
 		ServiceURLDeprecated: UnassignedAsDeprecated,
+		Username:             "admin",
+		Password:             "admin",
 		OverwriteHostName:    UnassignedAsDeprecated,
 		OverrideHostName:     "",
 		LocalLabel:           "default",
@@ -417,5 +419,11 @@ var defaultConfig = &Config{
 			"port":                   "9411",
 			"endpoint":               "/api/v2/spans",
 		},
+	},
+	LAProxyServer: laProxyServer{
+		Host:     "0.0.0.0",
+		Port:     "9740",
+		Username: "admin",
+		Password: "admin",
 	},
 }

--- a/adapter/config/parser.go
+++ b/adapter/config/parser.go
@@ -47,6 +47,7 @@ const DefaultGatewayName = "Default"
 
 // DefaultGatewayVHost represents the default vhost of default gateway environment if it is not configured
 const DefaultGatewayVHost = "localhost"
+
 // for /testtoken and /health check, if user not configured default env, we have no vhost
 
 const (
@@ -118,6 +119,8 @@ func ReadConfigs() (*Config, error) {
 		pkgconf.ResolveConfigEnvValues(reflect.ValueOf(&(adapterConfig.GlobalAdapter)).Elem(), "GlobalAdapter", true)
 		pkgconf.ResolveConfigEnvValues(reflect.ValueOf(&(adapterConfig.Enforcer)).Elem(), "Enforcer", false)
 		pkgconf.ResolveConfigEnvValues(reflect.ValueOf(&(adapterConfig.Analytics)).Elem(), "Analytics", false)
+		pkgconf.ResolveConfigEnvValues(reflect.ValueOf(&(adapterConfig.MoesifMicroservice)).Elem(), "MoesifMicroservice", true)
+		pkgconf.ResolveConfigEnvValues(reflect.ValueOf(&(adapterConfig.LAProxyServer)).Elem(), "LAProxyServer", true)
 	})
 	return adapterConfig, e
 }

--- a/adapter/config/types.go
+++ b/adapter/config/types.go
@@ -72,13 +72,15 @@ const (
 //	Don't use toml tag for configuration properties as it may affect environment variable based
 //	config resolution.
 type Config struct {
-	Adapter       adapter
-	Enforcer      enforcer
-	Envoy         envoy         `toml:"router"`
-	ControlPlane  controlPlane  `toml:"controlPlane"`
-	GlobalAdapter globalAdapter `toml:"globalAdapter"`
-	Analytics     analytics     `toml:"analytics"`
-	Tracing       tracing
+	Adapter            adapter
+	Enforcer           enforcer
+	Envoy              envoy         `toml:"router"`
+	ControlPlane       controlPlane  `toml:"controlPlane"`
+	GlobalAdapter      globalAdapter `toml:"globalAdapter"`
+	Analytics          analytics     `toml:"analytics"`
+	Tracing            tracing
+	MoesifMicroservice moesifMicroservice `toml:"moesifMicroservice"`
+	LAProxyServer      laProxyServer      `toml:"laProxyServer"`
 }
 
 // Adapter related Configurations
@@ -452,6 +454,19 @@ type tracing struct {
 	ConfigProperties map[string]string
 }
 
+type moesifMicroservice struct {
+	ServiceURL string `toml:"serviceUrl"`
+	Username   string `toml:"username"`
+	Password   string `toml:"password"`
+}
+
+type laProxyServer struct {
+	Host     string `toml:"host"`
+	Port     string `toml:"port"`
+	Username string `toml:"username"`
+	Password string `toml:"password"`
+}
+
 type metrics struct {
 	Enabled bool
 	Type    string
@@ -544,6 +559,8 @@ type globalAdapter struct {
 	ServiceURL string
 	// Deprecated: Use ServiceURL instead.
 	ServiceURLDeprecated string `toml:"serviceUrl"`
+	Username             string `toml:"username"`
+	Password             string `toml:"password"`
 	LocalLabel           string
 	// Deprecated: Use OverrideHostName instead.
 	OverwriteHostName string

--- a/adapter/go.mod
+++ b/adapter/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/go-openapi/jsonreference v0.19.3 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/goccy/go-json v0.4.7 // indirect
+	github.com/gorilla/mux v1.8.0
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect

--- a/adapter/go.sum
+++ b/adapter/go.sum
@@ -215,6 +215,8 @@ github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=

--- a/adapter/internal/adapter/adapter.go
+++ b/adapter/internal/adapter/adapter.go
@@ -254,6 +254,12 @@ func Run(conf *config.Config) {
 		go restserver.StartRestServer(conf)
 	}
 
+	// Proxy server for the LA
+	if true {
+		logger.LoggerMgw.Info("Starting proxy server for Local Adapter... ")
+
+	}
+
 	gaEnabled := conf.GlobalAdapter.Enabled
 	if gaEnabled {
 		go ga.InitGAClient()

--- a/adapter/internal/proxyserver/apiserver.go
+++ b/adapter/internal/proxyserver/apiserver.go
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package proxyserver
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/wso2/product-microgateway/adapter/config"
+	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
+)
+
+const organizationID = "organizationId"
+const queryParamValueALL = "ALL"
+
+// for the pupose of versioning of endpoints to external microservices
+const externalMicroserviceContextV1 = "/external/ms/v1/"
+
+const moeisfUniqueIdentifier = "Moesif"
+
+// Server is a wrapped http server with a http client
+type Server struct {
+	client *http.Client
+}
+
+// New function defines the new server structure with a http client.
+func New(conf *config.Config) *Server {
+
+	requestTimeOut := conf.ControlPlane.HTTPClient.RequestTimeOut
+
+	client := &http.Client{
+		Transport: nil,
+		Timeout:   requestTimeOut * time.Second,
+	}
+
+	srv := &Server{
+		client: client,
+	}
+	return srv
+}
+
+// RunAPIServer function initializes the GA API server.
+func (s *Server) RunAPIServer(conf *config.Config) {
+	router := mux.NewRouter()
+
+	// HTTPGetToExternalMSHandler is wrapper that takes unique identifier for the microservice,
+	// then return a function of type http.HandlerFunc
+	router.HandleFunc(externalMicroserviceContextV1+"moesif", BasicAuth(s.HTTPGetToExternalMSHandler(moeisfUniqueIdentifier))).Methods(http.MethodGet)
+	router.HandleFunc(externalMicroserviceContextV1+"moesif"+"?"+organizationID+"="+queryParamValueALL,
+		BasicAuth(s.HTTPGetToGAHandler)).Methods(http.MethodGet)
+
+	logger.LoggerMgw.Info("Starting LA Proxy Server...")
+	srv := &http.Server{
+		Handler:      router,
+		Addr:         conf.LAProxyServer.Host + ":" + conf.LAProxyServer.Port,
+		WriteTimeout: 60 * time.Second,
+		ReadTimeout:  60 * time.Second,
+	}
+
+	logger.LoggerMgw.Fatal(srv.ListenAndServe())
+}

--- a/adapter/internal/proxyserver/handler.go
+++ b/adapter/internal/proxyserver/handler.go
@@ -32,22 +32,22 @@ import (
 	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
 )
 
-// HTTPGetHandler function handles get requests
+// HTTPGetToGAHandler function handles get requests
 func (s *Server) HTTPGetToGAHandler(w http.ResponseWriter, r *http.Request) {
 	buildRequestToGA(s.client, w, r, http.MethodGet, nil)
 }
 
-// HTTPPostHandler function handles post requests
+// HTTPPostToGAHandler function handles post requests
 func (s *Server) HTTPPostToGAHandler(w http.ResponseWriter, r *http.Request) {
 	buildRequestToGA(s.client, w, r, http.MethodPost, r.Body)
 }
 
-// HTTPatchHandler function handles patch requests
+// HTTPatchToGAHandler function handles patch requests
 func (s *Server) HTTPatchToGAHandler(w http.ResponseWriter, r *http.Request) {
 	buildRequestToGA(s.client, w, r, http.MethodPatch, r.Body)
 }
 
-// HTTPGetForExternalMSHandler function handles get requests sending to external microservices
+// HTTPGetToExternalMSHandler function handles get requests sending to external microservices
 func (s *Server) HTTPGetToExternalMSHandler(msUniqueIdentifier string) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		buildRequestForExtMS(s.client, w, r, http.MethodGet, nil, msUniqueIdentifier)
@@ -61,7 +61,7 @@ func (s *Server) HTTPPostToExternalMSHandler(msUniqueIdentifier string) http.Han
 	})
 }
 
-// HTTPPostToExternalMSHandler function handles post requests sending to external microservices
+// HTTPPatchToExternalMSHandler function handles post requests sending to external microservices
 func (s *Server) HTTPPatchToExternalMSHandler(msUniqueIdentifier string) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		buildRequestForExtMS(s.client, w, r, http.MethodPatch, r.Body, msUniqueIdentifier)

--- a/adapter/internal/proxyserver/handler.go
+++ b/adapter/internal/proxyserver/handler.go
@@ -1,0 +1,217 @@
+/*
+ *  Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+	Package handler contains logic related to authenticate the GA API requests and handle API requests accordingly.
+*/
+
+package proxyserver
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/wso2/product-microgateway/adapter/config"
+	logger "github.com/wso2/product-microgateway/adapter/internal/loggers"
+)
+
+// HTTPGetHandler function handles get requests
+func (s *Server) HTTPGetToGAHandler(w http.ResponseWriter, r *http.Request) {
+	buildRequestToGA(s.client, w, r, http.MethodGet, nil)
+}
+
+// HTTPPostHandler function handles post requests
+func (s *Server) HTTPPostToGAHandler(w http.ResponseWriter, r *http.Request) {
+	buildRequestToGA(s.client, w, r, http.MethodPost, r.Body)
+}
+
+// HTTPatchHandler function handles patch requests
+func (s *Server) HTTPatchToGAHandler(w http.ResponseWriter, r *http.Request) {
+	buildRequestToGA(s.client, w, r, http.MethodPatch, r.Body)
+}
+
+// HTTPGetForExternalMSHandler function handles get requests sending to external microservices
+func (s *Server) HTTPGetToExternalMSHandler(msUniqueIdentifier string) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buildRequestForExtMS(s.client, w, r, http.MethodGet, nil, msUniqueIdentifier)
+	})
+}
+
+// HTTPPostToExternalMSHandler function handles post requests sending to external microservices
+func (s *Server) HTTPPostToExternalMSHandler(msUniqueIdentifier string) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buildRequestForExtMS(s.client, w, r, http.MethodPost, r.Body, msUniqueIdentifier)
+	})
+}
+
+// HTTPPostToExternalMSHandler function handles post requests sending to external microservices
+func (s *Server) HTTPPatchToExternalMSHandler(msUniqueIdentifier string) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buildRequestForExtMS(s.client, w, r, http.MethodPatch, r.Body, msUniqueIdentifier)
+	})
+}
+
+func buildRequestToGA(client *http.Client, w http.ResponseWriter, r *http.Request, httpMethod string, body io.Reader) {
+	conf, error := config.ReadConfigs()
+
+	if error != nil {
+		logger.LoggerMgw.Error("Error occured while reading config.")
+		return
+	}
+	var requestURL = conf.GlobalAdapter.ServiceURL + r.RequestURI
+
+	sendHTTPRequestToGA(client, conf, requestURL, w, httpMethod, body)
+}
+
+func buildRequestForExtMS(client *http.Client, w http.ResponseWriter, r *http.Request, httpMethod string, body io.Reader, msUniqueIdentifier string) {
+	conf, error := config.ReadConfigs()
+
+	if error != nil {
+		logger.LoggerMgw.Error("Error occured while reading config.")
+		return
+	}
+	var msServiceURL string
+
+	// Handle a new microservice by adding corresponding case.
+	switch msUniqueIdentifier {
+	case moeisfUniqueIdentifier:
+		msServiceURL = conf.MoesifMicroservice.ServiceURL
+	default:
+		logger.LoggerMgw.Error("Unrecognizable microservice identifier has been passed: ", msUniqueIdentifier)
+		return
+	}
+	var requestURL = msServiceURL + r.RequestURI
+
+	sendHTTPRequestToExtMS(client, conf, requestURL, w, httpMethod, body, msUniqueIdentifier)
+}
+
+func sendHTTPRequestToGA(client *http.Client, conf *config.Config, requestURL string, w http.ResponseWriter, httpMethod string, body io.Reader) {
+	logger.LoggerMgw.Debug("Request URL for Global Adapter: ", requestURL)
+	req, err := http.NewRequest(httpMethod, requestURL, body)
+
+	if err != nil {
+		w.WriteHeader(500)
+		logger.LoggerMgw.Error("Error occurred while constructing http request to Global Adapter ", err)
+		return
+	}
+	req.SetBasicAuth(conf.GlobalAdapter.Username, conf.GlobalAdapter.Password)
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+
+	if err != nil {
+		w.WriteHeader(500)
+		logger.LoggerMgw.Error("Error occurred while connecting to Global Adapter ", err)
+		return
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		bodyBytes, _ := ioutil.ReadAll(resp.Body)
+		bodyString := string(bodyBytes)
+		w.WriteHeader(resp.StatusCode)
+		fmt.Fprintf(w, "%s", bodyString)
+	}
+
+	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+	bodyString := string(bodyBytes)
+	fmt.Fprintf(w, "%s", bodyString)
+}
+
+func sendHTTPRequestToExtMS(client *http.Client, conf *config.Config, requestURL string, w http.ResponseWriter, httpMethod string, body io.Reader, msUniqueIdentifier string) {
+	logger.LoggerMgw.Debug(fmt.Sprintf("Request URL of the microservice (%s): ", msUniqueIdentifier), requestURL)
+	req, err := http.NewRequest(httpMethod, requestURL, body)
+
+	if err != nil {
+		w.WriteHeader(500)
+		logger.LoggerMgw.Error(fmt.Sprintf("Error occurred while constructing http request sending to microservice (%s) ", msUniqueIdentifier),
+			err)
+		return
+	}
+
+	var authUsername string
+	var authPassword string
+
+	// Handle a new microservice by adding corresponding case.
+	switch msUniqueIdentifier {
+	case moeisfUniqueIdentifier:
+		authUsername = conf.MoesifMicroservice.Username
+		authPassword = conf.MoesifMicroservice.Password
+	}
+
+	req.SetBasicAuth(authUsername, authPassword)
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+
+	if err != nil {
+		w.WriteHeader(500)
+		logger.LoggerMgw.Error(fmt.Sprintf("Error occurred while connecting to microservice (%s) ", msUniqueIdentifier), err)
+		return
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		bodyBytes, _ := ioutil.ReadAll(resp.Body)
+		bodyString := string(bodyBytes)
+		w.WriteHeader(resp.StatusCode)
+		fmt.Fprintf(w, "%s", bodyString)
+	}
+
+	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+	bodyString := string(bodyBytes)
+	fmt.Fprintf(w, "%s", bodyString)
+}
+
+// BasicAuth function authenticates the request.
+func BasicAuth(next http.HandlerFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		conf, error := config.ReadConfigs()
+
+		if error != nil {
+			logger.LoggerMgw.Error("Error occured while reading config.")
+			return
+		}
+		if ok {
+			usernameHash := sha256.Sum256([]byte(username))
+			passwordHash := sha256.Sum256([]byte(password))
+			expectedUsernameHash := sha256.Sum256([]byte(conf.LAProxyServer.Username))
+			expectedPasswordHash := sha256.Sum256([]byte(conf.LAProxyServer.Password))
+
+			usernameMatch := (subtle.ConstantTimeCompare(usernameHash[:], expectedUsernameHash[:]) == 1)
+			passwordMatch := (subtle.ConstantTimeCompare(passwordHash[:], expectedPasswordHash[:]) == 1)
+
+			if usernameMatch && passwordMatch {
+				next.ServeHTTP(w, r)
+				return
+			}
+		}
+
+		w.Header().Set("WWW-Authenticate", `Basic realm="restricted", charset="UTF-8"`)
+		http.Error(w, "Unauthorized Access", http.StatusUnauthorized)
+	})
+}


### PR DESCRIPTION
New proxy server has two types of downstreams.
 - Global Adapter
 - any external microservice(s)
 
 Currently only one microservice is added.
 One can add new microservice to the proxy by following similar steps to what discussed in wso2-enterprise/choreo-connect-global-adapter#243