### PR TITLE
Introduce separate hostname configuration for JWKS endpoint

### DIFF
--- a/adapter/config/default_config.go
+++ b/adapter/config/default_config.go
@@ -72,7 +72,8 @@ var defaultConfig = &Config{
 			KeyPath:  "/home/wso2/security/keystore/mg.key",
 			CertPath: "/home/wso2/security/keystore/mg.pem",
 		},
-		SystemHost: "localhost",
+		SystemHost:          "localhost",
+		InternalServiceHost: "",
 		Cors: globalCors{
 			Enabled:      true,
 			AllowOrigins: []string{"*"},

--- a/adapter/config/types.go
+++ b/adapter/config/types.go
@@ -111,6 +111,7 @@ type envoy struct {
 	EnforcerResponseTimeoutInSeconds time.Duration `default:"20"`
 	KeyStore                         keystore
 	SystemHost                       string `default:"localhost"`
+	InternalServiceHost              string
 	Cors                             globalCors
 	Upstream                         envoyUpstream
 	Connection                       connection

--- a/adapter/internal/discovery/xds/server.go
+++ b/adapter/internal/discovery/xds/server.go
@@ -816,15 +816,18 @@ func GenerateEnvoyResoucesForLabel(label string) ([]types.Resource, []types.Reso
 		logger.LoggerOasparser.Fatal("Error loading configuration. ", errReadConfig)
 	}
 	systemHost := conf.Envoy.SystemHost
-
+	internalServiceHost := conf.Envoy.InternalServiceHost
+	if internalServiceHost == "" {
+		internalServiceHost = systemHost
+	}
 	// Add testkey and JWKS endpoints
 	if conf.Enforcer.JwtIssuer.Enabled {
 		routeToken := envoyconf.CreateTokenRoute()
-		vhostToRouteArrayMap[systemHost] = append(vhostToRouteArrayMap[systemHost], routeToken)
+		vhostToRouteArrayMap[internalServiceHost] = append(vhostToRouteArrayMap[internalServiceHost], routeToken)
 	}
 	if conf.Enforcer.JwtGenerator.Enabled {
 		routeJwks := envoyconf.CreateJwksEndpoint()
-		vhostToRouteArrayMap[systemHost] = append(vhostToRouteArrayMap[systemHost], routeJwks)
+		vhostToRouteArrayMap[internalServiceHost] = append(vhostToRouteArrayMap[internalServiceHost], routeJwks)
 	}
 
 	// Add health endpoint

--- a/resources/conf/config.toml.template
+++ b/resources/conf/config.toml.template
@@ -80,8 +80,10 @@ sandboxVhost = "sandbox.host"
   clusterTimeoutInSeconds = 20
   # The timeout for response coming from enforcer to route per API request
   enforcerResponseTimeoutInSeconds = 20
-  # System hostname for system API resources (eg: /testkey and /health)
+  # System hostname for system API resources (eg: /ready and /health)
   systemHost = "localhost"
+  # Hostname for API Resources exposed within the cluster (eg: /.wellknown/jwks and /testkey)
+  internalServiceHost = "localhost"
 
 # Configurations of key store used in Choreo Connect Router
 [router.keystore]


### PR DESCRIPTION
### Purpose

Introduce a separate hostname configuration for JWKS endpoint. With this, health endpoint and ready endpoint could have a different hostname compared to JWKS endpoint.

```
[router]
InternalServiceHost = "gw.internal.wso2.com"
```
If this property remains unassigned, it would assign `systemHost` property's value.



### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
