### PR TITLE
Change log level of subscription validation failure

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/handler_providers/jwt_auth_provider.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/handler_providers/jwt_auth_provider.bal
@@ -183,7 +183,8 @@ public function validateSubscriptions(string jwtToken, jwt:JwtPayload payload, b
         if (errorcode is ()) {
             setErrorMessageToInvocationContext(API_AUTH_FORBIDDEN);
         }
-        return prepareError("Subscriptions validation failed.");
+        printInfo(KEY_JWT_AUTH_PROVIDER, "Subscriptions validation failed.");
+        return false;
     }
 }
 


### PR DESCRIPTION
### Purpose
Change log level of subscription validation failure from `ERROR` to `INFO`.

### Issues
Fixes https://github.com/wso2/api-manager/issues/1773

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->

- MacOS Ventura ( v13.2.1 )
- OpenJDK 1.8

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
