### PR TITLE
Build APIM Docker image instead of pulling from DockerHub

### DIFF
--- a/dev-scripts/code-coverage/prepare-files-before-int-tests.sh
+++ b/dev-scripts/code-coverage/prepare-files-before-int-tests.sh
@@ -35,5 +35,5 @@ fi
 echo "Preparing code coverage files before integration tests completed successfully..."
 
 # Temporary use wso2 RC image for integration tests. This have to be removed.
-docker pull wso2am/wso2am:4.2.0-rc1-alpine
-docker tag wso2am/wso2am:4.2.0-rc1-alpine wso2/wso2am:4.2.0
+docker pull wso2am/wso2am:4.2.0-alpine
+docker tag wso2am/wso2am:4.2.0-alpine wso2/wso2am:4.2.0

--- a/dev-scripts/code-coverage/prepare-files-before-int-tests.sh
+++ b/dev-scripts/code-coverage/prepare-files-before-int-tests.sh
@@ -33,3 +33,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
   sed -i '' "s/JAVA_OPTS.*/JAVA_OPTS=\${JAVA_OPTS} ${JAVA_AGENT_ARG} -Dhttpclient.hostnameVerifier=AllowAll/g"  ../../integration/test-integration/src/test/resources/dockerCompose/cc-cacert-mounted-mtls.yaml
 fi
 echo "Preparing code coverage files before integration tests completed successfully..."
+
+# Temporary use wso2 RC image for integration tests. This have to be removed.
+docker pull wso2am/wso2am:4.2.0-rc1-alpine
+docker tag wso2am/wso2am:4.2.0-rc1-alpine wso2/wso2am:4.2.0

--- a/distribution/src/main/assembly/assembly.xml
+++ b/distribution/src/main/assembly/assembly.xml
@@ -47,6 +47,10 @@
             <outputDirectory>choreo-connect-${project.version}/k8s-artifacts/choreo-connect-with-apim</outputDirectory>
         </fileSet>
         <fileSet>
