### PR TITLE
Move semantic version comparison to package

### DIFF
--- a/adapter/pkg/semanticversion/semantic_version.go
+++ b/adapter/pkg/semanticversion/semantic_version.go
@@ -81,3 +81,32 @@ func ValidateAndGetVersionComponents(version string, apiName string) (*SemVersio
 		Patch:   &patchVersion,
 	}, nil
 }
+
+// Compare - compares two semantic versions and returns true
+// if `version` is greater or equal than `baseVersion`
+func (baseVersion SemVersion) Compare(version SemVersion) bool {
+	if baseVersion.Major < version.Major {
+		return true
+	} else if baseVersion.Major > version.Major {
+		return false
+	} else {
+		if baseVersion.Minor < version.Minor {
+			return true
+		} else if baseVersion.Minor > version.Minor {
+			return false
+		} else {
+			if baseVersion.Patch != nil && version.Patch != nil {
+				if *baseVersion.Patch < *version.Patch {
+					return true
+				} else if *baseVersion.Patch > *version.Patch {
+					return false
+				}
+			} else if baseVersion.Patch == nil && version.Patch != nil {
+				return true
+			} else if baseVersion.Patch != nil && version.Patch == nil {
+				return false
+			}
+		}
+	}
+	return true
+}


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
This PR updates the semanticversion package by adding `Compare` function which returns boolean by comparing a semantic version with another semantic version

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
