### PR TITLE
Include API UUID in Access logs

### DIFF
--- a/adapter/internal/oasparser/envoyconf/internal_dtos.go
+++ b/adapter/internal/oasparser/envoyconf/internal_dtos.go
@@ -24,6 +24,7 @@ import (
 // routeCreateParams is the DTO used to provide information to the envoy route create function
 type routeCreateParams struct {
 	organizationID      string
+	apiUUID             string
 	title               string
 	version             string
 	apiType             string

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
@@ -381,7 +381,7 @@ func TestCreateRoutesWithChoreoSandboxEnvProp(t *testing.T) {
 func TestCreateHealthEndpoint(t *testing.T) {
 	route := envoy.CreateHealthEndpoint()
 	assert.NotNil(t, route, "Health Endpoint Route should not be null.")
-	assert.Equal(t, "/health", route.Name, "Health Route Name is incorrect.")
+	assert.Equal(t, "system#/health", route.Name, "Health Route Name is incorrect.")
 	assert.Equal(t, "/health", route.GetMatch().GetPath(), "Health route path is incorrect.")
 	assert.Equal(t, "{\"status\": \"healthy\"}", route.GetDirectResponse().GetBody().GetInlineString(), "Health response message is incorrect.")
 	assert.Equal(t, uint32(200), route.GetDirectResponse().GetStatus(), "Health response status is incorrect.")

--- a/adapter/pkg/config/log_types.go
+++ b/adapter/pkg/config/log_types.go
@@ -59,7 +59,7 @@ func getDefaultLogConfig() *LogConfig {
 			LogFile: "/dev/stdout",
 			// Following default value of "ReservedLogFormat" is document in log_config.toml for references.
 			// Update log_config.toml if any changes are done here.
-			ReservedLogFormat: "[%START_TIME%]' '%DYNAMIC_METADATA(envoy.filters.http.ext_authz:originalHost)%' " +
+			ReservedLogFormat: "[%START_TIME%]' '%ROUTE_NAME%' '%DYNAMIC_METADATA(envoy.filters.http.ext_authz:originalHost)%' " +
 				"'%REQ(:AUTHORITY)%' '%REQ(:METHOD)%' '%DYNAMIC_METADATA(envoy.filters.http.ext_authz:originalPath)%' " +
 				"'%REQ(:PATH)%' '%PROTOCOL%' '%RESPONSE_CODE%' '%RESPONSE_CODE_DETAILS%' '%RESPONSE_FLAGS%' '%REQ(USER-AGENT)%' " +
 				"'%REQ(X-REQUEST-ID)%' '%REQ(X-FORWARDED-FOR)%' '%UPSTREAM_HOST%' '%BYTES_RECEIVED%' '%BYTES_SENT%' '%DURATION%' " +

--- a/resources/conf/log_config.toml
+++ b/resources/conf/log_config.toml
@@ -31,7 +31,8 @@ logfile = "/dev/stdout" # This file will be created inside router container.
 # For example: secondaryLogFormat = "'%REQUEST_TX_DURATION%' '%RESPONSE_TX_DURATION%'"
 #
 # Following is the default value of 'reservedLogFormat'
-# reservedLogFormat: "[%START_TIME%]' '%DYNAMIC_METADATA(envoy.filters.http.ext_authz:originalHost)%' " +
+# Here '%ROUTE_NAME%' equals '<API_UUID>'
+# reservedLogFormat: "[%START_TIME%]' '%ROUTE_NAME%' '%DYNAMIC_METADATA(envoy.filters.http.ext_authz:originalHost)%' " +
 # "'%REQ(:AUTHORITY)%' '%REQ(:METHOD)%' '%DYNAMIC_METADATA(envoy.filters.http.ext_authz:originalPath)%' " +
 # "'%REQ(:PATH)%' '%PROTOCOL%' '%RESPONSE_CODE%' '%RESPONSE_CODE_DETAILS%' '%RESPONSE_FLAGS%' '%REQ(USER-AGENT)%' " +
 # "'%REQ(X-REQUEST-ID)%' '%REQ(X-FORWARDED-FOR)%' '%UPSTREAM_HOST%' '%BYTES_RECEIVED%' '%BYTES_SENT%' '%DURATION%' " +


### PR DESCRIPTION
### Purpose
$subject

Since for all API versions, there is an API UUID, it is possible to filter access logs for an endpoint in a component version.
Even though the sem version is used (the user invokes just with the major version) we will be able to verify the exact version the request belongs to.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: N/A
 - Integration tests added: N/A

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
