### PR TITLE
[3.2.x] Update removeSpecialCharsInPathParameters method

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/CodegenUtils.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/utils/CodegenUtils.java
@@ -183,6 +183,10 @@ public final class CodegenUtils {
             if (item.startsWith("{") && item.endsWith("}")) {
                 String modifiedItem = replaceSpecialChars(item);
                 modifiedPath = modifiedPath.replace(item, modifiedItem);
+            } else if (item.indexOf("{") > 0 && item.indexOf("}") > 0) {
+                // For special cases where an item can be in "abc.{var}" format
+                String modifiedItem = item.substring(item.indexOf("{"), item.indexOf("}") + 1);
+                modifiedPath = modifiedPath.replace(item, modifiedItem);
             }
         }
         return modifiedPath;


### PR DESCRIPTION
## Purpose
- Update `removeSpecialCharsInPathParameters` method to facilitate a special use case where path parameters are in format `abc.{var}`
- Fix https://github.com/wso2/product-microgateway/issues/3201