### PR TITLE
Upgrade Prometheus jar to 0.18.0 to upgrade snakeyaml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -627,7 +627,7 @@
         <jackson.databind.version>2.13.4.2</jackson.databind.version>
         <kraal.version>0.0.16</kraal.version>
         <kotlin.stdlib.version>1.3.31</kotlin.stdlib.version>
-        <prometheus.jmx.agent.version>0.17.2</prometheus.jmx.agent.version>
+        <prometheus.jmx.agent.version>0.18.0</prometheus.jmx.agent.version>
         <jms-module.version>0.6.3</jms-module.version>
         <jmx.api.version>2.0.1</jmx.api.version>
         <orbit.version.geronimo-jms_1.1_spec>1.1.1.wso2v1</orbit.version.geronimo-jms_1.1_spec>


### PR DESCRIPTION
### Purpose
The Prometheus jar is upgraded to 0.18.0 to upgrade snakeyaml to resolve security vulnerabilities.

### Issues
Fixes #3344

### Automation tests
 - Unit tests added: N/A
 - Integration tests added: N/A

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Tested in Mac OS

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
