### PR TITLE
Improvements related XDS communication between enforcer and adapter.

### DIFF
--- a/adapter/internal/discovery/xds/enforcercallbacks/enforcer_callbacks.go
+++ b/adapter/internal/discovery/xds/enforcercallbacks/enforcer_callbacks.go
@@ -53,11 +53,7 @@ func (cb *Callbacks) OnStreamClosed(id int64, node *core.Node) {
 // OnStreamRequest prints debug logs
 func (cb *Callbacks) OnStreamRequest(id int64, request *discovery.DiscoveryRequest) error {
 	nodeIdentifier := common.GetNodeIdentifier(request)
-	if nodeQueueInstance.IsNewNode(nodeIdentifier) {
-		logger.LoggerEnforcerXdsCallbacks.Infof("stream request on stream id: %d, from node: %s, version: %s",
-			id, nodeIdentifier, request.VersionInfo)
-	}
-	logger.LoggerEnforcerXdsCallbacks.Debugf("stream request on stream id: %d, from node: %s, version: %s, for type: %s",
+	logger.LoggerEnforcerXdsCallbacks.Infof("stream request on stream id: %d, from node: %s, version: %s, for type: %s",
 		id, nodeIdentifier, request.GetVersionInfo(), request.GetTypeUrl())
 	if request.ErrorDetail != nil {
 		logger.LoggerEnforcerXdsCallbacks.Errorf("Stream request for type %s on stream id: %d Error: %s", request.GetTypeUrl(),
@@ -82,7 +78,7 @@ func (cb *Callbacks) OnStreamRequest(id int64, request *discovery.DiscoveryReque
 func (cb *Callbacks) OnStreamResponse(context context.Context, id int64, request *discovery.DiscoveryRequest,
 	response *discovery.DiscoveryResponse) {
 	nodeIdentifier := common.GetNodeIdentifier(request)
-	logger.LoggerEnforcerXdsCallbacks.Debugf("stream response on stream id: %d node: %s for type: %s version: %s",
+	logger.LoggerEnforcerXdsCallbacks.Infof("stream response on stream id: %d node: %s for type: %s version: %s",
 		id, nodeIdentifier, request.GetTypeUrl(), response.GetVersionInfo())
 }
 

--- a/adapter/internal/eventhub/subscription.go
+++ b/adapter/internal/eventhub/subscription.go
@@ -131,7 +131,7 @@ func LoadSubscriptionData(configFile *config.Config, initialAPIUUIDListMap map[s
 			} else {
 				// Keep the iteration going on until a response is recieved.
 				logger.LoggerSync.Errorf("Error occurred while fetching data from control plane: %v", data.Error)
-				go func(d response) {
+				go func(d response, endpoint string, responseType interface{}) {
 					// Retry fetching from control plane after a configured time interval
 					if conf.ControlPlane.RetryInterval == 0 {
 						// Assign default retry interval
@@ -140,8 +140,8 @@ func LoadSubscriptionData(configFile *config.Config, initialAPIUUIDListMap map[s
 					logger.LoggerSync.Debugf("Time Duration for retrying: %v", conf.ControlPlane.RetryInterval*time.Second)
 					time.Sleep(conf.ControlPlane.RetryInterval * time.Second)
 					logger.LoggerSync.Infof("Retrying to fetch APIs from control plane. Time Duration for the next retry: %v", conf.ControlPlane.RetryInterval*time.Second)
-					go InvokeService(url.endpoint, url.responseType, nil, responseChannel, 0)
-				}(data)
+					go InvokeService(endpoint, responseType, nil, responseChannel, 0)
+				}(data, url.endpoint, url.responseType)
 			}
 		}
 	}

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApiDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApiDiscoveryClient.java
@@ -123,7 +123,12 @@ public class ApiDiscoveryClient implements Runnable {
         reqObserver = stub.withMaxInboundMessageSize(maxSize).streamApis(new StreamObserver<>() {
             @Override
             public void onNext(DiscoveryResponse response) {
-                logger.info("API event received with version : " + response.getVersionInfo());
+                logger.info("API event received with version : " + response.getVersionInfo() +
+                        " and size(bytes) : " + response.getSerializedSize());
+                if ((double) response.getSerializedSize() / maxSize > 0.90) {
+                    logger.error("Current response size exceeds 90% of the maximum message size for the type : " +
+                            response.getTypeUrl());
+                }
                 logger.debug("Received API discovery response " + response);
                 XdsSchedulerManager.getInstance().stopAPIDiscoveryScheduling();
                 latestReceived = response;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApiDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApiDiscoveryClient.java
@@ -125,8 +125,8 @@ public class ApiDiscoveryClient implements Runnable {
             public void onNext(DiscoveryResponse response) {
                 logger.info("API event received with version : " + response.getVersionInfo() +
                         " and size(bytes) : " + response.getSerializedSize());
-                if ((double) response.getSerializedSize() / maxSize > 0.90) {
-                    logger.error("Current response size exceeds 90% of the maximum message size for the type : " +
+                if ((double) response.getSerializedSize() / maxSize > 0.80) {
+                    logger.error("Current response size exceeds 80% of the maximum message size for the type : " +
                             response.getTypeUrl());
                 }
                 logger.debug("Received API discovery response " + response);

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApiListDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApiListDiscoveryClient.java
@@ -122,7 +122,8 @@ public class ApiListDiscoveryClient implements Runnable {
 
     public void watchApiList() {
         // TODO: (Praminda) implement a deadline with retries
-        reqObserver = stub.streamApiList(new StreamObserver<DiscoveryResponse>() {
+        int maxSize = Integer.parseInt(ConfigHolder.getInstance().getEnvVarConfig().getXdsMaxMsgSize());
+        reqObserver = stub.withMaxInboundMessageSize(maxSize).streamApiList(new StreamObserver<DiscoveryResponse>() {
             @Override
             public void onNext(DiscoveryResponse response) {
                 logger.info("API list event received with version : " + response.getVersionInfo());

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationDiscoveryClient.java
@@ -123,7 +123,8 @@ public class ApplicationDiscoveryClient implements Runnable {
 
     public void watchApplications() {
         // TODO: (Praminda) implement a deadline with retries
-        reqObserver = stub.streamApplications(new StreamObserver<DiscoveryResponse>() {
+        int maxSize = Integer.parseInt(ConfigHolder.getInstance().getEnvVarConfig().getXdsMaxMsgSize());
+        reqObserver = stub.withMaxInboundMessageSize(maxSize).streamApplications(new StreamObserver<DiscoveryResponse>() {
             @Override
             public void onNext(DiscoveryResponse response) {
                 logger.info("Application creation event received with version : " + response.getVersionInfo());

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationDiscoveryClient.java
@@ -128,7 +128,12 @@ public class ApplicationDiscoveryClient implements Runnable {
                 .streamApplications(new StreamObserver<DiscoveryResponse>() {
             @Override
             public void onNext(DiscoveryResponse response) {
-                logger.info("Application creation event received with version : " + response.getVersionInfo());
+                logger.info("Application creation event received with version : " + response.getVersionInfo() +
+                        " and size(bytes) : " + response.getSerializedSize());
+                if ((double) response.getSerializedSize() / maxSize > 0.90) {
+                    logger.error("Current response size exceeds 90% of the maximum message size for the type : " +
+                            response.getTypeUrl());
+                }
                 logger.debug("Received Application discovery response " + response);
                 XdsSchedulerManager.getInstance().stopApplicationDiscoveryScheduling();
                 latestReceived = response;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationDiscoveryClient.java
@@ -130,8 +130,8 @@ public class ApplicationDiscoveryClient implements Runnable {
             public void onNext(DiscoveryResponse response) {
                 logger.info("Application creation event received with version : " + response.getVersionInfo() +
                         " and size(bytes) : " + response.getSerializedSize());
-                if ((double) response.getSerializedSize() / maxSize > 0.90) {
-                    logger.error("Current response size exceeds 90% of the maximum message size for the type : " +
+                if ((double) response.getSerializedSize() / maxSize > 0.80) {
+                    logger.error("Current response size exceeds 80% of the maximum message size for the type : " +
                             response.getTypeUrl());
                 }
                 logger.debug("Received Application discovery response " + response);

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationDiscoveryClient.java
@@ -124,7 +124,8 @@ public class ApplicationDiscoveryClient implements Runnable {
     public void watchApplications() {
         // TODO: (Praminda) implement a deadline with retries
         int maxSize = Integer.parseInt(ConfigHolder.getInstance().getEnvVarConfig().getXdsMaxMsgSize());
-        reqObserver = stub.withMaxInboundMessageSize(maxSize).streamApplications(new StreamObserver<DiscoveryResponse>() {
+        reqObserver = stub.withMaxInboundMessageSize(maxSize)
+                .streamApplications(new StreamObserver<DiscoveryResponse>() {
             @Override
             public void onNext(DiscoveryResponse response) {
                 logger.info("Application creation event received with version : " + response.getVersionInfo());

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationKeyMappingDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationKeyMappingDiscoveryClient.java
@@ -130,8 +130,8 @@ public class ApplicationKeyMappingDiscoveryClient implements Runnable {
             public void onNext(DiscoveryResponse response) {
                 logger.info("Application key generation event received with version : " + response.getVersionInfo() +
                         " and size(bytes) : " + response.getSerializedSize());
-                if ((double) response.getSerializedSize() / maxSize > 0.90) {
-                    logger.error("Current response size exceeds 90% of the maximum message size for the type : " +
+                if ((double) response.getSerializedSize() / maxSize > 0.80) {
+                    logger.error("Current response size exceeds 80% of the maximum message size for the type : " +
                             response.getTypeUrl());
                 }
                 logger.debug("Received Application Key Mapping discovery response " + response);

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationKeyMappingDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationKeyMappingDiscoveryClient.java
@@ -128,7 +128,12 @@ public class ApplicationKeyMappingDiscoveryClient implements Runnable {
                 .streamApplicationKeyMappings(new StreamObserver<DiscoveryResponse>() {
             @Override
             public void onNext(DiscoveryResponse response) {
-                logger.info("Application key generation event received with version : " + response.getVersionInfo());
+                logger.info("Application key generation event received with version : " + response.getVersionInfo() +
+                        " and size(bytes) : " + response.getSerializedSize());
+                if ((double) response.getSerializedSize() / maxSize > 0.90) {
+                    logger.error("Current response size exceeds 90% of the maximum message size for the type : " +
+                            response.getTypeUrl());
+                }
                 logger.debug("Received Application Key Mapping discovery response " + response);
                 XdsSchedulerManager.getInstance().stopApplicationKeyMappingDiscoveryScheduling();
                 latestReceived = response;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationKeyMappingDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationKeyMappingDiscoveryClient.java
@@ -124,7 +124,8 @@ public class ApplicationKeyMappingDiscoveryClient implements Runnable {
     public void watchApplicationKeyMappings() {
         // TODO: (Praminda) implement a deadline with retries
         int maxSize = Integer.parseInt(ConfigHolder.getInstance().getEnvVarConfig().getXdsMaxMsgSize());
-        reqObserver = stub.withMaxInboundMessageSize(maxSize).streamApplicationKeyMappings(new StreamObserver<DiscoveryResponse>() {
+        reqObserver = stub.withMaxInboundMessageSize(maxSize)
+                .streamApplicationKeyMappings(new StreamObserver<DiscoveryResponse>() {
             @Override
             public void onNext(DiscoveryResponse response) {
                 logger.info("Application key generation event received with version : " + response.getVersionInfo());

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationKeyMappingDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationKeyMappingDiscoveryClient.java
@@ -123,7 +123,8 @@ public class ApplicationKeyMappingDiscoveryClient implements Runnable {
 
     public void watchApplicationKeyMappings() {
         // TODO: (Praminda) implement a deadline with retries
-        reqObserver = stub.streamApplicationKeyMappings(new StreamObserver<DiscoveryResponse>() {
+        int maxSize = Integer.parseInt(ConfigHolder.getInstance().getEnvVarConfig().getXdsMaxMsgSize());
+        reqObserver = stub.withMaxInboundMessageSize(maxSize).streamApplicationKeyMappings(new StreamObserver<DiscoveryResponse>() {
             @Override
             public void onNext(DiscoveryResponse response) {
                 logger.info("Application key generation event received with version : " + response.getVersionInfo());

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationPolicyDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationPolicyDiscoveryClient.java
@@ -124,7 +124,8 @@ public class ApplicationPolicyDiscoveryClient implements Runnable {
     public void watchApplicationPolicies() {
         // TODO: (Praminda) implement a deadline with retries
         int maxSize = Integer.parseInt(ConfigHolder.getInstance().getEnvVarConfig().getXdsMaxMsgSize());
-        reqObserver = stub.withMaxInboundMessageSize(maxSize).streamApplicationPolicies(new StreamObserver<DiscoveryResponse>() {
+        reqObserver = stub.withMaxInboundMessageSize(maxSize)
+                .streamApplicationPolicies(new StreamObserver<DiscoveryResponse>() {
             @Override
             public void onNext(DiscoveryResponse response) {
                 logger.info("Application policy event received with version : " + response.getVersionInfo());

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationPolicyDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationPolicyDiscoveryClient.java
@@ -128,7 +128,12 @@ public class ApplicationPolicyDiscoveryClient implements Runnable {
                 .streamApplicationPolicies(new StreamObserver<DiscoveryResponse>() {
             @Override
             public void onNext(DiscoveryResponse response) {
-                logger.info("Application policy event received with version : " + response.getVersionInfo());
+                logger.info("Application policy event received with version : " + response.getVersionInfo() +
+                        " and size(bytes) : " + response.getSerializedSize());
+                if ((double) response.getSerializedSize() / maxSize > 0.90) {
+                    logger.error("Current response size exceeds 90% of the maximum message size for the type : " +
+                            response.getTypeUrl());
+                }
                 logger.debug("Received Application Policy discovery response " + response);
                 XdsSchedulerManager.getInstance().stopApplicationPolicyDiscoveryScheduling();
                 latestReceived = response;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationPolicyDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationPolicyDiscoveryClient.java
@@ -123,7 +123,8 @@ public class ApplicationPolicyDiscoveryClient implements Runnable {
 
     public void watchApplicationPolicies() {
         // TODO: (Praminda) implement a deadline with retries
-        reqObserver = stub.streamApplicationPolicies(new StreamObserver<DiscoveryResponse>() {
+        int maxSize = Integer.parseInt(ConfigHolder.getInstance().getEnvVarConfig().getXdsMaxMsgSize());
+        reqObserver = stub.withMaxInboundMessageSize(maxSize).streamApplicationPolicies(new StreamObserver<DiscoveryResponse>() {
             @Override
             public void onNext(DiscoveryResponse response) {
                 logger.info("Application policy event received with version : " + response.getVersionInfo());

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationPolicyDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ApplicationPolicyDiscoveryClient.java
@@ -130,8 +130,8 @@ public class ApplicationPolicyDiscoveryClient implements Runnable {
             public void onNext(DiscoveryResponse response) {
                 logger.info("Application policy event received with version : " + response.getVersionInfo() +
                         " and size(bytes) : " + response.getSerializedSize());
-                if ((double) response.getSerializedSize() / maxSize > 0.90) {
-                    logger.error("Current response size exceeds 90% of the maximum message size for the type : " +
+                if ((double) response.getSerializedSize() / maxSize > 0.80) {
+                    logger.error("Current response size exceeds 80% of the maximum message size for the type : " +
                             response.getTypeUrl());
                 }
                 logger.debug("Received Application Policy discovery response " + response);

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/KeyManagerDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/KeyManagerDiscoveryClient.java
@@ -128,8 +128,8 @@ public class KeyManagerDiscoveryClient implements Runnable {
             public void onNext(DiscoveryResponse response) {
                 logger.info("Key manager event received with version : " + response.getVersionInfo() +
                         " and size(bytes) : " + response.getSerializedSize());
-                if ((double) response.getSerializedSize() / maxSize > 0.90) {
-                    logger.error("Current response size exceeds 90% of the maximum message size for the type : " +
+                if ((double) response.getSerializedSize() / maxSize > 0.80) {
+                    logger.error("Current response size exceeds 80% of the maximum message size for the type : " +
                             response.getTypeUrl());
                 }
                 logger.debug("Received KeyManagers discovery response " + response);

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/KeyManagerDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/KeyManagerDiscoveryClient.java
@@ -126,7 +126,12 @@ public class KeyManagerDiscoveryClient implements Runnable {
         reqObserver = stub.withMaxInboundMessageSize(maxSize).streamKeyManagers(new StreamObserver<>() {
             @Override
             public void onNext(DiscoveryResponse response) {
-                logger.info("Key manager event received with version : " + response.getVersionInfo());
+                logger.info("Key manager event received with version : " + response.getVersionInfo() +
+                        " and size(bytes) : " + response.getSerializedSize());
+                if ((double) response.getSerializedSize() / maxSize > 0.90) {
+                    logger.error("Current response size exceeds 90% of the maximum message size for the type : " +
+                            response.getTypeUrl());
+                }
                 logger.debug("Received KeyManagers discovery response " + response);
                 XdsSchedulerManager.getInstance().stopKeyManagerDiscoveryScheduling();
                 latestReceived = response;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/RevokedTokenDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/RevokedTokenDiscoveryClient.java
@@ -131,8 +131,8 @@ public class RevokedTokenDiscoveryClient implements Runnable {
             public void onNext(DiscoveryResponse response) {
                 logger.info("Revoked  token event received with version : " + response.getVersionInfo() +
                         " and size(bytes) : " + response.getSerializedSize());
-                if ((double) response.getSerializedSize() / maxSize > 0.90) {
-                    logger.error("Current response size exceeds 90% of the maximum message size for the type : " +
+                if ((double) response.getSerializedSize() / maxSize > 0.80) {
+                    logger.error("Current response size exceeds 80% of the maximum message size for the type : " +
                             response.getTypeUrl());
                 }
                 logger.debug("Received revoked tokens response " + response);

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/RevokedTokenDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/RevokedTokenDiscoveryClient.java
@@ -129,7 +129,12 @@ public class RevokedTokenDiscoveryClient implements Runnable {
         reqObserver = stub.withMaxInboundMessageSize(maxSize).streamTokens(new StreamObserver<>() {
             @Override
             public void onNext(DiscoveryResponse response) {
-                logger.info("Revoked  token event received with version : " + response.getVersionInfo());
+                logger.info("Revoked  token event received with version : " + response.getVersionInfo() +
+                        " and size(bytes) : " + response.getSerializedSize());
+                if ((double) response.getSerializedSize() / maxSize > 0.90) {
+                    logger.error("Current response size exceeds 90% of the maximum message size for the type : " +
+                            response.getTypeUrl());
+                }
                 logger.debug("Received revoked tokens response " + response);
                 XdsSchedulerManager.getInstance().stopRevokedTokenDiscoveryScheduling();
                 latestReceived = response;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/SubscriptionDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/SubscriptionDiscoveryClient.java
@@ -129,8 +129,8 @@ public class SubscriptionDiscoveryClient implements Runnable {
             public void onNext(DiscoveryResponse response) {
                 logger.info("Subscription event received with version : " + response.getVersionInfo() +
                         " and size(bytes) : " + response.getSerializedSize());
-                if ((double) response.getSerializedSize() / maxSize > 0.90) {
-                    logger.error("Current response size exceeds 90% of the maximum message size for the type : " +
+                if ((double) response.getSerializedSize() / maxSize > 0.80) {
+                    logger.error("Current response size exceeds 80% of the maximum message size for the type : " +
                             response.getTypeUrl());
                 }
                 logger.debug("Received Subscription discovery response " + response);

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/SubscriptionDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/SubscriptionDiscoveryClient.java
@@ -127,7 +127,12 @@ public class SubscriptionDiscoveryClient implements Runnable {
                 .streamSubscriptions(new StreamObserver<DiscoveryResponse>() {
             @Override
             public void onNext(DiscoveryResponse response) {
-                logger.info("Subscription event received with version : " + response.getVersionInfo());
+                logger.info("Subscription event received with version : " + response.getVersionInfo() +
+                        " and size(bytes) : " + response.getSerializedSize());
+                if ((double) response.getSerializedSize() / maxSize > 0.90) {
+                    logger.error("Current response size exceeds 90% of the maximum message size for the type : " +
+                            response.getTypeUrl());
+                }
                 logger.debug("Received Subscription discovery response " + response);
                 XdsSchedulerManager.getInstance().stopSubscriptionDiscoveryScheduling();
                 latestReceived = response;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/SubscriptionDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/SubscriptionDiscoveryClient.java
@@ -122,7 +122,8 @@ public class SubscriptionDiscoveryClient implements Runnable {
 
     public void watchSubscriptions() {
         // TODO: (Praminda) implement a deadline with retries
-        reqObserver = stub.streamSubscriptions(new StreamObserver<DiscoveryResponse>() {
+        int maxSize = Integer.parseInt(ConfigHolder.getInstance().getEnvVarConfig().getXdsMaxMsgSize());
+        reqObserver = stub.withMaxInboundMessageSize(maxSize).streamSubscriptions(new StreamObserver<DiscoveryResponse>() {
             @Override
             public void onNext(DiscoveryResponse response) {
                 logger.info("Subscription event received with version : " + response.getVersionInfo());

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/SubscriptionDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/SubscriptionDiscoveryClient.java
@@ -123,7 +123,8 @@ public class SubscriptionDiscoveryClient implements Runnable {
     public void watchSubscriptions() {
         // TODO: (Praminda) implement a deadline with retries
         int maxSize = Integer.parseInt(ConfigHolder.getInstance().getEnvVarConfig().getXdsMaxMsgSize());
-        reqObserver = stub.withMaxInboundMessageSize(maxSize).streamSubscriptions(new StreamObserver<DiscoveryResponse>() {
+        reqObserver = stub.withMaxInboundMessageSize(maxSize)
+                .streamSubscriptions(new StreamObserver<DiscoveryResponse>() {
             @Override
             public void onNext(DiscoveryResponse response) {
                 logger.info("Subscription event received with version : " + response.getVersionInfo());

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/SubscriptionPolicyDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/SubscriptionPolicyDiscoveryClient.java
@@ -122,7 +122,8 @@ public class SubscriptionPolicyDiscoveryClient implements Runnable {
 
     public void watchSubscriptionPolicies() {
         // TODO: (Praminda) implement a deadline with retries
-        reqObserver = stub.streamSubscriptionPolicies(new StreamObserver<>() {
+        int maxSize = Integer.parseInt(ConfigHolder.getInstance().getEnvVarConfig().getXdsMaxMsgSize());
+        reqObserver = stub.withMaxInboundMessageSize(maxSize).streamSubscriptionPolicies(new StreamObserver<>() {
             @Override
             public void onNext(DiscoveryResponse response) {
                 logger.info("Subscription policy event received with version : " + response.getVersionInfo());

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/SubscriptionPolicyDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/SubscriptionPolicyDiscoveryClient.java
@@ -126,7 +126,12 @@ public class SubscriptionPolicyDiscoveryClient implements Runnable {
         reqObserver = stub.withMaxInboundMessageSize(maxSize).streamSubscriptionPolicies(new StreamObserver<>() {
             @Override
             public void onNext(DiscoveryResponse response) {
-                logger.info("Subscription policy event received with version : " + response.getVersionInfo());
+                logger.info("Subscription policy event received with version : " + response.getVersionInfo() +
+                        " and size(bytes) : " + response.getSerializedSize());
+                if ((double) response.getSerializedSize() / maxSize > 0.90) {
+                    logger.error("Current response size exceeds 90% of the maximum message size for the type : " +
+                            response.getTypeUrl());
+                }
                 logger.debug("Received Subscription  policy discovery response " + response);
                 XdsSchedulerManager.getInstance().stopSubscriptionPolicyDiscoveryScheduling();
                 latestReceived = response;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/SubscriptionPolicyDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/SubscriptionPolicyDiscoveryClient.java
@@ -128,8 +128,8 @@ public class SubscriptionPolicyDiscoveryClient implements Runnable {
             public void onNext(DiscoveryResponse response) {
                 logger.info("Subscription policy event received with version : " + response.getVersionInfo() +
                         " and size(bytes) : " + response.getSerializedSize());
-                if ((double) response.getSerializedSize() / maxSize > 0.90) {
-                    logger.error("Current response size exceeds 90% of the maximum message size for the type : " +
+                if ((double) response.getSerializedSize() / maxSize > 0.80) {
+                    logger.error("Current response size exceeds 80% of the maximum message size for the type : " +
                             response.getTypeUrl());
                 }
                 logger.debug("Received Subscription  policy discovery response " + response);

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ThrottleDataDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ThrottleDataDiscoveryClient.java
@@ -126,8 +126,8 @@ public class ThrottleDataDiscoveryClient implements Runnable {
                     public void onNext(DiscoveryResponse response) {
                         logger.info("Throttle data event received with version : " + response.getVersionInfo() +
                                 " and size(bytes) : " + response.getSerializedSize());
-                        if ((double) response.getSerializedSize() / maxSize > 0.90) {
-                            logger.error("Current response size exceeds 90% of the maximum message size " +
+                        if ((double) response.getSerializedSize() / maxSize > 0.80) {
+                            logger.error("Current response size exceeds 80% of the maximum message size " +
                                     "for the type : " + response.getTypeUrl());
                         }
                         logger.debug("Received ThrottleData discovery response " + response);

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ThrottleDataDiscoveryClient.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/discovery/ThrottleDataDiscoveryClient.java
@@ -124,7 +124,12 @@ public class ThrottleDataDiscoveryClient implements Runnable {
                 .streamThrottleData(new StreamObserver<>() {
                     @Override
                     public void onNext(DiscoveryResponse response) {
-                        logger.info("Throttle data event received with version : " + response.getVersionInfo());
+                        logger.info("Throttle data event received with version : " + response.getVersionInfo() +
+                                " and size(bytes) : " + response.getSerializedSize());
+                        if ((double) response.getSerializedSize() / maxSize > 0.90) {
+                            logger.error("Current response size exceeds 90% of the maximum message size " +
+                                    "for the type : " + response.getTypeUrl());
+                        }
                         logger.debug("Received ThrottleData discovery response " + response);
                         XdsSchedulerManager.getInstance().stopThrottleDataDiscoveryScheduling();
                         latestReceived = response;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/subscription/SubscriptionDataStoreImpl.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/subscription/SubscriptionDataStoreImpl.java
@@ -23,7 +23,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.wso2.choreo.connect.discovery.subscription.APIs;
 import org.wso2.choreo.connect.enforcer.constants.APIConstants;
-import org.wso2.choreo.connect.enforcer.discovery.ApiListDiscoveryClient;
 import org.wso2.choreo.connect.enforcer.discovery.ApplicationDiscoveryClient;
 import org.wso2.choreo.connect.enforcer.discovery.ApplicationKeyMappingDiscoveryClient;
 import org.wso2.choreo.connect.enforcer.discovery.ApplicationPolicyDiscoveryClient;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/subscription/SubscriptionDataStoreImpl.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/subscription/SubscriptionDataStoreImpl.java
@@ -151,7 +151,8 @@ public class SubscriptionDataStoreImpl implements SubscriptionDataStore {
     private void initializeLoadingTasks() {
         SubscriptionDiscoveryClient.getInstance().watchSubscriptions();
         ApplicationDiscoveryClient.getInstance().watchApplications();
-        ApiListDiscoveryClient.getInstance().watchApiList();
+        // Disabled API List discovery as it is not set as per current adapter implementation.
+//        ApiListDiscoveryClient.getInstance().watchApiList();
         ApplicationPolicyDiscoveryClient.getInstance().watchApplicationPolicies();
         SubscriptionPolicyDiscoveryClient.getInstance().watchSubscriptionPolicies();
         ApplicationKeyMappingDiscoveryClient.getInstance().watchApplicationKeyMappings();


### PR DESCRIPTION
### Purpose
Log each and every XDS request response within adapter so that we can ensure when an XDS request is sent.
Setup XDS max message size for all the grpc client stubs.
Disable APIListDiscoveryClient


### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
