### PR TITLE
Remove /health and /ready from Access Logs

### DIFF
--- a/adapter/internal/oasparser/envoyconf/access_loggers.go
+++ b/adapter/internal/oasparser/envoyconf/access_loggers.go
@@ -178,12 +178,11 @@ func getAccessLogFilterConfig() *config_access_logv3.AccessLogFilter {
 	logConf := config.ReadLogConfigs()
 	conf, _ := config.ReadConfigs()
 
-	if logConf.AccessLogs.Excludes.SystemHost.Enabled {
-		logger.LoggerOasparser.Debugf("Access log excludes for system host is enabled with path regex: %q",
-			logConf.AccessLogs.Excludes.SystemHost.PathRegex)
-	} else {
+	if !logConf.AccessLogs.Excludes.SystemHost.Enabled {
 		return nil
 	}
+	logger.LoggerOasparser.Debugf("Access log excludes for system host is enabled with path regex: %q",
+		logConf.AccessLogs.Excludes.SystemHost.PathRegex)
 
 	systemHostFilter := &config_access_logv3.AccessLogFilter{
 		FilterSpecifier: &config_access_logv3.AccessLogFilter_HeaderFilter{

--- a/adapter/pkg/config/log_types.go
+++ b/adapter/pkg/config/log_types.go
@@ -23,10 +23,10 @@ type pkg struct {
 }
 
 type accessLog struct {
-	Enable       bool
-	LogFile      string
-	LogType      string
-	ExcludePaths ExcludePaths
+	Enable   bool
+	LogFile  string
+	LogType  string
+	Excludes AccessLogExcludes
 	// ReservedLogFormat is reserved for Choreo Gateway Access Logs Observability feature. Changes to this may
 	// break the functionality in the observability feature.
 	ReservedLogFormat string
@@ -35,10 +35,15 @@ type accessLog struct {
 	JSONFormat         map[string]string
 }
 
-// ExcludePaths represents the configurations related to exclude paths from access logs.
-type ExcludePaths struct {
-	Enabled bool
-	Regex   string
+// AccessLogExcludes represents the configurations related to excludes from access logs.
+type AccessLogExcludes struct {
+	SystemHost AccessLogExcludesSystemHost
+}
+
+// AccessLogExcludesSystemHost represents the configurations related to excludes from access logs for requests made to system host.
+type AccessLogExcludesSystemHost struct {
+	Enabled   bool
+	PathRegex string
 }
 
 // LogConfig represents the configurations related to adapter logs and envoy access logs.
@@ -67,9 +72,11 @@ func getDefaultLogConfig() *LogConfig {
 			Enable:  false,
 			LogFile: "/dev/stdout",
 			LogType: "text",
-			ExcludePaths: ExcludePaths{
-				Enabled: true,
-				Regex:   "^(/health|/ready)",
+			Excludes: AccessLogExcludes{
+				SystemHost: AccessLogExcludesSystemHost{
+					Enabled:   true,
+					PathRegex: "^(/health|/ready)$",
+				},
 			},
 			// Following default value of "ReservedLogFormat" is document in log_config.toml for references.
 			// Update log_config.toml if any changes are done here.

--- a/adapter/pkg/config/log_types.go
+++ b/adapter/pkg/config/log_types.go
@@ -23,15 +23,22 @@ type pkg struct {
 }
 
 type accessLog struct {
-	Enable  bool
-	LogFile string
-	LogType string
+	Enable       bool
+	LogFile      string
+	LogType      string
+	ExcludePaths ExcludePaths
 	// ReservedLogFormat is reserved for Choreo Gateway Access Logs Observability feature. Changes to this may
 	// break the functionality in the observability feature.
 	ReservedLogFormat string
 	// SecondaryLogFormat can be used by dev to log properties for debug purposes
 	SecondaryLogFormat string
 	JSONFormat         map[string]string
+}
+
+// ExcludePaths represents the configurations related to exclude paths from access logs.
+type ExcludePaths struct {
+	Enabled bool
+	Regex   string
 }
 
 // LogConfig represents the configurations related to adapter logs and envoy access logs.
@@ -60,6 +67,10 @@ func getDefaultLogConfig() *LogConfig {
 			Enable:  false,
 			LogFile: "/dev/stdout",
 			LogType: "text",
+			ExcludePaths: ExcludePaths{
+				Enabled: true,
+				Regex:   "^(/health|/ready)",
+			},
 			// Following default value of "ReservedLogFormat" is document in log_config.toml for references.
 			// Update log_config.toml if any changes are done here.
 			ReservedLogFormat: "[%START_TIME%]' '%DYNAMIC_METADATA(envoy.filters.http.ext_authz:originalHost)%' " +
@@ -77,8 +88,6 @@ func getDefaultLogConfig() *LogConfig {
 				"method":        "%REQ(:METHOD)%",
 				"apiPath":       "%DYNAMIC_METADATA(envoy.filters.http.ext_authz:originalPath)%",
 				"upstrmPath":    "%REQ(:PATH)%",
-				"apiUuid":       "%DYNAMIC_METADATA(envoy.filters.http.ext_authz:apiUUID)%",
-				"extAuthDtls":   "%DYNAMIC_METADATA(envoy.filters.http.ext_authz:extAuthDetails)%",
 				"prot":          "%PROTOCOL%",
 				"respCode":      "%RESPONSE_CODE%",
 				"respCodeDtls":  "%RESPONSE_CODE_DETAILS%",
@@ -95,6 +104,8 @@ func getDefaultLogConfig() *LogConfig {
 				"respTxDur":     "%RESPONSE_TX_DURATION%",
 				"reqDur":        "%REQUEST_DURATION%",
 				"respDur":       "%RESPONSE_DURATION%",
+				"apiUuid":       "%DYNAMIC_METADATA(envoy.filters.http.ext_authz:apiUUID)%",
+				"extAuthDtls":   "%DYNAMIC_METADATA(envoy.filters.http.ext_authz:extAuthDetails)%",
 			},
 		},
 	}

--- a/integration/mock-backend-server/src/main/resources/Dockerfile
+++ b/integration/mock-backend-server/src/main/resources/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 # -----------------------------------------------------------------------
 
-FROM adoptopenjdk/openjdk11:jre-11.0.18_10-alpine
+FROM adoptopenjdk/openjdk11:jre-11.0.20_8
 
 WORKDIR /home/app
 

--- a/resources/conf/log_config.toml
+++ b/resources/conf/log_config.toml
@@ -29,6 +29,10 @@ enable = false
 logfile = "/dev/stdout" # This file will be created inside router container.
 logType = "text" # LogTypes can be "text" or "json"
 
+[accessLogs.excludePaths]
+enabled = true
+regex = "^(/health|/ready)"
+
 # Log format that is append after "reservedLogFormat". This can be used by dev for debug purpose.
 # For example: secondaryLogFormat = "'%REQUEST_TX_DURATION%' '%RESPONSE_TX_DURATION%'"
 #
@@ -39,7 +43,8 @@ logType = "text" # LogTypes can be "text" or "json"
 # "'%REQ(:PATH)%' '%PROTOCOL%' '%RESPONSE_CODE%' '%RESPONSE_CODE_DETAILS%' '%RESPONSE_FLAGS%' '%REQ(USER-AGENT)%' " +
 # "'%REQ(X-REQUEST-ID)%' '%REQ(X-FORWARDED-FOR)%' '%UPSTREAM_HOST%' '%BYTES_RECEIVED%' '%BYTES_SENT%' '%DURATION%' " +
 # "'%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%' '%REQUEST_TX_DURATION%' '%RESPONSE_TX_DURATION%' '%REQUEST_DURATION%' " +
-# "'%RESPONSE_DURATION%' '%ROUTE_NAME%' '"
+# "'%RESPONSE_DURATION%' '%DYNAMIC_METADATA(envoy.filters.http.ext_authz:apiUUID)%' " +
+# "'%DYNAMIC_METADATA(envoy.filters.http.ext_authz:extAuthDetails)%' '"
 secondaryLogFormat = ""
 
 [accessLogs.jSONFormat]
@@ -49,8 +54,6 @@ host = "%REQ(:AUTHORITY)%"
 method = "%REQ(:METHOD)%"
 apiPath = "%DYNAMIC_METADATA(envoy.filters.http.ext_authz:originalPath)%"
 upstrmPath = "%REQ(:PATH)%"
-apiUUID = "%DYNAMIC_METADATA(envoy.filters.http.ext_authz:apiUUID)%"
-extAuthDtls = "%DYNAMIC_METADATA(envoy.filters.http.ext_authz:extAuthDetails)%"
 prot = "%PROTOCOL%"
 respCode = "%RESPONSE_CODE%"
 respCodeDtls = "%RESPONSE_CODE_DETAILS%"
@@ -67,3 +70,5 @@ reqTxDur = "%REQUEST_TX_DURATION%"
 respTxDur = "%RESPONSE_TX_DURATION%"
 reqDur = "%REQUEST_DURATION%"
 respDur = "%RESPONSE_DURATION%"
+apiUUID = "%DYNAMIC_METADATA(envoy.filters.http.ext_authz:apiUUID)%"
+extAuthDtls = "%DYNAMIC_METADATA(envoy.filters.http.ext_authz:extAuthDetails)%"

--- a/resources/conf/log_config.toml
+++ b/resources/conf/log_config.toml
@@ -29,9 +29,10 @@ enable = false
 logfile = "/dev/stdout" # This file will be created inside router container.
 logType = "text" # LogTypes can be "text" or "json"
 
-[accessLogs.excludePaths]
+[accessLogs.excludes]
+[accessLogs.excludes.systemHost]
 enabled = true
-regex = "^(/health|/ready)"
+pathRegex = "^(/health|/ready)$" # keep this empty to match all paths
 
 # Log format that is append after "reservedLogFormat". This can be used by dev for debug purpose.
 # For example: secondaryLogFormat = "'%REQUEST_TX_DURATION%' '%RESPONSE_TX_DURATION%'"


### PR DESCRIPTION
### Purpose
$subject

Config
```yaml
[accessLogs.excludes]
[accessLogs.excludes.systemHost]
enabled = true
pathRegex = "^(/health|/ready)$" # keep this empty to match all paths
```

### Docker Compose Tests
#### 1. System Host /health
```sh
$ curl -X GET "https://localhost:9095/health" -H "accept: application/json" -H "Authorization:Bearer $TOKEN" -k
{"status": "healthy"}
```

No Access log printed.

#### 2. Other Host /health

```sh
$ curl -X GET "https://localhost:9095/health" -H "accept: application/json" -H "Authorization:Bearer $TOKEN" -k -H 'Host: foo'
{"description":"The requested resource is not available.","code":"404","message":"Not Found"}
```

```json
{"apiPath":null,"respTxDur":null,"respCode":404,"upstrmSvcTime":null,"respCodeDtls":"route_not_found","respDur":null,"bytesSent":94,"extAuthDtls":null,"dur":0,"respFlag":"NR","time":"2023-09-04T05:48:03.697Z","reqTxDur":null,"prot":"HTTP/1.1","upstrmHost":null,"bytesRecv":0,"reqDur":0,"ua":"curl/7.79.1","reqId":"b91f7d9b-8eb4-438c-8fed-eacb227011a8","method":"GET","gwHost":null,"xff":null,"host":"foo","apiUuid":null,"upstrmPath":"/health"}
```

#### 3. System Host /health/foo/health

```sh
$ curl -X GET "https://localhost:9095/health/foo/health" -H "accept: application/json" -H "Authorization:Bearer $TOKEN" -k
{"description":"The requested resource is not available.","message":"Not Found","code":"404"}
```

```json
{"respCodeDtls":"route_not_found","apiPath":null,"time":"2023-09-04T05:48:52.486Z","upstrmSvcTime":null,"reqDur":0,"respDur":null,"xff":null,"ua":"curl/7.79.1","bytesRecv":0,"extAuthDtls":null,"respFlag":"NR","reqId":"cead9a49-9fe7-4ebd-8895-f3804ca1237b","dur":0,"gwHost":null,"bytesSent":94,"respCode":404,"upstrmPath":"/health/foo/health","host":"localhost:9095","respTxDur":null,"reqTxDur":null,"upstrmHost":null,"prot":"HTTP/1.1","method":"GET","apiUuid":null}
```

#### 4. System Host /token

```sh
curl -X POST "https://localhost:9095/testkey" -d "scope=read:pets" -H "Authorization: Basic YWRtaW46YWRtaW4=" -k -v
```

```json
{"upstrmSvcTime":null,"respTxDur":0,"extAuthDtls":null,"reqId":"22b2a953-e0ba-40f6-86a1-e28d9e97a7ee","prot":"HTTP/1.1","method":"POST","bytesRecv":15,"apiUuid":null,"bytesSent":762,"xff":null,"ua":"curl/7.79.1","respFlag":"-","respCodeDtls":"via_upstream","host":"enforcer","upstrmPath":"/testkey","reqDur":0,"respDur":108,"gwHost":null,"upstrmHost":"172.30.0.4:9001","dur":108,"apiPath":null,"time":"2023-09-04T06:07:49.854Z","reqTxDur":36,"respCode":200}
```

#### 5. Invoke API

```sh
curl -X GET "https://localhost:9095/v2/pet/findByStatus?status=pending" -H "accept: application/json" -H "Authorization:Bearer $TOKEN" -k
```

```json
{"dur":2006,"bytesRecv":0,"upstrmHost":"185.42.117.109:443","reqId":"781d3001-7d47-4989-a2fa-767f095c1229","respFlag":"-","reqDur":0,"upstrmPath":"/v3/9ec5a57e-733c-4338-9854-7ea31866dcba/pet/findByStatus?status=pending","extAuthDtls":null,"reqTxDur":1845,"respCodeDtls":"via_upstream","respDur":2005,"respCode":200,"prot":"HTTP/1.1","bytesSent":31,"apiPath":"/v2/pet/findByStatus?status=pending","gwHost":"localhost:9095","ua":"curl/7.79.1","apiUuid":"648957e7a675c35145393369","upstrmSvcTime":null,"method":"GET","host":"run.mocky.io","time":"2023-09-04T06:08:54.093Z","xff":null,"respTxDur":0}
```

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: N/A
 - Integration tests added: N/A

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Tested in Docker Compose

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
