### PR TITLE
Remove unnecessary configs passed from Adapter to Enforcer through xDS messages

### DIFF
--- a/adapter/config/default_config.go
+++ b/adapter/config/default_config.go
@@ -50,6 +50,14 @@ var defaultConfig = &Config{
 			CertFile:           "/home/wso2/security/truststore/consul/local-dc-client-consul-0.pem",
 			KeyFile:            "/home/wso2/security/truststore/consul/local-dc-client-consul-0-key.pem",
 		},
+		XdsPayloadFormatter: xdsPayloadFormatter{
+			KeyManagerConfigs: keyManagerConfigs{
+				RetainKeys: []string{
+					"self_validate_jwt", "issuer", "claim_mappings", "consumer_key_claim",
+					"scopes_claim", "jwks_endpoint", "certificate_type", "certificate_value", "environments",
+				},
+			},
+		},
 		Keystore: keystore{
 			KeyPath:  "/home/wso2/security/keystore/mg.key",
 			CertPath: "/home/wso2/security/keystore/mg.pem",

--- a/adapter/config/types.go
+++ b/adapter/config/types.go
@@ -89,6 +89,8 @@ type adapter struct {
 	VhostMapping []vhostMapping
 	// Consul represents the configuration required to connect to consul service discovery
 	Consul consul
+	// XdsPayloadFormatter represents the configuration to format the xds payload
+	XdsPayloadFormatter xdsPayloadFormatter
 	// Keystore contains the keyFile and Cert File of the adapter
 	Keystore keystore
 	// Trusted Certificates
@@ -206,6 +208,16 @@ type consul struct {
 	CertFile string
 	// KeyFile path to the key file(PEM encoded) required for tls connection between adapter and a consul client
 	KeyFile string
+}
+
+type xdsPayloadFormatter struct {
+	// KeyManagerConfigs contains format configurations related to key manager configuration
+	KeyManagerConfigs keyManagerConfigs
+}
+
+type keyManagerConfigs struct {
+	// RetainKeys contains the keys that should be retained in the xds payload
+	RetainKeys []string
 }
 
 // Global CORS configurations

--- a/adapter/internal/discovery/xds/marshaller.go
+++ b/adapter/internal/discovery/xds/marshaller.go
@@ -342,6 +342,8 @@ func marshalKeyMappingMapToList(keyMappingMap map[string]*subscription.Applicati
 
 // MarshalKeyManager converts the data into KeyManager proto type
 func MarshalKeyManager(keyManager *types.KeyManager) *keymgt.KeyManagerConfig {
+	// Filter the key manager configuration based on the configuration retention list
+	keyManager.Configuration = getFilteredKeyManagerConfig(keyManager.Configuration)
 	configList, err := json.Marshal(keyManager.Configuration)
 	configuration := string(configList)
 	if err == nil {

--- a/adapter/internal/discovery/xds/payloadfmt.go
+++ b/adapter/internal/discovery/xds/payloadfmt.go
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package xds
+
+import "github.com/wso2/product-microgateway/adapter/config"
+
+func getFilteredKeyManagerConfig(kmConfigMap map[string]interface{}) map[string]interface{} {
+	filteredKMConfigMap := make(map[string]interface{})
+	conf, _ := config.ReadConfigs()
+
+	for _, retainKey := range conf.Adapter.XdsPayloadFormatter.KeyManagerConfigs.RetainKeys {
+		// Does not required to check for case sensitivity as the enforcer reads from a hash map
+		val, ok := kmConfigMap[retainKey]
+		if ok {
+			filteredKMConfigMap[retainKey] = val
+		}
+	}
+	return filteredKMConfigMap
+}

--- a/adapter/internal/discovery/xds/payloadfmt_test.go
+++ b/adapter/internal/discovery/xds/payloadfmt_test.go
@@ -47,6 +47,7 @@ func TestGetFilteredKeyManagerConfig(t *testing.T) {
 		"consumer_key_claim":             "azp",
 		"certificate_type":               "JWKS",
 		"token_endpoint":                 "https://api.asgardeo.io/t/renukafernando/oauth2/token",
+		"environments":                   []string{"Production"},
 	}
 	expectedKmConfigMap := map[string]interface{}{
 		"claim_mappings":     []string{},
@@ -55,6 +56,7 @@ func TestGetFilteredKeyManagerConfig(t *testing.T) {
 		"scopes_claim":       "scope",
 		"consumer_key_claim": "azp",
 		"certificate_type":   "JWKS",
+		"environments":       []string{"Production"},
 	}
 
 	filteredConfig := getFilteredKeyManagerConfig(kmConfigMap)

--- a/adapter/internal/discovery/xds/payloadfmt_test.go
+++ b/adapter/internal/discovery/xds/payloadfmt_test.go
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package xds
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFilteredKeyManagerConfig(t *testing.T) {
+	kmConfigMap := map[string]interface{}{
+		"claim_mappings":     []string{},
+		"authorize_endpoint": "https://api.asgardeo.io/t/renukafernando/oauth2/authorize",
+		"grant_types": []string{
+			"refresh_token ",
+			"password",
+			"client_credentials",
+			"authorization_code",
+			"implicit",
+		},
+		"enable_oauth_app_creation":      true,
+		"certificate_value":              "https://api.asgardeo.io/t/renukafernando/oauth2/jwks",
+		"enable_map_oauth_consumer_apps": false,
+		"enable_token_hash":              false,
+		"revoke_endpoint":                "https://api.asgardeo.io/t/renukafernando/oauth2/revoke",
+		"well_known_endpoint":            "https://api.asgardeo.io/t/renukafernando/oauth2/token/.well-known/openid-configuration",
+		"self_validate_jwt":              true,
+		"scopes_claim":                   "scope",
+		"enable_token_encryption":        false,
+		"client_registration_endpoint":   "https://api.asgardeo.io/t/renukafernando/api/server/v1",
+		"logout_endpoint":                "https://api.asgardeo.io/t/renukafernando/oidc/logout",
+		"consumer_key_claim":             "azp",
+		"certificate_type":               "JWKS",
+		"token_endpoint":                 "https://api.asgardeo.io/t/renukafernando/oauth2/token",
+	}
+	expectedKmConfigMap := map[string]interface{}{
+		"claim_mappings":     []string{},
+		"certificate_value":  "https://api.asgardeo.io/t/renukafernando/oauth2/jwks",
+		"self_validate_jwt":  true,
+		"scopes_claim":       "scope",
+		"consumer_key_claim": "azp",
+		"certificate_type":   "JWKS",
+	}
+
+	filteredConfig := getFilteredKeyManagerConfig(kmConfigMap)
+	assert.Equal(t, expectedKmConfigMap, filteredConfig, "Filtered Key Manager Configuration is not as expected")
+}

--- a/adapter/internal/messaging/notification_listener.go
+++ b/adapter/internal/messaging/notification_listener.go
@@ -161,7 +161,7 @@ func handleKeyManagerEvents(data []byte) {
 		delete(xds.KeyManagerMap, xds.GenerateKeyManagerMapKey(keyManagerEvent.Name, keyManagerEvent.Organization))
 		xds.GenerateAndUpdateKeyManagerList()
 	} else if decodedByte != nil {
-		logger.LoggerInternalMsg.Infof("decoded Key Manager stream %s", string(decodedByte))
+		logger.LoggerInternalMsg.Debugf("decoded Key Manager stream %s", string(decodedByte))
 		kmConfigMapErr := json.Unmarshal([]byte(string(decodedByte)), &kmConfigMap)
 		if kmConfigMapErr != nil {
 			logger.LoggerInternalMsg.Errorf("Error occurred while unmarshalling key manager config map %v", kmConfigMapErr)
@@ -174,7 +174,7 @@ func handleKeyManagerEvents(data []byte) {
 				Type: keyManagerEvent.Type, Enabled: keyManagerEvent.Enabled,
 				TenantDomain: keyManagerEvent.TenantDomain, Organization: keyManagerEvent.Organization,
 				Configuration: kmConfigMap}
-			logger.LoggerInternalMsg.Infof("Key Manager data %v", keyManager.Configuration)
+			logger.LoggerInternalMsg.Debugf("Key Manager data %v", keyManager.Configuration)
 			xds.KeyManagerMap[xds.GenerateKeyManagerMapKey(keyManagerEvent.Name, keyManagerEvent.Organization)] = xds.MarshalKeyManager(&keyManager)
 			xds.GenerateAndUpdateKeyManagerList()
 		}

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/keymgt/KeyManagerHolder.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/keymgt/KeyManagerHolder.java
@@ -80,6 +80,10 @@ public class KeyManagerHolder {
     private Map<String,  Map<String, ExtendedTokenIssuerDto>> getAllKmIssuers(List<KeyManagerConfig> kmIssuers) {
         Map<String,  Map<String, ExtendedTokenIssuerDto>> kmIssuerMap = new ConcurrentHashMap<>();
         for (KeyManagerConfig keyManagerConfig : kmIssuers) {
+            if (!keyManagerConfig.getEnabled()) {
+                continue;
+            }
+
             JSONObject configObj = new JSONObject(keyManagerConfig.getConfiguration());
             Map<String, Object> configuration = new HashMap<>();
             Iterator<String> keysItr = configObj.keys();
@@ -89,10 +93,8 @@ public class KeyManagerHolder {
                 configuration.put(key, value);
             }
 
-            if (keyManagerConfig.getEnabled()) {
-                addKMTokenIssuers(keyManagerConfig.getName(), keyManagerConfig.getOrganization(),
-                        configuration, kmIssuerMap);
-            }
+            addKMTokenIssuers(keyManagerConfig.getName(), keyManagerConfig.getOrganization(),
+                configuration, kmIssuerMap);
         }
         return kmIssuerMap;
     }

--- a/resources/conf/config.toml.template
+++ b/resources/conf/config.toml.template
@@ -66,6 +66,13 @@ sandboxVhost = "sandbox.host"
   # Optional path to the private key for Consul communication. If this is set, then you need to also set certFile
   keyFile = "/home/wso2/security/truststore/consul/local-dc-client-consul-0-key.pem"
 
+# Configurations for formatting xDS payloads sent to other Choreo Connect components
+[adapter.xdsPayloadFormatter]
+# Enforcer Key Manager formattings
+[adapter.xdsPayloadFormatter.keyManagerConfigs]
+# Retain only the following keys in the Key Manager configurations from Control Plane events and send to Enforcer
+retainKeys = ["self_validate_jwt", "issuer", "claim_mappings", "consumer_key_claim", "scopes_claim", "jwks_endpoint", "certificate_type", "certificate_value", "environments"]
+
 # Configurations required for router to route the traffic from different clients to services
 [router] # --------------------------------------------------------
   # Host for listener of Router
@@ -481,7 +488,7 @@ enabled = true
     # Number of tasks can be submitted to the worker pool without being blocked.
     queueSizePerPool = 1000
   # HTTP client configuration.
-  [controlPlane.httpClient] 
+  [controlPlane.hTTPClient]
     requestTimeOut = 30
 
 # Global Adapter related configurations


### PR DESCRIPTION
### Purpose
$subject

#### Logs

adapter-1   | 2024-02-16 15:10:13 INFO [marshaller.go:346] - [xds.MarshalKeyManager] [-] [Renuka] Key Manager Configuration Before Filter: map[AuthorizeURL:https://choreo-am-service:9443/oauth2/authorize LogoutURL:https://choreo-am-service:9443/oidc/logout OAuthConfigurations.EncryptPersistedTokens:true RevokeURL:https://choreo-am-service:9443/oauth2/revoke ServerURL:https://choreo-am-service:9443/services/ TokenURL:https://choreo-am-service:9443/oauth2/token VALIDITY_PERIOD:3600 authorize_endpoint:https://choreo-am-service:9443/oauth2/authorize certificate_type:JWKS certificate_value:https://sts.preview-dv.choreo.dev/oauth2/jwks enable_map_oauth_consumer_apps:false enable_oauth_app_creation:true enable_token_encryption:false enable_token_generation:true enable_token_hash:false grant_types:[refresh_token urn:ietf:params:oauth:grant-type:saml2-bearer password client_credentials iwa:ntlm authorization_code urn:ietf:params:oauth:grant-type:token-exchange urn:ietf:params:oauth:grant-type:jwt-bearer] issuer:https://sts.preview-dv.choreo.dev:443/oauth2/token logout_endpoint:https://choreo-am-service:9443/oidc/logout revoke_endpoint:https://choreo-am-service:9443/oauth2/revoke self_validate_jwt:true token_endpoint:https://choreo-am-service:9443/oauth2/token token_format_string:[{"enable":true,"type":"REFERENCE","value":"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}"}] validation_enable:true]
adapter-1   | 2024-02-16 15:10:13 INFO [marshaller.go:350] - [xds.MarshalKeyManager] [-] [Renuka] Key Manager Configuration After Filter: {"certificate_type":"JWKS","certificate_value":"https://sts.preview-dv.choreo.dev/oauth2/jwks","issuer":"https://sts.preview-dv.choreo.dev:443/oauth2/token","self_validate_jwt":true}
adapter-1   | 2024-02-16 15:10:13 INFO [marshaller.go:346] - [xds.MarshalKeyManager] [-] [Renuka] Key Manager Configuration Before Filter: map[authorize_endpoint:https://dev.api.asgardeo.io/t/renukafernando/oauth2/authorize certificate_type:JWKS certificate_value:https://dev.api.asgardeo.io/t/renukafernando/oauth2/jwks claim_mappings:[] client_registration_endpoint:https://dev.api.asgardeo.io/t/renukafernando/api/server/v1 consumer_key_claim:azp enable_map_oauth_consumer_apps:false enable_oauth_app_creation:true enable_token_encryption:false enable_token_generation:true enable_token_hash:false grant_types:[refresh_token password client_credentials authorization_code implicit] issuer:https://dev.api.asgardeo.io/t/renukafernando/oauth2/token revoke_endpoint:https://dev.api.asgardeo.io/t/renukafernando/oauth2/revoke scopes_claim:scope self_validate_jwt:true token_endpoint:https://dev.api.asgardeo.io/t/renukafernando/oauth2/token]
adapter-1   | 2024-02-16 15:10:13 INFO [marshaller.go:350] - [xds.MarshalKeyManager] [-] [Renuka] Key Manager Configuration After Filter: {"certificate_type":"JWKS","certificate_value":"https://dev.api.asgardeo.io/t/renukafernando/oauth2/jwks","claim_mappings":[],"consumer_key_claim":"azp","issuer":"https://dev.api.asgardeo.io/t/renukafernando/oauth2/token","scopes_claim":"scope","self_validate_jwt":true}

#### Formatted Config

```json
{
  "certificate_type": "JWKS",
  "certificate_value": "https://sts.preview-dv.choreo.dev/oauth2/jwks",
  "issuer": "https://sts.preview-dv.choreo.dev:443/oauth2/token",
  "self_validate_jwt": true
}
```

```json
{
  "certificate_type": "JWKS",
  "certificate_value": "https://dev.api.asgardeo.io/t/renukafernando/oauth2/jwks",
  "claim_mappings": [],
  "consumer_key_claim": "azp",
  "issuer": "https://dev.api.asgardeo.io/t/renukafernando/oauth2/token",
  "scopes_claim": "scope",
  "self_validate_jwt": true
}

```

#### Event based key manager configs

adapter-1   | 2024-02-16 15:22:42 INFO [notification_listener.go:164] - [messaging.handleKeyManagerEvents] [-] decoded Key Manager stream {"claim_mappings":[],"authorize_endpoint":"https://dev.api.asgardeo.io/t/renukafernando/oauth2/authorize","grant_types":["refresh_token","password","client_credentials","authorization_code","implicit"],"enable_oauth_app_creation":true,"certificate_value":"https://dev.api.asgardeo.io/t/renukafernando/oauth2/jwks","enable_token_generation":true,"issuer":"https://dev.api.asgardeo.io/t/renukafernando/oauth2/token","enable_map_oauth_consumer_apps":false,"enable_token_hash":false,"self_validate_jwt":true,"revoke_endpoint":"https://dev.api.asgardeo.io/t/renukafernando/oauth2/revoke","scopes_claim":"scope","enable_token_encryption":false,"client_registration_endpoint":"https://dev.api.asgardeo.io/t/renukafernando/api/server/v1","consumer_key_claim":"azp","certificate_type":"JWKS","token_endpoint":"https://dev.api.asgardeo.io/t/renukafernando/oauth2/token"}
adapter-1   | 2024-02-16 15:22:42 INFO [notification_listener.go:177] - [messaging.handleKeyManagerEvents] [-] Key Manager data map[authorize_endpoint:https://dev.api.asgardeo.io/t/renukafernando/oauth2/authorize certificate_type:JWKS certificate_value:https://dev.api.asgardeo.io/t/renukafernando/oauth2/jwks claim_mappings:[] client_registration_endpoint:https://dev.api.asgardeo.io/t/renukafernando/api/server/v1 consumer_key_claim:azp enable_map_oauth_consumer_apps:false enable_oauth_app_creation:true enable_token_encryption:false enable_token_generation:true enable_token_hash:false grant_types:[refresh_token password client_credentials authorization_code implicit] issuer:https://dev.api.asgardeo.io/t/renukafernando/oauth2/token revoke_endpoint:https://dev.api.asgardeo.io/t/renukafernando/oauth2/revoke scopes_claim:scope self_validate_jwt:true token_endpoint:https://dev.api.asgardeo.io/t/renukafernando/oauth2/token]
adapter-1   | 2024-02-16 15:22:42 INFO [marshaller.go:346] - [xds.MarshalKeyManager] [-] [Renuka] Key Manager Configuration Before Filter: map[authorize_endpoint:https://dev.api.asgardeo.io/t/renukafernando/oauth2/authorize certificate_type:JWKS certificate_value:https://dev.api.asgardeo.io/t/renukafernando/oauth2/jwks claim_mappings:[] client_registration_endpoint:https://dev.api.asgardeo.io/t/renukafernando/api/server/v1 consumer_key_claim:azp enable_map_oauth_consumer_apps:false enable_oauth_app_creation:true enable_token_encryption:false enable_token_generation:true enable_token_hash:false grant_types:[refresh_token password client_credentials authorization_code implicit] issuer:https://dev.api.asgardeo.io/t/renukafernando/oauth2/token revoke_endpoint:https://dev.api.asgardeo.io/t/renukafernando/oauth2/revoke scopes_claim:scope self_validate_jwt:true token_endpoint:https://dev.api.asgardeo.io/t/renukafernando/oauth2/token]
adapter-1   | 2024-02-16 15:22:42 INFO [marshaller.go:350] - [xds.MarshalKeyManager] [-] [Renuka] Key Manager Configuration After Filter: {"certificate_type":"JWKS","certificate_value":"https://dev.api.asgardeo.io/t/renukafernando/oauth2/jwks","claim_mappings":[],"consumer_key_claim":"azp","issuer":"https://dev.api.asgardeo.io/t/renukafernando/oauth2/token","scopes_claim":"scope","self_validate_jwt":true}

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
