### PR TITLE
add scope validation for InternalAPIKeyAuthenticator

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
@@ -52,6 +52,7 @@ import org.wso2.choreo.connect.enforcer.util.FilterUtils;
 
 import java.text.ParseException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -270,9 +271,12 @@ public class InternalAPIKeyAuthenticator extends APIKeyHandler {
 
         Set<String> scopeSet = null;
         try {
-            scopeSet = new HashSet<>(
-                    jwtTokenPayloadInfo.getPayload().getStringListClaim(APIConstants.JwtTokenConstants.SCOPE)
-            );
+            scopeSet = new HashSet<>();
+            List<String> scopeList = jwtTokenPayloadInfo.getPayload()
+                    .getStringListClaim(APIConstants.JwtTokenConstants.SCOPE);
+            if (scopeList != null) {
+                scopeSet.addAll(scopeList);
+            }
             APIKeyValidationInfoDTO apiKeyValidationInfoDTO =  getAPIKeyValidationDTO(requestContext, payload);
             apiKeyValidationInfoDTO.setScopes(scopeSet);
 

--- a/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/jwtValidator/InternalKeyTestCase.java
+++ b/integration/test-integration/src/test/java/org/wso2/choreo/connect/tests/testcases/standalone/jwtValidator/InternalKeyTestCase.java
@@ -36,8 +36,8 @@ public class InternalKeyTestCase {
 
     @BeforeClass(description = "initialise the setup")
     void start() throws Exception {
-        internalKey = TokenUtil.getJwtForPetstoreWithDifferentContext(TestConstant.KEY_TYPE_PRODUCTION, null,
-                true, "v2/standard");
+        internalKey = TokenUtil.getJwtForPetstoreWithDifferentContext(TestConstant.KEY_TYPE_PRODUCTION,
+                "write:pets read:pets", true, "v2/standard");
         tamperedInternalKey = internalKey.substring(0, internalKey.length()-4);
     }
 


### PR DESCRIPTION
### Purpose
Validate scopes for internal api keys.
As mentioned in `[Architecture] [Choreo] Admin configuration for configuring developer portal IdP`, scope validation will be added to the API keys. To maintain the current behavior for console users (internal developers) following [PR](https://github.com/wso2-enterprise/choreo-product-apim/pull/749) should be merged before this

### Issues
- https://github.com/wso2-enterprise/choreo/issues/26160
