### PR TITLE
Include the original vhost in access logs

### DIFF
--- a/adapter/internal/oasparser/envoyconf/access_loggers.go
+++ b/adapter/internal/oasparser/envoyconf/access_loggers.go
@@ -18,6 +18,8 @@
 package envoyconf
 
 import (
+	"strings"
+
 	config_access_logv3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	file_accesslogv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
@@ -46,7 +48,8 @@ func getFileAccessLogConfigs() *config_access_logv3.AccessLog {
 			Format: &corev3.SubstitutionFormatString_TextFormatSource{
 				TextFormatSource: &corev3.DataSource{
 					Specifier: &corev3.DataSource_InlineString{
-						InlineString: logConf.AccessLogs.Format,
+						InlineString: logConf.AccessLogs.ReservedLogFormat +
+							strings.TrimLeft(logConf.AccessLogs.SecondaryLogFormat, "'") + "\n",
 					},
 				},
 			},

--- a/adapter/pkg/config/log_types.go
+++ b/adapter/pkg/config/log_types.go
@@ -25,7 +25,11 @@ type pkg struct {
 type accessLog struct {
 	Enable  bool
 	LogFile string
-	Format  string
+	// ReservedLogFormat is reserved for Choreo Gateway Access Logs Observability feature. Changes to this may
+	// break the functionality in the observability feature.
+	ReservedLogFormat string
+	// SecondaryLogFormat can be used by dev to log properties for debug purposes
+	SecondaryLogFormat string
 }
 
 // LogConfig represents the configurations related to adapter logs and envoy access logs.
@@ -53,9 +57,13 @@ func getDefaultLogConfig() *LogConfig {
 		AccessLogs: &accessLog{
 			Enable:  false,
 			LogFile: "/dev/stdout",
-			Format: "[%START_TIME%] '%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%' %RESPONSE_CODE% " +
-				"%RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%" +
-				"'%REQ(X-FORWARDED-FOR)%' '%REQ(USER-AGENT)%' '%REQ(X-REQUEST-ID)%' '%REQ(:AUTHORITY)%' '%UPSTREAM_HOST%'\n",
+			ReservedLogFormat: "[%START_TIME%]' '%DYNAMIC_METADATA(envoy.filters.http.ext_authz:originalHost)%' " +
+				"'%REQ(:AUTHORITY)%' '%REQ(:METHOD)%' '%DYNAMIC_METADATA(envoy.filters.http.ext_authz:originalPath)%' " +
+				"'%REQ(:PATH)%' '%PROTOCOL%' '%RESPONSE_CODE%' '%RESPONSE_CODE_DETAILS%' '%RESPONSE_FLAGS%' '%REQ(USER-AGENT)%' " +
+				"'%REQ(X-REQUEST-ID)%' '%REQ(X-FORWARDED-FOR)%' '%UPSTREAM_HOST%' '%BYTES_RECEIVED%' '%BYTES_SENT%' '%DURATION%' " +
+				"'%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%' '%REQUEST_TX_DURATION%' '%RESPONSE_TX_DURATION%' '%REQUEST_DURATION%' " +
+				"'%RESPONSE_DURATION%' '",
+			SecondaryLogFormat: "",
 		},
 	}
 	adapterLogConfig.Rotation.MaxSize = 10

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/RouterAccessLogConstants.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/RouterAccessLogConstants.java
@@ -23,4 +23,5 @@ package org.wso2.choreo.connect.enforcer.constants;
  */
 public class RouterAccessLogConstants {
     public static final String ORIGINAL_PATH_DATA_NAME = "originalPath";
+    public static final String ORIGINAL_HOST_DATA_NAME = "originalHost";
 }

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/grpc/ExtAuthService.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/grpc/ExtAuthService.java
@@ -180,7 +180,9 @@ public class ExtAuthService extends AuthorizationGrpc.AuthorizationImplBase {
                         addMetadata(structBuilder, key, value));
             }
             addMetadata(structBuilder, RouterAccessLogConstants.ORIGINAL_PATH_DATA_NAME,
-                    responseObject.getRequestPath().split("\\?")[0]);
+                    responseObject.getRequestPath());
+            addMetadata(structBuilder, RouterAccessLogConstants.ORIGINAL_HOST_DATA_NAME,
+                    request.getAttributes().getRequest().getHttp().getHost());
 
             HeaderValueOption headerValueOption = HeaderValueOption.newBuilder()
                     .setHeader(HeaderValue.newBuilder().setKey(APIConstants.API_TRACE_KEY).setValue(traceKey).build())

--- a/resources/conf/log_config.toml
+++ b/resources/conf/log_config.toml
@@ -26,5 +26,7 @@ logLevel = "INFO"
 
 [accessLogs]
 enable = false
-logfile = "/tmp/envoy.access.log" # This file will be created inside router container.
-format = "[%START_TIME%]' '%DYNAMIC_METADATA(envoy.filters.http.ext_authz:originalHost)%' '%REQ(:AUTHORITY)%' '%REQ(:METHOD)%' '%DYNAMIC_METADATA(envoy.filters.http.ext_authz:originalPath)%' '%REQ(:PATH)%' '%PROTOCOL%' '%RESPONSE_CODE%' '%RESPONSE_CODE_DETAILS%' '%RESPONSE_FLAGS%' '%REQ(USER-AGENT)%' '%REQ(X-REQUEST-ID)%' '%REQ(X-FORWARDED-FOR)%' '%UPSTREAM_HOST%' '%BYTES_RECEIVED%' '%BYTES_SENT%' '%DURATION%' '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%' '%REQUEST_TX_DURATION%' '%RESPONSE_TX_DURATION%' '%REQUEST_DURATION%' '%RESPONSE_DURATION%\n"
+logfile = "/dev/stdout" # This file will be created inside router container.
+# Log format that is append after "reservedLogFormat". This can be used by dev for debug purpose.
+# For example: secondaryLogFormat = "'%REQUEST_TX_DURATION%' '%RESPONSE_TX_DURATION%'"
+secondaryLogFormat = ""

--- a/resources/conf/log_config.toml
+++ b/resources/conf/log_config.toml
@@ -27,4 +27,4 @@ logLevel = "INFO"
 [accessLogs]
 enable = false
 logfile = "/tmp/envoy.access.log" # This file will be created inside router container.
-format = "[%START_TIME%] '%REQ(:METHOD)% %DYNAMIC_METADATA(envoy.filters.http.ext_authz:originalPath)% %REQ(:PATH)% %PROTOCOL%' %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% '%REQ(X-FORWARDED-FOR)%' '%REQ(USER-AGENT)%' '%REQ(X-REQUEST-ID)%' '%REQ(:AUTHORITY)%' '%UPSTREAM_HOST%'\n"
+format = "[%START_TIME%]' '%DYNAMIC_METADATA(envoy.filters.http.ext_authz:originalHost)%' '%REQ(:AUTHORITY)%' '%REQ(:METHOD)%' '%DYNAMIC_METADATA(envoy.filters.http.ext_authz:originalPath)%' '%REQ(:PATH)%' '%PROTOCOL%' '%RESPONSE_CODE%' '%RESPONSE_CODE_DETAILS%' '%RESPONSE_FLAGS%' '%REQ(USER-AGENT)%' '%REQ(X-REQUEST-ID)%' '%REQ(X-FORWARDED-FOR)%' '%UPSTREAM_HOST%' '%BYTES_RECEIVED%' '%BYTES_SENT%' '%DURATION%' '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%' '%REQUEST_TX_DURATION%' '%RESPONSE_TX_DURATION%' '%REQUEST_DURATION%' '%RESPONSE_DURATION%\n"


### PR DESCRIPTION
### Purpose
Include the original vhost in access logs
The original vhost (authority header received from request) has to be included in the access log to filter out the gateway environment.

Query params will be available in the original request path as well as in the backend request path in access logs. The user is responsible for not sending sensitive data with query params.

#### Without SecondaryLogFormat
```toml
[accessLogs]
enable = true
logfile = "/dev/stdout" # This file will be created inside router container.
# SecondaryLogFormat = "'foo' 'bar'"
```

```log
[2023-04-18T12:50:47.897Z]' '-' 'enforcer' 'POST' '-' '/testkey' 'HTTP/1.1' '200' 'via_upstream' '-' 'curl/7.79.1' 'c1142d8f-ddbf-4c19-b97e-f2b073862330' '-' '172.26.0.4:9001' '15' '762' '107' '-' '56' '0' '1' '107' '
[2023-04-18T12:50:49.921Z]' '-' 'localhost:9095' 'GET' '-' '/v2/pet/findByStatus?status=pending' 'HTTP/1.1' '404' 'route_not_found' 'NR' 'curl/7.79.1' '9914e51b-9f28-43be-9e31-c3f0ce8e160e' '-' '-' '0' '94' '0' '-' '-' '-' '0' '-' '
[2023-04-18T12:50:51.279Z]' 'localhost:9095' 'localhost:9095' 'GET' '/ORG_ID/pet/findByStatus?status=pending' '/ORG_ID/pet/findByStatus?status=pending' 'HTTP/1.1' '503' 'no_healthy_upstream' 'UH' 'curl/7.79.1' '409e0974-7db4-4398-966c-2f34e3e169d2' '-' '-' '0' '86' '65' '-' '-' '-' '0' '-' '
[2023-04-18T12:51:06.465Z]' 'localhost:9095' 'petstore.swagger.io' 'GET' '/ORG_ID/pet/findByStatus?status=pending' '/v2/pet/findByStatus?status=pending' 'HTTP/1.1' '200' 'via_upstream' '-' 'curl/7.79.1' '464d7ed7-fff3-4cbd-a2bf-da59c16b582d' '-' '54.84.236.148:443' '0' '1085' '951' '-' '732' '0' '0' '951' '
```

#### With SecondaryLogFormat

```toml
[accessLogs]
enable = true
logfile = "/dev/stdout" # This file will be created inside router container.
SecondaryLogFormat = "'foo' 'bar'"
```

```log
[2023-04-18T12:49:10.001Z]' '-' 'enforcer' 'POST' '-' '/testkey' 'HTTP/1.1' '200' 'via_upstream' '-' 'curl/7.79.1' 'd73f2e6a-2b88-431e-a3e1-63bfce0fa6bb' '-' '172.25.0.4:9001' '15' '762' '90' '-' '45' '0' '2' '90' 'foo' 'bar'
[2023-04-18T12:49:13.051Z]' '-' 'localhost:9095' 'GET' '-' '/v2/pet/findByStatus?status=pending' 'HTTP/1.1' '404' 'route_not_found' 'NR' 'curl/7.79.1' '38ae13ce-dce0-424d-aaf1-dd821580471c' '-' '-' '0' '94' '0' '-' '-' '-' '0' '-' 'foo' 'bar'
[2023-04-18T12:49:15.166Z]' 'localhost:9095' 'localhost:9095' 'GET' '/ORG_ID/pet/findByStatus?status=pending' '/ORG_ID/pet/findByStatus?status=pending' 'HTTP/1.1' '503' 'no_healthy_upstream' 'UH' 'curl/7.79.1' '69cf017c-86e4-4e16-a7c3-0b7fb9551027' '-' '-' '0' '86' '55' '-' '-' '-' '0' '-' 'foo' 'bar'
[2023-04-18T12:49:35.545Z]' 'localhost:9095' 'petstore.swagger.io' 'GET' '/ORG_ID/pet/findByStatus?status=pending' '/v2/pet/findByStatus?status=pending' 'HTTP/1.1' '200' 'via_upstream' '-' 'curl/7.79.1' 'abacd50e-09d9-4326-9b7c-9abe6b4b4b5f' '-' '34.235.63.42:443' '0' '947' '928' '-' '712' '0' '1' '927' 'foo' 'bar'
```


<!-- Short description of the issue you are going to solve with this PR. -->

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Tested with Docker Compose.

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
