### PR TITLE
[3.2.x] Upgrade Ballerina version to 1.2.36

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -574,7 +574,7 @@
     </build>
 
     <properties>
-        <ballerina.platform.version>1.2.35</ballerina.platform.version>
+        <ballerina.platform.version>1.2.36</ballerina.platform.version>
         <broker.version>0.970.5</broker.version>
         <assembly.plugin.version>3.1.1</assembly.plugin.version>
         <compiler.plugin.version>3.7.0</compiler.plugin.version>


### PR DESCRIPTION
### Purpose
This PR upgrades the Ballerina version to 1.2.36.

Fixes https://github.com/wso2/api-manager/issues/1447