+            <directory>../resources/docker-compose/apim</directory>
+            <outputDirectory>choreo-connect-${project.version}/docker-compose/choreo-connect-with-apim</outputDirectory>
+        </fileSet>
+        <fileSet>
             <directory>../resources/k8s-artifacts</directory>
             <excludes>
                 <exclude>./apim/**</exclude>
@@ -74,11 +78,6 @@
         <file>
             <source>../resources/docker-compose/docker-compose.yaml</source>
             <outputDirectory>choreo-connect-${project.version}/docker-compose/choreo-connect</outputDirectory>
-        </file>
-        <file>
-            <source>../resources/docker-compose/apim/docker-compose.yaml</source>
-            <outputDirectory>choreo-connect-${project.version}/docker-compose/choreo-connect-with-apim
-            </outputDirectory>
         </file>
         <file>
             <source>../resources/security/mg.key</source>
@@ -123,11 +122,6 @@
         <file>
             <source>../resources/security/mg.pem</source>
             <outputDirectory>choreo-connect-${project.version}/docker-compose/resources/router/security/truststore
-            </outputDirectory>
-        </file>
-        <file>
-            <source>../resources/docker-compose/apim/conf/deployment.toml</source>
-            <outputDirectory>choreo-connect-${project.version}/docker-compose/choreo-connect-with-apim/conf
             </outputDirectory>
         </file>
         <file>

--- a/integration/test-integration/src/test/resources/dockerCompose/apim-in-common-network-docker-compose.yaml
+++ b/integration/test-integration/src/test/resources/dockerCompose/apim-in-common-network-docker-compose.yaml
@@ -4,7 +4,7 @@ networks:
     name: apim_and_cc
 services:
   apim:
-    image: wso2am/wso2am:4.2.0-rc1-alpine
+    image: wso2/wso2am:4.2.0
     user: root
     ports:
       - "9764:9764"

--- a/resources/docker-compose/apim/docker-compose.yaml
+++ b/resources/docker-compose/apim/docker-compose.yaml
@@ -1,7 +1,8 @@
 version: "3.7"
 services:
   apim:
-    image: wso2am/wso2am:4.2.0-rc1-alpine
+    image: wso2/wso2am:4.2.0
+    build: ./dockerfiles/apim
     healthcheck:
       test: ["CMD", "nc", "-z","localhost", "9444"]
       interval: 10s

--- a/resources/docker-compose/apim/dockerfiles/apim/Dockerfile
+++ b/resources/docker-compose/apim/dockerfiles/apim/Dockerfile
@@ -1,0 +1,131 @@
+# ------------------------------------------------------------------------
+#
+# Copyright 2023 WSO2, LLC. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# ------------------------------------------------------------------------
+
+# set base Docker image to Ubuntu Docker image
+FROM ubuntu:22.04
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+# install dependencies
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata curl ca-certificates fontconfig locales python-is-python3 libxml2-utils netcat unzip wget \
+    && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
+    && locale-gen en_US.UTF-8 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_VERSION jdk-17.0.6+10
+
+# install Temurin OpenJDK 17
+RUN set -eux; \
+    ARCH="$(dpkg --print-architecture)"; \
+    case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='9e0e88bbd9fa662567d0c1e22d469268c68ac078e9e5fe5a7244f56fec71f55f'; \
+         BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.6%2B10/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.6_10.tar.gz'; \
+         ;; \
+       armhf|arm) \
+         ESUM='fe4d0c6d5bb8cf7f59f7ff82c0c1fd988bbe5cccf3bc7377dc8ae50740b46c82'; \
+         BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.6%2B10/OpenJDK17U-jdk_arm_linux_hotspot_17.0.6_10.tar.gz'; \
+         ;; \
+       ppc64el|powerpc:common64) \
+         ESUM='cb772c3fdf3f9fed56f23a37472acf2b80de20a7113fe09933891c6ef0ecde95'; \
+         BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.6%2B10/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.6_10.tar.gz'; \
+         ;; \
+       s390x|s390:64-bit) \
+         ESUM='32e53321dd3e724e111e5445fbdcbcefde893e59055cc1f102d20fa3bb62ccc3'; \
+         BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.6%2B10/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.6_10.tar.gz'; \
+         ;; \
+       amd64|i386:x86-64) \
+         ESUM='a0b1b9dd809d51a438f5fa08918f9aca7b2135721097f0858cf29f77a35d4289'; \
+         BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.6%2B10/OpenJDK17U-jdk_x64_linux_hotspot_17.0.6_10.tar.gz'; \
+         ;; \
+       *) \
+         echo "Unsupported arch: ${ARCH}"; \
+         exit 1; \
+         ;; \
+    esac; \
+    curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
+    echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+    mkdir -p /opt/java/openjdk; \
+    cd /opt/java/openjdk; \
+    tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
+    rm -rf /tmp/openjdk.tar.gz;
+
+ENV JAVA_HOME=/opt/java/openjdk \
+    PATH="/opt/java/openjdk/bin:$PATH"
+
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v4.2.0.0"
+
+# set Docker image build arguments
+# build arguments for user/group configurations
+ARG USER=wso2carbon
+ARG USER_ID=802
+ARG USER_GROUP=wso2
+ARG USER_GROUP_ID=802
+ARG USER_HOME=/home/${USER}
+# build arguments for WSO2 product installation
+ARG WSO2_SERVER_NAME=wso2am
+ARG WSO2_SERVER_VERSION=4.2.0
+ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
+ARG WSO2_SERVER_HOME=${USER_HOME}/wso2am-4.2.0
+# build argument for MOTD
+ARG MOTD="\n\
+Welcome to WSO2 Docker resources.\n\
+------------------------------------ \n\
+This Docker container comprises of a WSO2 product, running with its latest GA release \n\
+which is under the Apache License, Version 2.0. \n\
+Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
+
+# create the non-root user and group and set MOTD login message
+RUN \
+    groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} \
+    && useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER} \
+    && echo '[ ! -z "${TERM}" -a -r /etc/motd ] && cat /etc/motd' >> /etc/bash.bashrc; echo "${MOTD}" > /etc/motd
+
+# copy init script to user home
+COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
+
+# add the WSO2 product distribution to user's home directory
+COPY --chown=wso2carbon:wso2 ${WSO2_SERVER}.zip .
+RUN \
+    unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
+    && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
+    && mkdir ${USER_HOME}/wso2-tmp \
+    && bash -c 'mkdir -p ${USER_HOME}/solr/{indexed-data,database}' \
+    && chown wso2carbon:wso2 -R ${USER_HOME}/solr \
+    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp \
+    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp \
+    && rm -f ${WSO2_SERVER}.zip
+
+# remove unnecesary packages
+RUN apt-get purge -y netcat unzip wget
+
+# set the user and work directory
+USER ${USER_ID}
+WORKDIR ${USER_HOME}
+
+# set environment variables
+ENV WORKING_DIRECTORY=${USER_HOME} \
+    WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
+
+# expose ports
+EXPOSE 9763 9443 9999 11111 8280 8243 5672 9711 9611 9099
+
+# initiate container and start WSO2 Carbon server
+ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/resources/docker-compose/apim/dockerfiles/apim/docker-entrypoint.sh
+++ b/resources/docker-compose/apim/dockerfiles/apim/docker-entrypoint.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# ------------------------------------------------------------------------
+# Copyright 2023 WSO2, LLC. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+# ------------------------------------------------------------------------
+
+set -e
+
+# volume mounts
+config_volume=${WORKING_DIRECTORY}/wso2-config-volume
+artifact_volume=${WORKING_DIRECTORY}/wso2-artifact-volume
+# home of the directories to be artifact synced within the WSO2 product home
+deployment_volume=${WSO2_SERVER_HOME}/repository/deployment/server
+# home of the directories with preserved, default deployment artifacts
+original_deployment_artifacts=${WORKING_DIRECTORY}/wso2-tmp
+
+# check if the WSO2 non-root user home exists
+test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not exist" && exit 1
+
+# check if the WSO2 product home exists
+test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
+
+# shared artifact directories
+directories=("executionplans" "synapse-configs")
+# if the original directory locations of artifacts to be synced between nodes are empty,
+# copy the preserved, default content of these folders to these original locations
+for shared_directory in ${directories[@]}; do
+  if test -d ${original_deployment_artifacts}/${shared_directory};
+  then
+    if [[ -z "$(ls -A ${deployment_volume}/${shared_directory})" ]]; then
+      if ! cp -R ${original_deployment_artifacts}/${shared_directory}/* ${deployment_volume}/${shared_directory};
+      then
+        echo "Failed to copy the preserved, default artifacts to original location (${deployment_volume}/${shared_directory})"
+        exit 1
+      fi
+      echo "Successfully copied the preserved, default artifacts to original location (${deployment_volume}/${shared_directory})"
+    fi
+  fi
+done
+
+# optimize WSO2 Carbon Server, if the profile name is defined as an environment variable
+if [[ ! -z "${PROFILE_NAME}" ]]
+then
+  echo "Optimizing WSO2 Carbon Server" >&2
+  sh ${WSO2_SERVER_HOME}/bin/profileSetup.sh -Dprofile=${PROFILE_NAME}
+fi
+
+# copy any configuration changes mounted to config_volume
+test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
+# copy any artifact changes mounted to artifact_volume
+test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+
+# start WSO2 Carbon server
+echo "Start WSO2 Carbon server" >&2
+if [[ -z "${PROFILE_NAME}" ]]
+then
+  # start the server with the provided startup arguments
+  sh ${WSO2_SERVER_HOME}/bin/api-manager.sh "$@"
+else
+  # start the server with the specified profile and provided startup arguments
+  sh ${WSO2_SERVER_HOME}/bin/api-manager.sh -Dprofile=${PROFILE_NAME} "$@"
+fi

--- a/resources/k8s-artifacts/apim/apim-deployment.yaml
+++ b/resources/k8s-artifacts/apim/apim-deployment.yaml
@@ -40,7 +40,7 @@ spec:
             - "wso2apim"
       containers:
         - name: wso2apim
-          image: wso2am/wso2am:4.2.0-rc1-alpine
+          image: wso2/wso2am:4.2.0
           resources:
             limits:
               memory: "2Gi"


### PR DESCRIPTION
### Purpose
$subject
APIM RC docker image will bot available in DockerHub, hence users have to download the APIM 4.2.0 from WSO2 website and copy it to the following location of the Choreo Connect distribution.

```
<Distribution Location>/docker-compose/choreo-connect-with-apim/dockerfiles/apim/wso2am-4.2.0.zip
```

And start the docker compose as usual.

For kubernetes try out, users have to first run the following command and build the APIM docker image.
```
docker-compose -f <Distribution Location>/docker-compose/choreo-connect-with-apim/docker-compose.yaml  build apim 
```

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
Mac ARM64 - Docker Compose

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
