### PR TITLE
Update analytics publisher client version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -626,7 +626,7 @@
         <apictl.version>4.0.0</apictl.version>
         <apim.version>4.0.0</apim.version>
         <grpc.healthProbe.version>0.4.17</grpc.healthProbe.version>
-        <analytics.publisher.client.version>1.2.4</analytics.publisher.client.version>
+        <analytics.publisher.client.version>1.2.6</analytics.publisher.client.version>
         <awaitility.version>4.2.0</awaitility.version>
         <apache.httpcomponents.version>4.5.14</apache.httpcomponents.version>
         <jackson.databind.version>2.14.1</jackson.databind.version>


### PR DESCRIPTION
### Purpose

This will update the analytics publisher client version to 1.2.6

Related with: https://github.com/wso2-enterprise/choreo/issues/21793
