### PR TITLE
Bug fix: x-choreo-test-session-id is appended to CORS config repeatedly 

### DIFF
--- a/adapter/internal/oasparser/envoyconf/envoyconf_internal_test.go
+++ b/adapter/internal/oasparser/envoyconf/envoyconf_internal_test.go
@@ -704,6 +704,8 @@ func TestGetCorsPolicy(t *testing.T) {
 	// Test configuration when all the fields are provided.
 	corsPolicy2 := getCorsPolicy(corsConfigModel2)
 	assert.NotNil(t, corsPolicy2, "Cors Policy should not be null.")
+	// To make sure that the allow headers in the config passed is not modified.
+	assert.Equal(t, 2, len(corsConfigModel2.AccessControlAllowHeaders), "Cors Config is modified which is not supposed to be modified.")
 	assert.NotEmpty(t, corsPolicy2.GetAllowOriginStringMatch(), "Cors Allowded Origins should not be null.")
 	assert.Equal(t, regexp.QuoteMeta("http://test.com"),
 		corsPolicy2.GetAllowOriginStringMatch()[0].GetSafeRegex().GetRegex(),

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -1454,10 +1454,11 @@ func getCorsPolicy(corsConfig *model.CorsConfig) *cors_filter_v3.CorsPolicy {
 	if corsConfig == nil || !corsConfig.Enabled {
 		return nil
 	}
+	var finalAccessControlAllowHeaders []string
 
 	conf, _ := config.ReadConfigs()
 	if len(conf.Envoy.Cors.MandatoryHeaders) > 0 {
-		corsConfig.AccessControlAllowHeaders = append(corsConfig.AccessControlAllowHeaders, conf.Envoy.Cors.MandatoryHeaders...)
+		finalAccessControlAllowHeaders = append(corsConfig.AccessControlAllowHeaders, conf.Envoy.Cors.MandatoryHeaders...)
 	}
 
 	stringMatcherArray := []*envoy_type_matcherv3.StringMatcher{}
@@ -1485,8 +1486,8 @@ func getCorsPolicy(corsConfig *model.CorsConfig) *cors_filter_v3.CorsPolicy {
 	if len(corsConfig.AccessControlAllowMethods) > 0 {
 		corsPolicy.AllowMethods = strings.Join(corsConfig.AccessControlAllowMethods, ", ")
 	}
-	if len(corsConfig.AccessControlAllowHeaders) > 0 {
-		corsPolicy.AllowHeaders = strings.Join(corsConfig.AccessControlAllowHeaders, ", ")
+	if len(finalAccessControlAllowHeaders) > 0 {
+		corsPolicy.AllowHeaders = strings.Join(finalAccessControlAllowHeaders, ", ")
 	}
 	if len(corsConfig.AccessControlExposeHeaders) > 0 {
 		corsPolicy.ExposeHeaders = strings.Join(corsConfig.AccessControlExposeHeaders, ", ")


### PR DESCRIPTION


### Purpose
$subject happens depending on the number of resources. For 1st resource once, for the second two times and so on. And this could lead to failures at nginx level due to increased header buffer sizes.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
