### PR TITLE
Remove additional Deployment Type validation based on keytype included in JWT claims

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/KeyValidator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/KeyValidator.java
@@ -160,17 +160,17 @@ public class KeyValidator {
                             String apiContextTemplate = apiContext.substring(0, lastIndexOfVersion);
                             sub = datastore.getSubscriptionByAppIdApiContextVersionRange(app.getUUID(),
                                     apiContextTemplate, "v" + apiSemVersion.getMajor());
-                            if (sub == null) {
-                                log.info(
-                                        "Valid subscription not found for oauth access token. application:" +
-                                                " {} app_UUID: {} API_Context:API_Version: {} API_UUID : {}",
-                                        app.getName(), app.getUUID(), apiContext + ":" + apiVersion, uuid);
-                            } else {
-                                log.debug("All information is retrieved from the in-memory data store.");
-                            }
                         } catch (EnforcerException e) {
                             log.debug("API version: {} is not a valid semantic version", apiVersion);
                         }
+                    } else {
+                        log.debug("All information is retrieved from the in-memory data store.");
+                    }
+                    if (sub == null) {
+                        log.info(
+                                "Valid subscription not found for oauth access token. application:" +
+                                        " {} app_UUID: {} API_Context:API_Version: {} API_UUID : {}",
+                                app.getName(), app.getUUID(), apiContext + ":" + apiVersion, uuid);
                     } else {
                         log.debug("All information is retrieved from the in-memory data store.");
                     }

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
@@ -300,13 +300,6 @@ public class JWTAuthenticator implements Authenticator {
                     AuthenticationContext authenticationContext = FilterUtils
                             .generateAuthenticationContext(requestContext, jwtTokenIdentifier, validationInfo,
                                     apiKeyValidationInfoDTO, endUserToken, jwtToken, true);
-                    //TODO: (VirajSalaka) Place the keytype population logic properly for self contained token
-                    if (claims.getClaim("keytype") != null) {
-                        authenticationContext.setKeyType(claims.getClaim("keytype").toString());
-                    }
-                    // Check if the token has access to the gateway configured environment.
-                    checkTokenEnvAgainstDeploymentType(requestContext.getAuthenticationContext().getKeyType(),
-                            requestContext.getMatchedAPI());
                     if (!"Unlimited".equals(authenticationContext.getTier())) {
                         // For subscription rate limiting, it is required to populate dynamic metadata
                         String subscriptionId = authenticationContext.getApiUUID() + ":" +


### PR DESCRIPTION


### Purpose
Remove additional Deployment Type validation based on keytype included in JWT claims. This is unnecessary because the choreo should always depend on the keytype assigned based on the application key entry

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
