### PR TITLE
Fix not printing debug logs in apim-analytics-publisher

### DIFF
--- a/enforcer-parent/enforcer/pom.xml
+++ b/enforcer-parent/enforcer/pom.xml
@@ -157,7 +157,7 @@
                             <exclude>org.apache.logging:*</exclude>
                             <exclude>log4j:*</exclude>
                             <exclude>org.slf4j:slf4j-log4j12</exclude>
-                            <exclude>org.apache.logging.log4j:log4j-slf4j-impl</exclude>
+                            <exclude>org.apache.logging.log4j:log4j-slf4j2-impl</exclude>
                             <exclude>org.apache.logging.log4j:log4j-api</exclude>
                             <exclude>org.apache.logging.log4j:log4j-core</exclude>
                             <exclude>org.apache.logging.log4j:log4j-jcl</exclude>
@@ -192,7 +192,7 @@
                                 org.apache.logging.log4j, org.json.wso2
                             </includeGroupIds>
                             <includeArtifactIds>
-                                log4j-api, log4j-core, log4j-jcl, json, log4j-slf4j-impl
+                                log4j-api, log4j-core, log4j-jcl, json, log4j-slf4j2-impl
                             </includeArtifactIds>
                         </configuration>
                     </execution>
@@ -528,7 +528,7 @@
         <!-- slf4j binding -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -508,7 +508,7 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j-impl</artifactId>
+                <artifactId>log4j-slf4j2-impl</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
             <dependency>
@@ -674,7 +674,7 @@
         <jaeger.exporter.version>1.6.0</jaeger.exporter.version>
         <apache.tomcat.dependency.version>10.1.4</apache.tomcat.dependency.version>
         <java.websocket.version>1.5.3</java.websocket.version>
-        <slf4j.api.version>2.0.6</slf4j.api.version>
+        <slf4j.api.version>1.7.36</slf4j.api.version>
         <json.smart.version>2.4.8</json.smart.version>
         <junit.version>4.13.2</junit.version>
         <log4j.version>2.19.0</log4j.version>


### PR DESCRIPTION
### Purpose
$subject

The slf4j.api.version 2.0.6 is incompatible for org.wso2.am.analytics.publisher.client

Default versions
```log
[INFO] +- org.wso2.am.analytics.publisher:org.wso2.am.analytics.publisher.client:jar:1.1.3:compile
[INFO] |  +- io.github.openfeign:feign-httpclient:jar:11.0:compile
[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.2:compile
```

```log
[INFO] \- org.wso2.orbit.graphQL:graphQL:jar:19.2.wso2v2:compile
[INFO]    +- com.graphql-java:graphql-java:jar:19.2:compile
[INFO]    |  \- org.slf4j:slf4j-api:jar:1.7.35:compile
```

Related PR: https://github.com/wso2/product-microgateway/pull/3044

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/3269

### Automation tests
 - Unit tests added: N/A
 - Integration tests added: N/A

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Tested in Docker Compose for Analytics Debug logs + Analytics in Choreo

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
