### PR TITLE
Upgrade jmx_prometheus_javaagent to 0.17.2

### DIFF
--- a/distribution/LICENSE-RUNTIME.txt
+++ b/distribution/LICENSE-RUNTIME.txt
@@ -14,7 +14,7 @@ below is and where the actual text of the license can be found.
 Name                                                                                                Version        License
 _________________________________________________________________________________________________________________________________________________
 org.wso2.micro.gateway.tools-3.2.5.jar                                                              bundle         apache2
-jmx_prometheus_javaagent-0.14.0.jar                                                                 jar            apache2             
+jmx_prometheus_javaagent-0.17.2.jar                                                                 jar            apache2
 
 
 The license types used by the above libraries and their information is given below:

--- a/distribution/resources/bin/gateway
+++ b/distribution/resources/bin/gateway
@@ -298,7 +298,7 @@ if [ ! "$CMD" = "stop" ]; then
       fi
       if [ "$OBSERVABILITY_FLAG" == "true" ]; then
           jmx_port=$(sed -n '2p' $CONFIG_OUT_FILE)
-          export JAVA_OPTS="$JAVA_OPTS -javaagent:$GW_HOME/lib/gateway/jmx_prometheus_javaagent-0.14.0.jar=$jmx_port:$GW_HOME/conf/Prometheus/config.yml"
+          export JAVA_OPTS="$JAVA_OPTS -javaagent:$GW_HOME/lib/gateway/jmx_prometheus_javaagent-0.17.2.jar=$jmx_port:$GW_HOME/conf/Prometheus/config.yml"
       fi
   fi
   if [ -a "$CONFIG_OUT_FILE" ];then

--- a/distribution/resources/bin/gateway.bat
+++ b/distribution/resources/bin/gateway.bat
@@ -97,7 +97,7 @@ IF EXIST %CONF_OUT_FILE% (
             GOTO :setJavaOpts
         )
         :setJavaOpts
-            SET JAVA_OPTS="-javaagent:%GW_HOME%\lib\gateway\jmx_prometheus_javaagent-0.14.0.jar=%jmxPort%:%GW_HOME%\conf\Prometheus\config.yml"
+            SET JAVA_OPTS="-javaagent:%GW_HOME%\lib\gateway\jmx_prometheus_javaagent-0.17.2.jar=%jmxPort%:%GW_HOME%\conf\Prometheus\config.yml"
     )
 
 IF EXIST %CONF_OUT_FILE% DEL /Q /F %CONF_OUT_FILE%

--- a/pom.xml
+++ b/pom.xml
@@ -622,7 +622,7 @@
         <jackson.databind.version>2.13.4.2</jackson.databind.version>
         <kraal.version>0.0.16</kraal.version>
         <kotlin.stdlib.version>1.3.31</kotlin.stdlib.version>
-        <prometheus.jmx.agent.version>0.14.0</prometheus.jmx.agent.version>
+        <prometheus.jmx.agent.version>0.17.2</prometheus.jmx.agent.version>
         <jms-module.version>0.6.3</jms-module.version>
         <jmx.api.version>2.0.1</jmx.api.version>
         <orbit.version.geronimo-jms_1.1_spec>1.1.1.wso2v1</orbit.version.geronimo-jms_1.1_spec>


### PR DESCRIPTION
## Purpose
Vulnerabilities [CVE-2022-1471](https://github.com/advisories/GHSA-mjmj-j48q-9wg2) and [CVE-2022-25857](https://github.com/advisories/GHSA-3mc7-4q67-w48m)  are identified in `org.yaml:snakeyaml 1.26` version which is coming from `jmx_prometheus_javaagent-0.14.0.jar` included in the Microgateway runtime.

This PR upgrades `jmx_prometheus_javaagent` to the latest version [0.17.2](https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.17.2/) to fix the vulnerabilities.