### PR TITLE
[3.2.x] Make gRPC timeout parameter configurable

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
@@ -183,6 +183,7 @@ public const string GRPC_ANALYTICS = "analytics.gRPCAnalytics";
 public const string GRPC_ANALYTICS_ENABLE = "enable";
 public const string GRPC_ENDPOINT_URL = "endpointURL";
 public const string GRPC_RETRY_TIME_MILLISECONDS = "reconnectTimeInMillies";
+public const string GRPC_TIMEOUT_MILLISECONDS = "timeoutInMillis";
  
 //validation_filter related constatnts
 public const string PATHS = "paths";

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/micro_gw_conf_defaults.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/micro_gw_conf_defaults.bal
@@ -84,6 +84,7 @@ public const string DEFAULT_AM_ANALYTICS_VERSION_310 = "3.1.0";
 //constants for gRPC analytics
 public const string DEFAULT_GRPC_ENDPOINT_URL = "https://localhost:9806";
 public const int DEFAULT_GRPC_RECONNECT_TIME_IN_MILLES = 6000;
+public const int DEFAULT_GRPC_TIMEOUT_IN_MILLIS = 2147483647;
 
 public const boolean DEFAULT_HTTP2_ENABLED = true;
 

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/grpcAnalytics/gRPC_analytics_client.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/grpcAnalytics/gRPC_analytics_client.bal
@@ -4,6 +4,7 @@ import ballerina/task;
 grpc:StreamingClient gRPCEp = new grpc:StreamingClient();
 boolean gRPCConnection = false; //check gRPC connection
 int reConnectTime =  <int>getConfigIntValue(GRPC_ANALYTICS,GRPC_RETRY_TIME_MILLISECONDS, DEFAULT_GRPC_RECONNECT_TIME_IN_MILLES);
+int timeout = <int>getConfigIntValue(GRPC_ANALYTICS,GRPC_TIMEOUT_MILLISECONDS, DEFAULT_GRPC_TIMEOUT_IN_MILLIS);
 boolean isTaskStarted = false;    //to check gRPC reconnect task
 
 task:Scheduler gRPCConnectTimer = new({
@@ -46,7 +47,7 @@ config = {
         },
         verifyHostname:false //to avoid SSL certificate validation error
     },
-    timeoutInMillis : 2147483647
+    timeoutInMillis : timeout
 } );
 
 # `initGRPCService` function binds gRPC streaming client endpoint with server message listner.

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/analytics_util.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/analytics_util.bal
@@ -28,6 +28,7 @@ boolean configsRead = false;
 boolean isGrpcAnalyticsEnabled = false;
 string endpointURL = "";
 int gRPCReconnectTime = 3000;
+int gRPCTimeout = DEFAULT_GRPC_TIMEOUT_IN_MILLIS;
 
 function populateThrottleAnalyticsDTO(http:FilterContext context) returns (ThrottleAnalyticsEventDTO | error) {
     boolean isSecured = <boolean>context.attributes[IS_SECURED];
@@ -183,10 +184,12 @@ function initializegRPCAnalytics() {
     isGrpcAnalyticsEnabled = <boolean>getConfigBooleanValue(GRPC_ANALYTICS, GRPC_ANALYTICS_ENABLE, DEFAULT_ANALYTICS_ENABLED);
     endpointURL = <string>getConfigValue(GRPC_ANALYTICS, GRPC_ENDPOINT_URL, DEFAULT_GRPC_ENDPOINT_URL);
     gRPCReconnectTime = <int>getConfigIntValue(GRPC_ANALYTICS, GRPC_RETRY_TIME_MILLISECONDS, DEFAULT_GRPC_RECONNECT_TIME_IN_MILLES);
+    gRPCTimeout = <int>getConfigIntValue(GRPC_ANALYTICS,GRPC_TIMEOUT_MILLISECONDS, DEFAULT_GRPC_TIMEOUT_IN_MILLIS);
     printDebug(KEY_GRPC_ANALYTICS, "gRPC endpoint URL : " + endpointURL);
     printDebug(KEY_GRPC_ANALYTICS, "gRPC keyStore file : " + <string>getConfigValue(LISTENER_CONF_INSTANCE_ID, KEY_STORE_PATH, DEFAULT_KEY_STORE_PATH));
     printDebug(KEY_GRPC_ANALYTICS, "gRPC trustStore file : " + <string>getConfigValue(LISTENER_CONF_INSTANCE_ID, TRUST_STORE_PATH, DEFAULT_TRUST_STORE_PATH));
     printDebug(KEY_GRPC_ANALYTICS, "gRPC retry time  : " + gRPCReconnectTime.toString());
+    printDebug(KEY_GRPC_ANALYTICS, "gRPC timeout  : " + gRPCTimeout.toString());
 
     if (isGrpcAnalyticsEnabled) {
         initGRPCService();


### PR DESCRIPTION
### Purpose
- Resolves https://github.com/wso2/product-microgateway/issues/3471
- Forwardport https://github.com/wso2-support/product-microgateway/pull/411
- Make gRPC `timeoutInMillis` parameter user configurable. Previously this was set to 2147483647. Now users can configure this with a default value of 2147483647.




