### PR TITLE
Fixed attribute issue.

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/AnalyticsFilter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/AnalyticsFilter.java
@@ -146,6 +146,12 @@ public class AnalyticsFilter {
 
             requestContext.addMetadataToMap(MetadataConstants.API_ORGANIZATION_ID,
                     requestContext.getMatchedAPI().getOrganizationId());
+            // Adding UserName and the APIContext
+            String endUserName = requestContext.getAuthenticationContext().getUsername();
+            requestContext.addMetadataToMap(MetadataConstants.API_USER_NAME_KEY,
+                    endUserName == null ? APIConstants.END_USER_UNKNOWN : endUserName);
+            requestContext.addMetadataToMap(MetadataConstants.API_CONTEXT_KEY,
+                    requestContext.getMatchedAPI().getBasePath());
         } finally {
             if (Utils.tracingEnabled()) {
                 analyticsSpanScope.close();

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/ChoreoAnalyticsProvider.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/ChoreoAnalyticsProvider.java
@@ -43,7 +43,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Analytics Data Provider of Microgateway
+ * Analytics Data Provider of Microgateway.
  */
 public class ChoreoAnalyticsProvider implements AnalyticsDataProvider {
     private static final Logger logger = LogManager.getLogger(APIFactory.class);
@@ -113,6 +113,7 @@ public class ChoreoAnalyticsProvider implements AnalyticsDataProvider {
         api.setApiVersion(getValueAsString(fieldsMap, MetadataConstants.API_VERSION_KEY));
         api.setApiCreatorTenantDomain(getValueAsString(fieldsMap, MetadataConstants.API_CREATOR_TENANT_DOMAIN_KEY));
         api.setOrganizationId(getValueAsString(fieldsMap, MetadataConstants.API_ORGANIZATION_ID));
+        api.setApiContext(getValueAsString(fieldsMap, MetadataConstants.API_CONTEXT_KEY));
 
         return api;
     }
@@ -209,6 +210,12 @@ public class ChoreoAnalyticsProvider implements AnalyticsDataProvider {
     @Override
     public String getUserAgentHeader() {
         return logEntry.getRequest().getUserAgent();
+    }
+
+    @Override
+    public String getUserName() {
+        Map<String, Value> fieldsMap = getFieldsMapFromLogEntry();
+        return getValueAsString(fieldsMap, MetadataConstants.API_USER_NAME_KEY);
     }
 
     @Override

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/ChoreoFaultAnalyticsProvider.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/ChoreoFaultAnalyticsProvider.java
@@ -194,6 +194,10 @@ public class ChoreoFaultAnalyticsProvider implements AnalyticsDataProvider {
         return null;
     }
 
+    public String getUserName() {
+        return null;
+    }
+
     @Override
     public String getUserAgentHeader() {
         // User agent is not required for fault scenario

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/APIConstants.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/APIConstants.java
@@ -37,7 +37,7 @@ public class APIConstants {
     public static final String UNAUTHENTICATED_TIER = "Unauthenticated";
     public static final String END_USER_ANONYMOUS = "anonymous";
     public static final String ANONYMOUS_PREFIX = "anon:";
-
+    public static final String END_USER_UNKNOWN = "unknown";
     public static final String GATEWAY_SIGNED_JWT_CACHE = "SignedJWTParseCache";
     public static final String DEFAULT_ISSUER = "Resident Key Manager";
     public static final String GATEWAY_PUBLIC_CERTIFICATE_ALIAS = "gateway_certificate_alias";

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/MetadataConstants.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/MetadataConstants.java
@@ -29,6 +29,8 @@ public class MetadataConstants {
     public static final String API_CREATOR_KEY = WSO2_METADATA_PREFIX + "api-creator";
     public static final String API_NAME_KEY = WSO2_METADATA_PREFIX + "api-name";
     public static final String API_VERSION_KEY = WSO2_METADATA_PREFIX + "api-version";
+    public static final String API_USER_NAME_KEY = WSO2_METADATA_PREFIX + "user-name";
+    public static final String API_CONTEXT_KEY = WSO2_METADATA_PREFIX + "api-context";
     public static final String API_TYPE_KEY = WSO2_METADATA_PREFIX + "api-type";
     public static final String API_CREATOR_TENANT_DOMAIN_KEY = WSO2_METADATA_PREFIX + "api-creator-tenant-domain";
     public static final String API_ORGANIZATION_ID = WSO2_METADATA_PREFIX + "api-organization-id";

--- a/pom.xml
+++ b/pom.xml
@@ -521,7 +521,7 @@
         <andes.client.version>3.3.12</andes.client.version>
         <azure.messaging.eventhubs.version>5.6.0</azure.messaging.eventhubs.version>
         <woodstox-core.version>6.4.0</woodstox-core.version>
-        <carbon.apimgt.version>9.0.369.3</carbon.apimgt.version>
+        <carbon.apimgt.version>9.0.369.4</carbon.apimgt.version>
         <build.helper.plugin.version>3.2.0</build.helper.plugin.version>
         <commons.version>3.9</commons.version>
         <commons.io.version>2.7</commons.io.version>


### PR DESCRIPTION
Same changes done in this PR can be found in the approved PR #3143
### Purpose
Modification to retrieve the end user name and api context as a default analytics metric.

### Goals
By default, end user name and api context should be sent as a metric by the provider.

### Approach 
Fix the enforcer AnalyticsFilter
Fix the default analytics provider (ChoreoAnalyticsProvider)

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
JDK 11.0.16
Ubuntu 22.04.1 LTS
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested
