### PR TITLE
Global cache for JWKS

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/AuthFilter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/AuthFilter.java
@@ -98,7 +98,7 @@ public class AuthFilter implements Filter {
 
         // TODO: Set authenticators for isMutualSSLProtected, isBasicAuthProtected
         if (isOAuthProtected) {
-            Authenticator jwtAuthenticator = new JWTAuthenticator(jwksMap);
+            Authenticator jwtAuthenticator = new JWTAuthenticator();
             authenticators.add(jwtAuthenticator);
         }
 

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/AuthFilter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/AuthFilter.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.choreo.connect.enforcer.security;
 
-import com.nimbusds.jose.jwk.JWKSet;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -47,7 +46,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This is the filter handling the authentication for the requests flowing through the gateway.
@@ -55,8 +53,6 @@ import java.util.concurrent.ConcurrentHashMap;
 public class AuthFilter implements Filter {
     private List<Authenticator> authenticators = new ArrayList<>();
     private static final Logger log = LogManager.getLogger(AuthFilter.class);
-
-    private static ConcurrentHashMap<String, JWKSet> jwksMap = new ConcurrentHashMap<>();
 
     @Override
     public void init(APIConfig apiConfig, Map<String, String> configProperties) {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/AuthFilter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/AuthFilter.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.choreo.connect.enforcer.security;
 
+import com.nimbusds.jose.jwk.JWKSet;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -46,6 +47,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This is the filter handling the authentication for the requests flowing through the gateway.
@@ -53,6 +55,8 @@ import java.util.Objects;
 public class AuthFilter implements Filter {
     private List<Authenticator> authenticators = new ArrayList<>();
     private static final Logger log = LogManager.getLogger(AuthFilter.class);
+
+    private static ConcurrentHashMap<String, JWKSet> jwksMap = new ConcurrentHashMap<>();
 
     @Override
     public void init(APIConfig apiConfig, Map<String, String> configProperties) {
@@ -94,7 +98,7 @@ public class AuthFilter implements Filter {
 
         // TODO: Set authenticators for isMutualSSLProtected, isBasicAuthProtected
         if (isOAuthProtected) {
-            Authenticator jwtAuthenticator = new JWTAuthenticator();
+            Authenticator jwtAuthenticator = new JWTAuthenticator(jwksMap);
             authenticators.add(jwtAuthenticator);
         }
 

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
@@ -74,7 +74,7 @@ import java.util.UUID;
 public class JWTAuthenticator implements Authenticator {
 
     private static final Logger log = LogManager.getLogger(JWTAuthenticator.class);
-    private final JWTValidator jwtValidator;
+    private final JWTValidator jwtValidator = new JWTValidator();
     private final boolean isGatewayTokenCacheEnabled;
     private AbstractAPIMgtGatewayJWTGenerator jwtGenerator;
 
@@ -88,7 +88,6 @@ public class JWTAuthenticator implements Authenticator {
         }
         this.choreoGatewayEnv = APIConstants.JwtTokenConstants.ENV_NAME_PREFIX
                 + ConfigHolder.getInstance().getEnvVarConfig().getEnforcerLabel();
-        this.jwtValidator = new JWTValidator();
     }
 
     @Override

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
@@ -82,7 +82,7 @@ public class JWTAuthenticator implements Authenticator {
 
     private final String choreoGatewayEnv;
 
-    public JWTAuthenticator(ConcurrentHashMap<String, JWKSet> jwksMap) {
+    public JWTAuthenticator() {
         EnforcerConfig enforcerConfig = ConfigHolder.getInstance().getConfig();
         this.isGatewayTokenCacheEnabled = enforcerConfig.getCacheDto().isEnabled();
         if (enforcerConfig.getJwtConfigurationDto().isEnabled()) {
@@ -90,7 +90,7 @@ public class JWTAuthenticator implements Authenticator {
         }
         this.choreoGatewayEnv = APIConstants.JwtTokenConstants.ENV_NAME_PREFIX
                 + ConfigHolder.getInstance().getEnvVarConfig().getEnforcerLabel();
-        this.jwtValidator = new JWTValidator(jwksMap);
+        this.jwtValidator = new JWTValidator();
     }
 
     @Override

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.choreo.connect.enforcer.security.jwt;
 
-import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.util.DateUtils;
 import io.opentelemetry.context.Scope;
@@ -67,7 +66,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 
 /**

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/validator/JWTValidator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/validator/JWTValidator.java
@@ -55,11 +55,9 @@ public class JWTValidator {
     private static final Logger logger = LogManager.getLogger(JWTValidator.class);
     private JWTTransformer jwtTransformer;
     private JWKSet jwkSet;
-    private final ConcurrentHashMap<String, JWKSet> jwksMap;
+    private static final ConcurrentHashMap<String, JWKSet> jwksMap = new ConcurrentHashMap<>();
 
-    public JWTValidator(ConcurrentHashMap<String, JWKSet> jwksMap) {
-        this.jwksMap = jwksMap;
-    }
+    public JWTValidator() {}
 
 
     public JWTValidationInfo validateJWTToken(SignedJWTInfo signedJWTInfo) throws EnforcerException {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/validator/JWTValidator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/validator/JWTValidator.java
@@ -121,7 +121,8 @@ public class JWTValidator {
             if (StringUtils.isNotEmpty(keyID)) {
                 if (tokenIssuer.getJwksConfigurationDTO().isEnabled() && StringUtils
                         .isNotEmpty(jwksUrl)) {
-                    // Check JWKSet Available in Cache 
+                    // Check JWKSet Available in Cache
+                    // jwkSet is maintained to reduce the performance impact of using a concurrent hashmap
                     if (jwkSet == null) {
                         if (jwksMap.containsKey(jwksUrl)) {
                             jwkSet = jwksMap.get(jwksUrl);


### PR DESCRIPTION
### Purpose

Reduce calls to JWKS endpoint  for Access token validation by caching all JWKS objects against their url. Before making a jwks call to a specific url we check the JWKS cache and try verify if it has the needed public key, otherwise we make the call.


### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->

### Automation tests
 - Unit tests added: No
 - Integration tests added: No
### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [ ] Assigned the project
- [x] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
