### PR TITLE
Update analytics publisher client version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -615,7 +615,7 @@
         <apictl.version>4.0.0</apictl.version>
         <apim.version>4.0.0</apim.version>
         <grpc.healthProbe.version>0.4.16</grpc.healthProbe.version>
-        <analytics.publisher.client.version>1.1.4</analytics.publisher.client.version>
+        <analytics.publisher.client.version>1.2.2</analytics.publisher.client.version>
         <awaitility.version>4.2.0</awaitility.version>
         <apache.httpcomponents.version>4.5.14</apache.httpcomponents.version>
         <jackson.databind.version>2.14.1</jackson.databind.version>

--- a/pom.xml
+++ b/pom.xml
@@ -587,7 +587,7 @@
         <io.netty.version>4.1.87.Final</io.netty.version>
         <jaeger.exporter.version>1.6.0</jaeger.exporter.version>
         <java.websocket.version>1.5.1</java.websocket.version>
-        <json.smart.version>2.4.7</json.smart.version>
+        <json.smart.version>2.4.9</json.smart.version>
         <junit.version>4.13.2</junit.version>
         <log4j.version>2.17.1</log4j.version>
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>


### PR DESCRIPTION
### Purpose
This will update the analytics publisher client version to 1.2.2

### Issues
Related with https://github.com/wso2-enterprise/choreo/issues/19544
