### PR TITLE
[choreo] bug fix: set xds cache under a common label for dynamic environments

### DIFF
--- a/adapter/internal/discovery/xds/server.go
+++ b/adapter/internal/discovery/xds/server.go
@@ -388,7 +388,11 @@ func UpdateAPI(vHost string, apiProject mgw.ProjectAPI, environments []string) (
 	//newLabels = model.GetXWso2Label(openAPIV3Struct.ExtensionProps)
 	//:TODO: since currently labels are not taking from x-wso2-label, I have made it to be taken from the method
 	// argument.
-	newLabels = environments
+	if conf.ControlPlane.DynamicEnvironments.Enabled {
+		newLabels = conf.ControlPlane.EnvironmentLabels
+	} else {
+		newLabels = environments
+	}
 	logger.LoggerXds.Infof("Added/Updated the content for Organization : %v under OpenAPI Key : %v", organizationID, apiIdentifier)
 	logger.LoggerXds.Debugf("Newly added labels for Organization : %v for the OpenAPI Key : %v are %v", organizationID, apiIdentifier, newLabels)
 	oldLabels, _ := orgIDOpenAPIEnvoyMap[organizationID][apiIdentifier]
@@ -401,7 +405,7 @@ func UpdateAPI(vHost string, apiProject mgw.ProjectAPI, environments []string) (
 		openAPIEnvoyMap[apiIdentifier] = newLabels
 		orgIDOpenAPIEnvoyMap[organizationID] = openAPIEnvoyMap
 	}
-	updateVhostInternalMaps(apiYaml.ID, apiYaml.Name, apiYaml.Version, vHost, newLabels)
+	updateVhostInternalMaps(apiYaml.ID, apiYaml.Name, apiYaml.Version, vHost, environments)
 
 	// create cert map for API
 	certMap := make(map[string][]byte)


### PR DESCRIPTION
### Purpose
we have noted that the choreo-connect adapter still update it's xds cache under a label as same as the gateway environment's name. Due to this router is not getting such updates, because router is only configured to listen on a particular gateway label.

With these changes, adapter will set xds cache under a common label(specific to dataplane cluster), which specified in config (`conf.ControlPlane.gatewayLabels`) 

Note: This applies only if dynamic environments enabled (`conf.Controlplane.DynamicEnvironments`) 

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
