### PR TITLE
[3.2.x] Add swagger-core dependency to the POM

### DIFF
--- a/components/micro-gateway-cli/pom.xml
+++ b/components/micro-gateway-cli/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>swagger-parser</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-models</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -284,6 +284,11 @@
                 <version>${swagger.v3.parser.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-core</artifactId>
+                <version>${swagger.v3.models.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-models</artifactId>
                 <version>${swagger.models.version}</version>


### PR DESCRIPTION
### Purpose
This PR adds the io.swagger.core.v3:swagger-core dependency to the POM to define the version packed into the CLI jar.

Fixes https://github.com/wso2/product-microgateway/issues/3231

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
