### PR TITLE
[Choreo] Fix for rate-limiter unlimited value

### DIFF
--- a/adapter/internal/discovery/xds/rate_limiter_cache.go
+++ b/adapter/internal/discovery/xds/rate_limiter_cache.go
@@ -145,6 +145,20 @@ func (r *rateLimitPolicyCache) AddAPILevelRateLimitPolicies(apiID string, mgwSwa
 				rlsConfigs = append(rlsConfigs, rlsConfig)
 			}
 		}
+	} else if level == envoyconf.RateLimitDisabled {
+		rlsConfigs = []*rls_config.RateLimitDescriptor{
+			{
+				Key:   envoyconf.DescriptorKeyForPath,
+				Value: mgwSwagger.GetXWso2Basepath(),
+				Descriptors: []*rls_config.RateLimitDescriptor{
+					{
+						Key:       envoyconf.DescriptorKeyForMethod,
+						Value:     envoyconf.DescriptorValueForAPIMethod,
+						RateLimit: nil,
+					},
+				},
+			},
+		}
 	} else {
 		return fmt.Errorf("invalid rate limit policy level: %q", level)
 	}

--- a/adapter/internal/discovery/xds/rate_limiter_cache.go
+++ b/adapter/internal/discovery/xds/rate_limiter_cache.go
@@ -63,7 +63,7 @@ type rateLimitPolicyCache struct {
 
 // AddAPILevelRateLimitPolicies adds inline Rate Limit policies in APIs to be updated in the Rate Limiter service.
 func (r *rateLimitPolicyCache) AddAPILevelRateLimitPolicies(apiID string, mgwSwagger *mgw.MgwSwagger, policies map[string]*mgw.APIRateLimitPolicy) error {
-	if mgwSwagger.RateLimitLevel == "" || mgwSwagger.RateLimitLevel == envoyconf.RateLimitDisabled {
+	if mgwSwagger.RateLimitLevel == "" || mgwSwagger.RateLimitLevel == envoyconf.Unlimited {
 		return nil
 	}
 	level := strings.ToUpper(mgwSwagger.RateLimitLevel)

--- a/adapter/internal/discovery/xds/rate_limiter_cache_test.go
+++ b/adapter/internal/discovery/xds/rate_limiter_cache_test.go
@@ -85,6 +85,7 @@ func testAddAPILevelRateLimitPolicies(t *testing.T) {
 		"5000PerMin":    {PolicyName: "5000PerMin", Count: 5000, SpanUnit: "MINUTE"},
 		"2000PerMin":    {PolicyName: "2000PerMin", Count: 2000, SpanUnit: "MINUTE"},
 		"100000PerHOUR": {PolicyName: "100000PerHOUR", Count: 100000, SpanUnit: "HOUR"},
+		"UNLIMITED":     {PolicyName: "UNLIMITED", Count: -1, SpanUnit: "MINUTE"},
 	}
 
 	tests := []struct {
@@ -157,9 +158,9 @@ func testAddAPILevelRateLimitPolicies(t *testing.T) {
 		},
 		{
 			// Note: Each test case is depend on the earlier test cases
-			desc:         "Add an API with no Rate Limit policies",
+			desc:         "Add an API with no Rate Limit policies (Unlimited)",
 			apiID:        "vhost1:API4",
-			mgwSwagger:   getDummyAPISwagger("4", "", "", "", "", "", ""),
+			mgwSwagger:   getDummyAPISwagger("4", envoyconf.RateLimitDisabled, "UNLIMITED", "", "", "", ""),
 			policies:     rateLimitPolicies,
 			expectsError: false,
 			apiLevelRateLimitPolicies: map[string]map[string]map[string][]*rls_config.RateLimitDescriptor{
@@ -351,9 +352,9 @@ func testDeleteAPILevelRateLimitPolicies(t *testing.T) {
 		},
 		{
 			desc:  "Delete API in an Org that has no APIs with rate limits",
-			org:   "org4",
+			org:   "org1",
 			vHost: "vhost1",
-			apiID: "vhost1:API5",
+			apiID: "vhost1:API4",
 			apiLevelRateLimitPolicies: map[string]map[string]map[string][]*rls_config.RateLimitDescriptor{
 				"org1": {"vhost1": {}},
 			},

--- a/adapter/internal/discovery/xds/rate_limiter_cache_test.go
+++ b/adapter/internal/discovery/xds/rate_limiter_cache_test.go
@@ -160,7 +160,7 @@ func testAddAPILevelRateLimitPolicies(t *testing.T) {
 			// Note: Each test case is depend on the earlier test cases
 			desc:         "Add an API with no Rate Limit policies (Unlimited)",
 			apiID:        "vhost1:API4",
-			mgwSwagger:   getDummyAPISwagger("4", envoyconf.RateLimitDisabled, "UNLIMITED", "", "", "", ""),
+			mgwSwagger:   getDummyAPISwagger("4", envoyconf.Unlimited, "UNLIMITED", "", "", "", ""),
 			policies:     rateLimitPolicies,
 			expectsError: false,
 			apiLevelRateLimitPolicies: map[string]map[string]map[string][]*rls_config.RateLimitDescriptor{

--- a/adapter/internal/discovery/xds/server.go
+++ b/adapter/internal/discovery/xds/server.go
@@ -442,7 +442,7 @@ func UpdateAPI(vHost string, apiProject mgw.ProjectAPI, environments []string) (
 			return nil, err
 		}
 
-		if mgwSwagger.RateLimitLevel == envoyconf.RateLimitDisabled {
+		if mgwSwagger.RateLimitLevel == envoyconf.Unlimited {
 			rlsPolicyCache.DeleteAPILevelRateLimitPolicies(mgwSwagger.OrganizationID, mgwSwagger.VHost, apiIdentifier)
 		}
 	}

--- a/adapter/internal/oasparser/envoyconf/constants.go
+++ b/adapter/internal/oasparser/envoyconf/constants.go
@@ -140,4 +140,5 @@ const (
 	RateLimiterDomain                    = "Default"
 	RateLimitPolicyOperationLevel string = "OPERATION"
 	RateLimitPolicyAPILevel       string = "API"
+	RateLimitDisabled             string = "UNLIMITED"
 )

--- a/adapter/internal/oasparser/envoyconf/constants.go
+++ b/adapter/internal/oasparser/envoyconf/constants.go
@@ -140,5 +140,5 @@ const (
 	RateLimiterDomain                    = "Default"
 	RateLimitPolicyOperationLevel string = "OPERATION"
 	RateLimitPolicyAPILevel       string = "API"
-	RateLimitDisabled             string = "Unlimited"
+	Unlimited                     string = "UNLIMITED"
 )

--- a/adapter/internal/oasparser/envoyconf/constants.go
+++ b/adapter/internal/oasparser/envoyconf/constants.go
@@ -140,5 +140,5 @@ const (
 	RateLimiterDomain                    = "Default"
 	RateLimitPolicyOperationLevel string = "OPERATION"
 	RateLimitPolicyAPILevel       string = "API"
-	RateLimitDisabled             string = "UNLIMITED"
+	RateLimitDisabled             string = "Unlimited"
 )

--- a/adapter/internal/oasparser/model/api_yaml.go
+++ b/adapter/internal/oasparser/model/api_yaml.go
@@ -116,7 +116,7 @@ func getRateLimitPolicy(throttlingLimit ThrottlingLimit) APIRateLimitPolicy {
 	policyName := GetRLPolicyName(throttlingLimit.RequestCount, throttlingLimit.Unit)
 	var rlType string = "REQUEST_COUNT"
 	rlPolicy.PolicyName = policyName
-	rlPolicy.Count = uint32(throttlingLimit.RequestCount)
+	rlPolicy.Count = throttlingLimit.RequestCount
 	rlPolicy.Type = rlType
 	rlPolicy.Span = 1
 	rlPolicy.SpanUnit = throttlingLimit.Unit

--- a/adapter/internal/oasparser/model/api_yaml.go
+++ b/adapter/internal/oasparser/model/api_yaml.go
@@ -125,6 +125,9 @@ func getRateLimitPolicy(throttlingLimit ThrottlingLimit) APIRateLimitPolicy {
 
 // GetRLPolicyName from throttlingLimit fields
 func GetRLPolicyName(requestCount int, unit string) string {
+	if requestCount == -1 {
+		return ""
+	}
 	caser := cases.Title(language.English)
 	return strconv.Itoa(requestCount) + "Per" + caser.String(strings.ToLower(unit))
 }

--- a/adapter/internal/oasparser/model/api_yaml_test.go
+++ b/adapter/internal/oasparser/model/api_yaml_test.go
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ func TestExtractAPIRateLimitPolicies(t *testing.T) {
 	assert.Equal(t, 1, len(apiProjectWithOperationLimit.RateLimitPolicies))
 	assert.Equal(t, policyName, apiProjectWithOperationLimit.RateLimitPolicies[policyName].PolicyName)
 	assert.Equal(t, "REQUEST_COUNT", apiProjectWithOperationLimit.RateLimitPolicies[policyName].Type)
-	assert.Equal(t, uint32(10), apiProjectWithOperationLimit.RateLimitPolicies[policyName].Count)
+	assert.Equal(t, 10, apiProjectWithOperationLimit.RateLimitPolicies[policyName].Count)
 	assert.Equal(t, "MINUTE", apiProjectWithOperationLimit.RateLimitPolicies[policyName].SpanUnit)
 	assert.Equal(t, uint32(1), apiProjectWithOperationLimit.RateLimitPolicies[policyName].Span)
 
@@ -89,7 +89,7 @@ func TestExtractAPIRateLimitPolicies(t *testing.T) {
 	assert.Equal(t, 1, len(apiProjectWithOperationLimit.RateLimitPolicies))
 	assert.Equal(t, policyName, apiProjectWithOperationLimit.RateLimitPolicies[apiPolicyName].PolicyName)
 	assert.Equal(t, "REQUEST_COUNT", apiProjectWithOperationLimit.RateLimitPolicies[apiPolicyName].Type)
-	assert.Equal(t, uint32(10), apiProjectWithOperationLimit.RateLimitPolicies[apiPolicyName].Count)
+	assert.Equal(t, 10, apiProjectWithOperationLimit.RateLimitPolicies[apiPolicyName].Count)
 	assert.Equal(t, "MINUTE", apiProjectWithOperationLimit.RateLimitPolicies[apiPolicyName].SpanUnit)
 	assert.Equal(t, uint32(1), apiProjectWithOperationLimit.RateLimitPolicies[apiPolicyName].Span)
 }

--- a/adapter/internal/oasparser/model/mgw_swagger.go
+++ b/adapter/internal/oasparser/model/mgw_swagger.go
@@ -1235,7 +1235,12 @@ func (swagger *MgwSwagger) PopulateSwaggerFromAPIYaml(apiData APIYaml, apiType s
 		if data.ThrottlingLimit.Unit != "" {
 			logger.LoggerOasparser.Debugf("API level throttling limit found. Request count: %v, Unit: %v",
 				data.ThrottlingLimit.RequestCount, data.ThrottlingLimit.Unit)
-			swagger.RateLimitLevel = "API"
+			if data.ThrottlingLimit.RequestCount != -1 {
+				swagger.RateLimitLevel = "API"
+			} else {
+				logger.LoggerOasparser.Debug("Rate-limiting disabled for the API.")
+				swagger.RateLimitLevel = "UNLIMITED"
+			}
 			swagger.RateLimitPolicy = GetRLPolicyName(data.ThrottlingLimit.RequestCount, data.ThrottlingLimit.Unit)
 		} else {
 			logger.LoggerOasparser.Debug("API level throttling limit not found. Setting throttling policy level as 'Operation Level'")

--- a/adapter/internal/oasparser/model/mgw_swagger.go
+++ b/adapter/internal/oasparser/model/mgw_swagger.go
@@ -434,10 +434,10 @@ func (swagger *MgwSwagger) SetRateLimitPoliciesForOperations(apiYamlOperations [
 func createOperationRateLimitDataMap(apiYamlOperations []OperationYaml) map[string]string {
 	m := make(map[string]string)
 	for _, operation := range apiYamlOperations {
-		keyValue := operation.Target + operation.Verb
 		if operation.ThrottlingLimit.Unit == "" && operation.ThrottlingLimit.RequestCount == 0 {
 			continue
 		}
+		keyValue := operation.Target + operation.Verb
 		m[keyValue] = GetRLPolicyName(operation.ThrottlingLimit.RequestCount, operation.ThrottlingLimit.Unit)
 	}
 	return m

--- a/adapter/internal/oasparser/model/types.go
+++ b/adapter/internal/oasparser/model/types.go
@@ -180,7 +180,7 @@ type ThrottlingLimit struct {
 type APIRateLimitPolicy struct {
 	PolicyName string `json:"policyName,omitempty"`
 	Type       string `json:"type,omitempty"`
-	Count      uint32 `json:"count,omitempty"`
+	Count      int    `json:"count,omitempty"`
 	Unit       string `json:"unit,omitempty"`
 	Span       uint32 `json:"span,omitempty"`
 	SpanUnit   string `json:"spanUnit,omitempty"`

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/standalone/CcWithJwtConfigAndTransformer.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/setup/standalone/CcWithJwtConfigAndTransformer.java
@@ -41,11 +41,14 @@ public class CcWithJwtConfigAndTransformer {
                 null, null, null, "ratelimit_api.yaml");
         ApictlUtils.createProject("operation_level_ratelimit_openAPI.yaml", "ratelimit_operation_level_test",
                 null, null, null, "operation_level_ratelimit_api.yaml");
+        ApictlUtils.createProject("api_level_without_ratelimit_openAPI.yaml", "api_level_without_ratelimit_test",
+                null, null, null, "api_level_without_ratelimit_api.yaml");
         Utils.delay(10000, "Could not wait till project creation.");
 
         ApictlUtils.deployAPI("petstore", "test");
         ApictlUtils.deployAPI("ratelimit_test", "test");
         ApictlUtils.deployAPI("ratelimit_operation_level_test", "test");
+        ApictlUtils.deployAPI("api_level_without_ratelimit_test", "test");
         Utils.delay(5000, "Could not wait till initial setup completion.");
     }
 

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/ratelimit/APILevelWithoutRateLimitTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/ratelimit/APILevelWithoutRateLimitTestCase.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.choreo.connect.tests.testcases.standalone.ratelimit;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.am.integration.test.utils.http.HTTPSClientUtils;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+import org.wso2.choreo.connect.tests.common.model.API;
+import org.wso2.choreo.connect.tests.common.model.ApplicationDTO;
+import org.wso2.choreo.connect.tests.util.TestConstant;
+import org.wso2.choreo.connect.tests.util.TokenUtil;
+import org.wso2.choreo.connect.tests.util.Utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class APILevelWithoutRateLimitTestCase {
+    private String testKey;
+    private String endpointURL;
+    private Map<String, String> headers = new HashMap<>();
+
+    @BeforeClass
+    public void createApiProject() throws Exception {
+        API api = new API();
+        api.setName("apiLevelWithoutRatelimit");
+        api.setContext("v2/apiLevelWithoutRateLimit");
+        api.setVersion("1.0.0");
+        api.setProvider("admin");
+
+        ApplicationDTO applicationDto = new ApplicationDTO();
+        applicationDto.setName("jwtApp");
+        applicationDto.setTier("Unlimited");
+        applicationDto.setId((int) (Math.random() * 1000));
+
+        testKey = TokenUtil.getJWT(api, applicationDto, "Unlimited", TestConstant.KEY_TYPE_PRODUCTION,
+                3600, null, true);
+        endpointURL = Utils.getServiceURLHttps("/v2/apiLevelWithoutRateLimit/pet/3");
+        headers.put("Internal-Key", testKey);
+    }
+
+    @Test(description = "Test rate-limiting headers with envoy rate-limit service")
+    public void testRateLimitingHeadersWithEnvoyRateLimitService() throws Exception {
+        HttpResponse response = HTTPSClientUtils.doGet(endpointURL, headers);
+        Map<String,String> responseHeadersMap = response.getHeaders();
+        Assert.assertTrue(!responseHeadersMap.containsKey("x-ratelimit-limit"), "x-ratelimit-limit available");
+        Assert.assertTrue(!responseHeadersMap.containsKey("x-ratelimit-reset"), "x-ratelimit-reset available");
+        Assert.assertTrue(!responseHeadersMap.containsKey("x-ratelimit-remaining"), "x-ratelimit-remaining header available");
+    }
+}

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/ratelimit/APILevelWithoutRateLimitTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/ratelimit/APILevelWithoutRateLimitTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org).
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -56,12 +56,12 @@ public class APILevelWithoutRateLimitTestCase {
         headers.put("Internal-Key", testKey);
     }
 
-    @Test(description = "Test rate-limiting headers with envoy rate-limit service")
+    @Test(description = "Test rate-limiting disabled scenario")
     public void testRateLimitingHeadersWithEnvoyRateLimitService() throws Exception {
         HttpResponse response = HTTPSClientUtils.doGet(endpointURL, headers);
         Map<String,String> responseHeadersMap = response.getHeaders();
-        Assert.assertTrue(!responseHeadersMap.containsKey("x-ratelimit-limit"), "x-ratelimit-limit available");
-        Assert.assertTrue(!responseHeadersMap.containsKey("x-ratelimit-reset"), "x-ratelimit-reset available");
+        Assert.assertTrue(!responseHeadersMap.containsKey("x-ratelimit-limit"), "x-ratelimit-limit header available");
+        Assert.assertTrue(!responseHeadersMap.containsKey("x-ratelimit-reset"), "x-ratelimit-reset header available");
         Assert.assertTrue(!responseHeadersMap.containsKey("x-ratelimit-remaining"), "x-ratelimit-remaining header available");
     }
 }

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/ratelimit/OperationLevelRatelimitTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/ratelimit/OperationLevelRatelimitTestCase.java
@@ -80,9 +80,12 @@ public class OperationLevelRatelimitTestCase {
     }
 
     @Test(description = "Test an operation without defining envoy rate-limits")
-    public void testResourceWithoutEnvoyRateLimits() throws Exception {
+    public void testOperationWithoutEnvoyRateLimits() throws Exception {
         String endpointURL = Utils.getServiceURLHttps("/v2/operationLevelRL/pets/findByTags");
-        Assert.assertFalse(RateLimitUtils.isThrottled(RateLimitUtils.sendMultipleRequests(
-                endpointURL, headers, 10)), "Rate-limit applied to a rate-limit level undefined operation.");
+        HttpResponse response = HttpsClientRequest.doGet(endpointURL, headers);
+        Map<String,String> responseHeadersMap = response.getHeaders();
+        Assert.assertTrue(!responseHeadersMap.containsKey("x-ratelimit-limit"), "x-ratelimit-limit header available");
+        Assert.assertTrue(!responseHeadersMap.containsKey("x-ratelimit-reset"), "x-ratelimit-reset header available");
+        Assert.assertTrue(!responseHeadersMap.containsKey("x-ratelimit-remaining"), "x-ratelimit-remaining header available");
     }
 }

--- a/integration/test-integration/src/test/resources/apiYaml/api_level_without_ratelimit_api.yaml
+++ b/integration/test-integration/src/test/resources/apiYaml/api_level_without_ratelimit_api.yaml
@@ -1,0 +1,96 @@
+type: api
+version: v4.1.0
+data:
+  id: 2b547d7c-4f7b-4f31-ad6b-05b4960dccc
+  name: apiLevelWithoutRatelimit
+  context: /v2/apiLevelWithoutRateLimit
+  version: 1.0.0
+  throttlingLimit:
+    requestCount: -1
+    unit: MINUTE
+  provider: admin
+  lifeCycleStatus: PUBLISHED
+  responseCachingEnabled: false
+  cacheTimeout: 300
+  hasThumbnail: false
+  isDefaultVersion: false
+  isRevision: false
+  revisionId: 0
+  enableSchemaValidation: false
+  type: HTTP
+  transport:
+    - http
+    - https
+  tags: []
+  authorizationHeader: Authorization
+  securityScheme:
+    - oauth2
+    - oauth_basic_auth_api_key_mandatory
+  visibility: PUBLIC
+  visibleRoles: []
+  visibleTenants: []
+  mediationPolicies: []
+  subscriptionAvailability: CURRENT_TENANT
+  subscriptionAvailableTenants: []
+  additionalProperties: []
+  additionalPropertiesMap: {}
+  accessControl: NONE
+  accessControlRoles: []
+  businessInformation: {}
+  corsConfiguration:
+    corsConfigurationEnabled: false
+    accessControlAllowOrigins:
+      - '*'
+    accessControlAllowCredentials: false
+    accessControlAllowHeaders:
+      - authorization
+      - Access-Control-Allow-Origin
+      - Content-Type
+      - SOAPAction
+      - apikey
+      - Internal-Key
+    accessControlAllowMethods:
+      - GET
+      - PUT
+      - POST
+      - DELETE
+      - PATCH
+      - OPTIONS
+  websubSubscriptionConfiguration:
+    enable: false
+    secret: ""
+    signingAlgorithm: SHA1
+    signatureHeader: x-hub-signature
+  createdTime: "1667890908062"
+  lastUpdatedTime: 2022-11-08 12:31:51.42
+  endpointConfig:
+    endpoint_type: http
+    sandbox_endpoints:
+      url: http://mockBackend:2383/v2
+    production_endpoints:
+      url: http://mockBackend:2383/v2
+  endpointImplementationType: ENDPOINT
+  scopes: []
+  operations:
+    -
+      id: ""
+      target: /pet/{petId}
+      verb: GET
+      authType: Application & Application User
+      scopes: []
+      usedProductIds: []
+      operationPolicies:
+        request: []
+        response: []
+        fault: []
+  categories: []
+  keyManagers:
+    - all
+  advertiseInfo:
+    advertised: false
+    apiOwner: admin
+    vendor: WSO2
+  gatewayVendor: wso2
+  gatewayType: wso2/synapse
+  asyncTransportProtocols: []
+  organizationId: carbon.super

--- a/integration/test-integration/src/test/resources/apiYaml/operation_level_ratelimit_api.yaml
+++ b/integration/test-integration/src/test/resources/apiYaml/operation_level_ratelimit_api.yaml
@@ -83,20 +83,8 @@ data:
         request: []
         response: []
         fault: []
-    -
-      id: ""
-      target: /pet/{petId}
-      verb: GET
-      authType: Application & Application User
-      scopes: []
-      usedProductIds: []
-      throttlingLimit:
-        requestCount: 3
-        unit: MINUTE
-      operationPolicies:
-        request: []
-        response: []
-        fault: []
+    # By placing this POST operation before the GET /pet/{petId} covers the applying of
+    # UNLIMITED throttling policy in combination with other throttling policies.
     -
       id: ""
       target: /pet/{petId}
@@ -106,6 +94,20 @@ data:
       usedProductIds: []
       throttlingLimit:
         requestCount: -1
+        unit: MINUTE
+      operationPolicies:
+        request: []
+        response: []
+        fault: []
+    -
+      id: ""
+      target: /pet/{petId}
+      verb: GET
+      authType: Application & Application User
+      scopes: []
+      usedProductIds: []
+      throttlingLimit:
+        requestCount: 3
         unit: MINUTE
       operationPolicies:
         request: []

--- a/integration/test-integration/src/test/resources/openAPIs/api_level_without_ratelimit_openAPI.yaml
+++ b/integration/test-integration/src/test/resources/openAPIs/api_level_without_ratelimit_openAPI.yaml
@@ -1,0 +1,72 @@
+swagger: '2.0'
+info:
+  description: 'This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.'
+  version: 1.0.0
+  title: apiLevelWithoutRateLimit
+x-wso2-cors:
+  accessControlAllowOrigins:
+    - http://test1.com
+    - http://test2.com
+  accessControlAllowHeaders:
+    - Authorization
+    - X-PINGOTHER
+  accessControlAllowMethods:
+    - GET
+    - PUT
+    - POST
+  accessControlAllowCredentials: true
+host: 'mockBackend:2383'
+x-wso2-production-endpoints:
+  urls:
+    - 'http://mockBackend:2383/v2'
+x-wso2-endpoints:
+  - myDynamicEndpoint:
+      urls:
+        - http://mockBackend:2390/v2 # same base path as x-wso2-production-endpoints
+      type: loadbalance
+x-wso2-basePath: /v2/apiLevelWithoutRateLimit
+schemes:
+  - http
+paths:
+  '/pet/{petId}':
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+securityDefinitions:
+  api_key:
+    type: apiKey
+    name: api_key
+    in: header
+  petstore_auth:
+    type: oauth2
+    authorizationUrl: 'http://mockBackend:2380/oauth/authorize'
+    flow: implicit
+    scopes:
+      'read:pets': read your pets
+      'write:pets': modify pets in your account

--- a/integration/test-integration/src/test/resources/testng-cc-standalone.xml
+++ b/integration/test-integration/src/test/resources/testng-cc-standalone.xml
@@ -85,6 +85,7 @@
             <class name="org.wso2.choreo.connect.tests.setup.standalone.CcWithJwtConfigAndTransformer"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.jwtGenerator.CustomJwtTransformerTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.filter.CustomFilterTestCase"/>
+            <class name="org.wso2.choreo.connect.tests.testcases.standalone.ratelimit.APILevelWithoutRateLimitTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.ratelimit.ApiLevelRatelimitTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.ratelimit.OperationLevelRatelimitTestCase"/>
             <class name="org.wso2.choreo.connect.tests.testcases.standalone.ratelimit.RateLimiterXdsTestCase"/>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
             <modules>
                 <module>adapter</module>
                 <module>enforcer-parent</module>
+                <module>rate-limiter</module>
                 <module>distribution</module>
                 <module>integration</module>
             </modules>

--- a/resources/conf/config.toml
+++ b/resources/conf/config.toml
@@ -19,6 +19,17 @@
   securedListenerPort = 9095
   systemHost = "localhost"
 
+[router.ratelimit]
+  enabled = true
+  host = "rate-limiter"
+  port = 8091
+  requestTimeoutInMillis= 80
+  failureModeDeny = false
+  keyFilePath = "/home/wso2/security/keystore/mg.key"
+  certFilePath = "/home/wso2/security/keystore/mg.pem"
+  caCertFilePath = "/home/wso2/security/truststore/rate-limiter.pem"
+  sSLCertSANHostname = ""
+
 [router.keystore]
   certPath = "/home/wso2/security/keystore/mg.pem"
   keyPath = "/home/wso2/security/keystore/mg.key"

--- a/resources/conf/config.toml
+++ b/resources/conf/config.toml
@@ -21,14 +21,6 @@
 
 [router.ratelimit]
   enabled = true
-  host = "rate-limiter"
-  port = 8091
-  requestTimeoutInMillis= 80
-  failureModeDeny = false
-  keyFilePath = "/home/wso2/security/keystore/mg.key"
-  certFilePath = "/home/wso2/security/keystore/mg.pem"
-  caCertFilePath = "/home/wso2/security/truststore/rate-limiter.pem"
-  sSLCertSANHostname = ""
 
 [router.keystore]
   certPath = "/home/wso2/security/keystore/mg.pem"

--- a/resources/k8s-artifacts/choreo-connect/config-toml-configmap.yaml
+++ b/resources/k8s-artifacts/choreo-connect/config-toml-configmap.yaml
@@ -58,6 +58,9 @@ data:
       verifyHostName = true
       disableSslVerification = false
 
+    [router.ratelimit]
+      enabled = true
+
     [enforcer]
     [enforcer.jwtIssuer]
       enabled = true
@@ -103,4 +106,3 @@ data:
 
     [enforcer.metrics]
       enabled = false
-


### PR DESCRIPTION
### Purpose
Fixes the request count value assigning for the Unlimited value in rate-limiter.

```
{
        "id": "",
        "target": "/*",
        "verb": "GET",
        "throttlingLimit": {
          "requestCount": -1,
          "unit": "MINUTE"
        },
        "authType": "Application \u0026 Application User",
        "scopes": [],
        "usedProductId

```

rate-limiter config value :

```
choreo-connect %  curl http://localhost:6070/rlconfig -i                         
HTTP/1.1 200 OK
Date: Fri, 10 Mar 2023 12:19:57 GMT
Content-Length: 0

```
 



### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2/product-microgateway/issues/3290

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
