### PR TITLE
Internal-endpoint-testing: handle x-choreo-test-session-id header cors config

### DIFF
--- a/adapter/config/default_config.go
+++ b/adapter/config/default_config.go
@@ -84,6 +84,7 @@ var defaultConfig = &Config{
 				"testKey", "Internal-Key"},
 			AllowCredentials: false,
 			ExposeHeaders:    []string{},
+			MandatoryHeaders: []string{"x-choreo-test-session-id"},
 		},
 		Upstream: envoyUpstream{
 			TLS: upstreamTLS{

--- a/adapter/config/types.go
+++ b/adapter/config/types.go
@@ -216,6 +216,7 @@ type globalCors struct {
 	AllowHeaders     []string
 	AllowCredentials bool
 	ExposeHeaders    []string
+	MandatoryHeaders []string
 }
 
 // Envoy Upstream Related Configurations

--- a/adapter/internal/oasparser/envoyconf/constants.go
+++ b/adapter/internal/oasparser/envoyconf/constants.go
@@ -157,3 +157,8 @@ const (
 	AccessLogTypeText = "text"
 	AccessLogTypeJSON = "json"
 )
+
+// Test session header name used for internal endpoint testing
+const (
+	choreoTestSessionHeaderName = "x-choreo-test-session-id"
+)

--- a/adapter/internal/oasparser/envoyconf/envoyconf_internal_test.go
+++ b/adapter/internal/oasparser/envoyconf/envoyconf_internal_test.go
@@ -719,7 +719,7 @@ func TestGetCorsPolicy(t *testing.T) {
 	// Test the configuration when headers configuration is not provided.
 	corsPolicy3 := getCorsPolicy(corsConfigModel3)
 	assert.NotNil(t, corsPolicy3, "Cors Policy should not be null.")
-	assert.Empty(t, corsPolicy3.GetAllowHeaders(), "Cors Allow headers should be null.")
+	assert.Equal(t, "x-choreo-test-session-id", corsPolicy3.GetAllowHeaders(), "Cors Allow headers mismatch")
 	assert.Empty(t, corsPolicy3.GetExposeHeaders(), "Cors Expose Headers should be null.")
 	assert.NotEmpty(t, corsPolicy3.GetAllowOriginStringMatch(), "Cors Allowded Origins should not be null.")
 	assert.Equal(t, regexp.QuoteMeta("http://test1.com"),
@@ -737,7 +737,7 @@ func TestGetCorsPolicy(t *testing.T) {
 	err := routeWithoutCors.GetTypedPerFilterConfig()[wellknown.CORS].UnmarshalTo(corsConfig1)
 
 	assert.Nilf(t, err, "Error while parsing Cors Configuration %v", corsConfig1)
-	assert.Empty(t, corsConfig1.GetAllowHeaders(), "Cors AllowHeaders should be empty.")
+	assert.Equal(t, "x-choreo-test-session-id", corsConfig1.GetAllowHeaders(), "Cors Allow headers mismatch")
 	assert.Empty(t, corsConfig1.GetAllowCredentials(), "Cors AllowCredentials should be empty.")
 	assert.Empty(t, corsConfig1.GetAllowMethods(), "Cors AllowMethods should be empty.")
 	assert.Empty(t, corsConfig1.GetAllowOriginStringMatch(), "Cors AllowOriginStringMatch should be empty.")

--- a/adapter/internal/oasparser/envoyconf/envoyconf_internal_test.go
+++ b/adapter/internal/oasparser/envoyconf/envoyconf_internal_test.go
@@ -737,7 +737,7 @@ func TestGetCorsPolicy(t *testing.T) {
 	err := routeWithoutCors.GetTypedPerFilterConfig()[wellknown.CORS].UnmarshalTo(corsConfig1)
 
 	assert.Nilf(t, err, "Error while parsing Cors Configuration %v", corsConfig1)
-	assert.Equal(t, "x-choreo-test-session-id", corsConfig1.GetAllowHeaders(), "Cors Allow headers mismatch")
+	assert.Empty(t, corsConfig1.GetAllowHeaders(), "Cors AllowHeaders should be empty.")
 	assert.Empty(t, corsConfig1.GetAllowCredentials(), "Cors AllowCredentials should be empty.")
 	assert.Empty(t, corsConfig1.GetAllowMethods(), "Cors AllowMethods should be empty.")
 	assert.Empty(t, corsConfig1.GetAllowOriginStringMatch(), "Cors AllowOriginStringMatch should be empty.")

--- a/adapter/internal/oasparser/envoyconf/envoyconf_internal_test.go
+++ b/adapter/internal/oasparser/envoyconf/envoyconf_internal_test.go
@@ -711,7 +711,7 @@ func TestGetCorsPolicy(t *testing.T) {
 	assert.NotNil(t, corsPolicy2.GetAllowMethods())
 	assert.Equal(t, "GET, POST", corsPolicy2.GetAllowMethods(), "Cors allow methods mismatch.")
 	assert.NotNil(t, corsPolicy2.GetAllowHeaders(), "Cors Allowed headers should not be null.")
-	assert.Equal(t, "X-TEST-HEADER1, X-TEST-HEADER2", corsPolicy2.GetAllowHeaders(), "Cors Allow headers mismatch")
+	assert.Equal(t, "X-TEST-HEADER1, X-TEST-HEADER2, x-choreo-test-session-id", corsPolicy2.GetAllowHeaders(), "Cors Allow headers mismatch")
 	assert.NotNil(t, corsPolicy2.GetExposeHeaders(), "Cors Expose headers should not be null.")
 	assert.Equal(t, "X-Custom-Header", corsPolicy2.GetExposeHeaders(), "Cors Expose headers mismatch")
 	assert.True(t, corsPolicy2.GetAllowCredentials().GetValue(), "Cors Access Allow Credentials should be true")

--- a/adapter/internal/oasparser/envoyconf/listener.go
+++ b/adapter/internal/oasparser/envoyconf/listener.go
@@ -46,7 +46,7 @@ func CreateRoutesConfigForRds(vHosts []*routev3.VirtualHost) *routev3.RouteConfi
 	routeConfiguration := routev3.RouteConfiguration{
 		Name:                   rdsConfigName,
 		VirtualHosts:           vHosts,
-		RequestHeadersToRemove: []string{clusterHeaderName, gatewayURLHeaderName},
+		RequestHeadersToRemove: []string{clusterHeaderName, gatewayURLHeaderName, choreoTestSessionHeaderName},
 	}
 	return &routeConfiguration
 }

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -1455,11 +1455,7 @@ func getCorsPolicy(corsConfig *model.CorsConfig) *cors_filter_v3.CorsPolicy {
 		return nil
 	}
 
-	conf, errReadConfig := config.ReadConfigs()
-	if errReadConfig != nil {
-		logger.LoggerOasparser.Error("Error loading configuration. ", errReadConfig)
-		return nil;
-	}
+	conf, _ := config.ReadConfigs()
 	if len(conf.Envoy.Cors.MandatoryHeaders) > 0 {
 		corsConfig.AccessControlAllowHeaders = append(corsConfig.AccessControlAllowHeaders, conf.Envoy.Cors.MandatoryHeaders...)
 	}

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -1455,8 +1455,14 @@ func getCorsPolicy(corsConfig *model.CorsConfig) *cors_filter_v3.CorsPolicy {
 		return nil
 	}
 
-	// Append `x-choreo-test-session-id` used for internal endpoint testing to AccessControlAllowHeaders.
-	corsConfig.AccessControlAllowHeaders = append(corsConfig.AccessControlAllowHeaders, choreoTestSessionHeaderName)
+	conf, errReadConfig := config.ReadConfigs()
+	if errReadConfig != nil {
+		logger.LoggerOasparser.Error("Error loading configuration. ", errReadConfig)
+		return nil;
+	}
+	if len(conf.Envoy.Cors.MandatoryHeaders) > 0 {
+		corsConfig.AccessControlAllowHeaders = append(corsConfig.AccessControlAllowHeaders, conf.Envoy.Cors.MandatoryHeaders...)
+	}
 
 	stringMatcherArray := []*envoy_type_matcherv3.StringMatcher{}
 	for _, origin := range corsConfig.AccessControlAllowOrigins {

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -1455,6 +1455,9 @@ func getCorsPolicy(corsConfig *model.CorsConfig) *cors_filter_v3.CorsPolicy {
 		return nil
 	}
 
+	// Append `x-choreo-test-session-id` used for internal endpoint testing to AccessControlAllowHeaders.
+	corsConfig.AccessControlAllowHeaders = append(corsConfig.AccessControlAllowHeaders, choreoTestSessionHeaderName)
+
 	stringMatcherArray := []*envoy_type_matcherv3.StringMatcher{}
 	for _, origin := range corsConfig.AccessControlAllowOrigins {
 		regexMatcher := &envoy_type_matcherv3.StringMatcher{

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/security/CorsTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/security/CorsTestCase.java
@@ -42,7 +42,7 @@ public class CorsTestCase {
     private String allowedOrigin1 = "http://test1.com";
     private String allowedOrigin2 = "http://test2.com";
     private String allowedMethods = "GET,PUT,POST";
-    private String allowedHeaders = "Authorization,X-PINGOTHER";
+    private String allowedHeaders = "Authorization,X-PINGOTHER,x-choreo-test-session-id";
     private String exposeHeaders = "X-Custom-Header";
 
     private static final String ORIGIN_HEADER = "Origin";


### PR DESCRIPTION
### Purpose
This PR enables the `x-choreo-test-session-id` header to be used for internal endpoint testing. Also the header is added to the RequestHeadersToRemove config.

Related to https://github.com/wso2-enterprise/choreo/issues/25701

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
