### PR TITLE
Update json-smart, callhome and ballerina platform versions

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/templates/ballerinaToml.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/ballerinaToml.mustache
@@ -45,7 +45,7 @@ target = "java8"
 
      [[platform.libraries]]
         module = "callhome"
-        path = "{{toolkitHome}}/lib/gateway/platform/core-1.0.14.jar"
+        path = "{{toolkitHome}}/lib/gateway/platform/core-1.0.16.jar"
 
      [[platform.libraries]]
         module = "bind-api"

--- a/components/micro-gateway-core/src/main/ballerina/Ballerina.toml
+++ b/components/micro-gateway-core/src/main/ballerina/Ballerina.toml
@@ -6,7 +6,7 @@ version= "3.2.7"
 target = "java8"
 
     [[platform.libraries]]
-    path = "../../../target/org.wso2.micro.gateway.core-3.2.7.jar"
+    path = "../../../target/org.wso2.micro.gateway.core-3.2.8-SNAPSHOT.jar"
 
     [[platform.libraries]]
     path = "../../../target/lib/dependencies/org.everit.json.schema-1.5.0.wso2.v1.jar"
@@ -24,17 +24,17 @@ target = "java8"
     path = "../../../target/lib/dependencies/nimbus-jose-jwt-8.8.jar"
 
     [[platform.libraries]]
-    path = "../../../target/lib/dependencies/json-smart-2.3.jar"
+    path = "../../../target/lib/dependencies/json-smart-2.4.10.jar"
 
     [[platform.libraries]]
     path = "../../../target/lib/dependencies/asm-1.0.2.jar"
 
     # jackson libraries are added for the use of default claim retriever implementation
     [[platform.libraries]]
-    path = "../../../target/lib/dependencies/jackson-annotations-2.13.2.jar"
+    path = "../../../target/lib/dependencies/jackson-annotations-2.14.2.jar"
 
     [[platform.libraries]]
-    path = "../../../target/lib/dependencies/jackson-core-2.13.2.jar"
+    path = "../../../target/lib/dependencies/jackson-core-2.14.2.jar"
 
     [[platform.libraries]]
     path = "../../../target/lib/dependencies/jackson-databind-2.13.4.2.jar"

--- a/pom.xml
+++ b/pom.xml
@@ -574,7 +574,7 @@
     </build>
 
     <properties>
-        <ballerina.platform.version>1.2.38</ballerina.platform.version>
+        <ballerina.platform.version>1.2.39</ballerina.platform.version>
         <broker.version>0.970.5</broker.version>
         <assembly.plugin.version>3.1.1</assembly.plugin.version>
         <compiler.plugin.version>3.7.0</compiler.plugin.version>
@@ -623,7 +623,7 @@
         <com.google.protobuf.version>3.11.3</com.google.protobuf.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jackson.version>2.13.2</jackson.version>
+        <jackson.version>2.14.2</jackson.version>
         <jackson.databind.version>2.13.4.2</jackson.databind.version>
         <kraal.version>0.0.16</kraal.version>
         <kotlin.stdlib.version>1.3.31</kotlin.stdlib.version>
@@ -643,11 +643,11 @@
         <com.jayway.jsonpath.version>2.4.0.wso2v2</com.jayway.jsonpath.version>
         <everit.version>1.5.0.wso2.v1</everit.version>
         <org.wso2.json.version>3.0.0.wso2v1</org.wso2.json.version>
-        <carbon.callhome.version>1.0.14</carbon.callhome.version>
+        <carbon.callhome.version>1.0.16</carbon.callhome.version>
         <org.wso2.carbon.analytics-common>6.1.45</org.wso2.carbon.analytics-common>
         <org.wso2.orbit.com.lmax>3.4.2.wso2v1</org.wso2.orbit.com.lmax>
         <com.nimbusds.nimbus-jose-jwt>8.8</com.nimbusds.nimbus-jose-jwt>
-        <net.minidev.json-smart.version>2.3</net.minidev.json-smart.version>
+        <net.minidev.json-smart.version>2.4.10</net.minidev.json-smart.version>
         <net.minidev.asm.version>1.0.2</net.minidev.asm.version>
     </properties>
 


### PR DESCRIPTION
### Purpose
Update json-smart, callhome and ballerina platform versions for micro-gateway 3.2.0 version.


### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Mac OS, JDK-1.8

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
