### PR TITLE
Add support for invocations with internal key for Websocket APIs

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/RestAPI.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/RestAPI.java
@@ -35,7 +35,6 @@ import org.wso2.choreo.connect.enforcer.commons.model.RequestContext;
 import org.wso2.choreo.connect.enforcer.commons.model.ResourceConfig;
 import org.wso2.choreo.connect.enforcer.commons.model.SecuritySchemaConfig;
 import org.wso2.choreo.connect.enforcer.config.ConfigHolder;
-import org.wso2.choreo.connect.enforcer.config.dto.AuthHeaderDto;
 import org.wso2.choreo.connect.enforcer.config.dto.FilterDTO;
 import org.wso2.choreo.connect.enforcer.constants.APIConstants;
 import org.wso2.choreo.connect.enforcer.cors.CorsFilter;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/Utils.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/Utils.java
@@ -19,10 +19,17 @@ package org.wso2.choreo.connect.enforcer.api;
 
 import org.wso2.choreo.connect.discovery.api.EndpointClusterConfig;
 import org.wso2.choreo.connect.enforcer.commons.model.EndpointCluster;
+import org.wso2.choreo.connect.enforcer.commons.model.RequestContext;
 import org.wso2.choreo.connect.enforcer.commons.model.RetryConfig;
+import org.wso2.choreo.connect.enforcer.commons.model.SecuritySchemaConfig;
+import org.wso2.choreo.connect.enforcer.config.ConfigHolder;
+import org.wso2.choreo.connect.enforcer.config.dto.AuthHeaderDto;
+import org.wso2.choreo.connect.enforcer.constants.APIConstants;
+import org.wso2.choreo.connect.enforcer.util.FilterUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Utility Methods used across different APIs.
@@ -65,5 +72,60 @@ public class Utils {
             }
         }
         return endpointCluster;
+    }
+
+    static void populateRemoveAndProtectedHeaders(RequestContext requestContext) {
+        // If the resource has disabled security, then the authorization headers are
+        // passed as it is.
+        // Expectation is that the backend should validate the authorization header if
+        // it is not processed
+        // at the gateway level.
+        // It is required to check if the resource Path is not null, because when CORS
+        // preflight request handling, or
+        // generic OPTIONS method call happens, matchedResourcePath becomes null.
+        if (requestContext.getMatchedResourcePath() != null &&
+                requestContext.getMatchedResourcePath().isDisableSecurity()) {
+            return;
+        }
+
+        Map<String, SecuritySchemaConfig> securitySchemeDefinitions = requestContext.getMatchedAPI()
+                .getSecuritySchemeDefinitions();
+        // API key headers are considered to be protected headers, such that the header
+        // would not be sent
+        // to backend and traffic manager.
+        // This would prevent leaking credentials, even if user is invoking unsecured
+        // resource with some
+        // credentials.
+        for (Map.Entry<String, SecuritySchemaConfig> entry : securitySchemeDefinitions.entrySet()) {
+            SecuritySchemaConfig schema = entry.getValue();
+            if (APIConstants.SWAGGER_API_KEY_AUTH_TYPE_NAME.equalsIgnoreCase(schema.getType())) {
+                if (APIConstants.SWAGGER_API_KEY_IN_HEADER.equals(schema.getIn())) {
+                    requestContext.getProtectedHeaders().add(schema.getName());
+                    requestContext.getRemoveHeaders().add(schema.getName());
+                    continue;
+                }
+                if (APIConstants.SWAGGER_API_KEY_IN_QUERY.equals(schema.getIn())) {
+                    requestContext.getQueryParamsToRemove().add(schema.getName());
+                }
+            }
+        }
+
+        // Internal-Key credential is considered to be protected headers, such that the
+        // header would not be sent
+        // to backend and traffic manager.
+        String internalKeyHeader = ConfigHolder.getInstance().getConfig().getAuthHeader()
+                .getTestConsoleHeaderName().toLowerCase();
+        requestContext.getRemoveHeaders().add(internalKeyHeader);
+        // Avoid internal key being published to the Traffic Manager
+        requestContext.getProtectedHeaders().add(internalKeyHeader);
+
+        // Remove Authorization Header
+        AuthHeaderDto authHeader = ConfigHolder.getInstance().getConfig().getAuthHeader();
+        String authHeaderName = FilterUtils.getAuthHeaderName(requestContext);
+        if (!authHeader.isEnableOutboundAuthHeader()) {
+            requestContext.getRemoveHeaders().add(authHeaderName);
+        }
+        // Authorization Header should not be included in the throttle publishing event.
+        requestContext.getProtectedHeaders().add(authHeaderName);
     }
 }

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/WebSocketAPI.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/WebSocketAPI.java
@@ -145,13 +145,13 @@ public class WebSocketAPI implements API {
 
         this.apiLifeCycleState = api.getApiLifeCycleState();
         this.apiConfig = new APIConfig.Builder(name).uuid(api.getId()).vhost(vhost).basePath(basePath).version(version)
-            .resources(resources).apiType(apiType).apiLifeCycleState(apiLifeCycleState)
-            .apiSecurity(securityScopesMap).tier(api.getTier()).endpointSecurity(endpointSecurity)
-            .authHeader(api.getAuthorizationHeader()).disableSecurity(api.getDisableSecurity())
-            .organizationId(api.getOrganizationId()).endpoints(endpoints).apiProvider(api.getApiProvider())
-            .securitySchemeDefinitions(securitySchemeDefinitions).enableBackendJWT(api.getEnableBackendJWT())
-            .backendJWTConfiguration(backendJWTConfiguration).deploymentType(api.getDeploymentType())
-            .environmentId(api.getEnvironmentId()).environmentName(api.getEnvironmentName()).build();
+                .resources(resources).apiType(apiType).apiLifeCycleState(apiLifeCycleState)
+                .apiSecurity(securityScopesMap).tier(api.getTier()).endpointSecurity(endpointSecurity)
+                .authHeader(api.getAuthorizationHeader()).disableSecurity(api.getDisableSecurity())
+                .organizationId(api.getOrganizationId()).endpoints(endpoints).apiProvider(api.getApiProvider())
+                .securitySchemeDefinitions(securitySchemeDefinitions).enableBackendJWT(api.getEnableBackendJWT())
+                .backendJWTConfiguration(backendJWTConfiguration).deploymentType(api.getDeploymentType())
+                .environmentId(api.getEnvironmentId()).environmentName(api.getEnvironmentName()).build();
         initFilters();
         initUpgradeFilters();
         return basePath;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/WebSocketAPI.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/WebSocketAPI.java
@@ -33,13 +33,11 @@ import org.wso2.choreo.connect.enforcer.commons.model.RequestContext;
 import org.wso2.choreo.connect.enforcer.commons.model.ResourceConfig;
 import org.wso2.choreo.connect.enforcer.commons.model.SecuritySchemaConfig;
 import org.wso2.choreo.connect.enforcer.config.ConfigHolder;
-import org.wso2.choreo.connect.enforcer.config.dto.AuthHeaderDto;
 import org.wso2.choreo.connect.enforcer.constants.APIConstants;
 import org.wso2.choreo.connect.enforcer.cors.CorsFilter;
 import org.wso2.choreo.connect.enforcer.security.AuthFilter;
 import org.wso2.choreo.connect.enforcer.throttle.ThrottleConstants;
 import org.wso2.choreo.connect.enforcer.throttle.ThrottleFilter;
-import org.wso2.choreo.connect.enforcer.util.FilterUtils;
 import org.wso2.choreo.connect.enforcer.websocket.WebSocketMetaDataFilter;
 import org.wso2.choreo.connect.enforcer.websocket.WebSocketThrottleFilter;
 import org.wso2.choreo.connect.enforcer.websocket.WebSocketThrottleResponse;
@@ -162,7 +160,7 @@ public class WebSocketAPI implements API {
         ResponseObject responseObject = new ResponseObject();
         responseObject.setRequestPath(requestContext.getRequestPath());
         responseObject.setApiUuid(apiConfig.getUuid());
-        populateRemoveAndProtectedHeaders(requestContext);
+        Utils.populateRemoveAndProtectedHeaders(requestContext);
         
         if (executeFilterChain(requestContext)) {
             responseObject.setStatusCode(APIConstants.StatusCodes.OK.getCode());
@@ -278,58 +276,4 @@ public class WebSocketAPI implements API {
         return webSocketThrottleResponse;
     }
 
-    private void populateRemoveAndProtectedHeaders(RequestContext requestContext) {
-        // If the resource has disabled security, then the authorization headers are
-        // passed as it is.
-        // Expectation is that the backend should validate the authorization header if
-        // it is not processed
-        // at the gateway level.
-        // It is required to check if the resource Path is not null, because when CORS
-        // preflight request handling, or
-        // generic OPTIONS method call happens, matchedResourcePath becomes null.
-        if (requestContext.getMatchedResourcePath() != null &&
-                requestContext.getMatchedResourcePath().isDisableSecurity()) {
-            return;
-        }
-
-        Map<String, SecuritySchemaConfig> securitySchemeDefinitions = requestContext.getMatchedAPI()
-                .getSecuritySchemeDefinitions();
-        // API key headers are considered to be protected headers, such that the header
-        // would not be sent
-        // to backend and traffic manager.
-        // This would prevent leaking credentials, even if user is invoking unsecured
-        // resource with some
-        // credentials.
-        for (Map.Entry<String, SecuritySchemaConfig> entry : securitySchemeDefinitions.entrySet()) {
-            SecuritySchemaConfig schema = entry.getValue();
-            if (APIConstants.SWAGGER_API_KEY_AUTH_TYPE_NAME.equalsIgnoreCase(schema.getType())) {
-                if (APIConstants.SWAGGER_API_KEY_IN_HEADER.equals(schema.getIn())) {
-                    requestContext.getProtectedHeaders().add(schema.getName());
-                    requestContext.getRemoveHeaders().add(schema.getName());
-                    continue;
-                }
-                if (APIConstants.SWAGGER_API_KEY_IN_QUERY.equals(schema.getIn())) {
-                    requestContext.getQueryParamsToRemove().add(schema.getName());
-                }
-            }
-        }
-
-        // Internal-Key credential is considered to be protected headers, such that the
-        // header would not be sent
-        // to backend and traffic manager.
-        String internalKeyHeader = ConfigHolder.getInstance().getConfig().getAuthHeader()
-                .getTestConsoleHeaderName().toLowerCase();
-        requestContext.getRemoveHeaders().add(internalKeyHeader);
-        // Avoid internal key being published to the Traffic Manager
-        requestContext.getProtectedHeaders().add(internalKeyHeader);
-
-        // Remove Authorization Header
-        AuthHeaderDto authHeader = ConfigHolder.getInstance().getConfig().getAuthHeader();
-        String authHeaderName = FilterUtils.getAuthHeaderName(requestContext);
-        if (!authHeader.isEnableOutboundAuthHeader()) {
-            requestContext.getRemoveHeaders().add(authHeaderName);
-        }
-        // Authorization Header should not be included in the throttle publishing event.
-        requestContext.getProtectedHeaders().add(authHeaderName);
-    }
 }

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/WebSocketAPI.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/WebSocketAPI.java
@@ -145,13 +145,13 @@ public class WebSocketAPI implements API {
 
         this.apiLifeCycleState = api.getApiLifeCycleState();
         this.apiConfig = new APIConfig.Builder(name).uuid(api.getId()).vhost(vhost).basePath(basePath).version(version)
-        .resources(resources).apiType(apiType).apiLifeCycleState(apiLifeCycleState)
-        .apiSecurity(securityScopesMap).tier(api.getTier()).endpointSecurity(endpointSecurity)
-        .authHeader(api.getAuthorizationHeader()).disableSecurity(api.getDisableSecurity())
-        .organizationId(api.getOrganizationId()).endpoints(endpoints).apiProvider(api.getApiProvider())
-        .securitySchemeDefinitions(securitySchemeDefinitions).enableBackendJWT(api.getEnableBackendJWT())
-        .backendJWTConfiguration(backendJWTConfiguration).deploymentType(api.getDeploymentType())
-        .environmentId(api.getEnvironmentId()).environmentName(api.getEnvironmentName()).build();
+            .resources(resources).apiType(apiType).apiLifeCycleState(apiLifeCycleState)
+            .apiSecurity(securityScopesMap).tier(api.getTier()).endpointSecurity(endpointSecurity)
+            .authHeader(api.getAuthorizationHeader()).disableSecurity(api.getDisableSecurity())
+            .organizationId(api.getOrganizationId()).endpoints(endpoints).apiProvider(api.getApiProvider())
+            .securitySchemeDefinitions(securitySchemeDefinitions).enableBackendJWT(api.getEnableBackendJWT())
+            .backendJWTConfiguration(backendJWTConfiguration).deploymentType(api.getDeploymentType())
+            .environmentId(api.getEnvironmentId()).environmentName(api.getEnvironmentName()).build();
         initFilters();
         initUpgradeFilters();
         return basePath;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/WebSocketAPI.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/WebSocketAPI.java
@@ -20,21 +20,26 @@ package org.wso2.choreo.connect.enforcer.api;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.wso2.choreo.connect.discovery.api.Api;
+import org.wso2.choreo.connect.discovery.api.Resource;
 import org.wso2.choreo.connect.discovery.api.Scopes;
 import org.wso2.choreo.connect.discovery.api.SecurityList;
 import org.wso2.choreo.connect.discovery.api.SecurityScheme;
 import org.wso2.choreo.connect.enforcer.commons.Filter;
 import org.wso2.choreo.connect.enforcer.commons.model.APIConfig;
+import org.wso2.choreo.connect.enforcer.commons.model.BackendJWTConfiguration;
 import org.wso2.choreo.connect.enforcer.commons.model.EndpointCluster;
 import org.wso2.choreo.connect.enforcer.commons.model.EndpointSecurity;
 import org.wso2.choreo.connect.enforcer.commons.model.RequestContext;
+import org.wso2.choreo.connect.enforcer.commons.model.ResourceConfig;
 import org.wso2.choreo.connect.enforcer.commons.model.SecuritySchemaConfig;
 import org.wso2.choreo.connect.enforcer.config.ConfigHolder;
+import org.wso2.choreo.connect.enforcer.config.dto.AuthHeaderDto;
 import org.wso2.choreo.connect.enforcer.constants.APIConstants;
 import org.wso2.choreo.connect.enforcer.cors.CorsFilter;
 import org.wso2.choreo.connect.enforcer.security.AuthFilter;
 import org.wso2.choreo.connect.enforcer.throttle.ThrottleConstants;
 import org.wso2.choreo.connect.enforcer.throttle.ThrottleFilter;
+import org.wso2.choreo.connect.enforcer.util.FilterUtils;
 import org.wso2.choreo.connect.enforcer.websocket.WebSocketMetaDataFilter;
 import org.wso2.choreo.connect.enforcer.websocket.WebSocketThrottleFilter;
 import org.wso2.choreo.connect.enforcer.websocket.WebSocketThrottleResponse;
@@ -68,9 +73,12 @@ public class WebSocketAPI implements API {
         String name = api.getTitle();
         String version = api.getVersion();
         String apiType = api.getApiType();
-        Map<String, SecuritySchemaConfig> securitySchemes = new HashMap<>();
-        Map<String, List<String>> apiSecurity = new HashMap<>();
+        Map<String, SecuritySchemaConfig> securitySchemeDefinitions = new HashMap<>();
+        Map<String, List<String>> securityScopesMap = new HashMap<>();
         Map<String, EndpointCluster> endpoints = new HashMap<>();
+        List<ResourceConfig> resources = new ArrayList<>();
+        EndpointSecurity endpointSecurity = new EndpointSecurity();
+        BackendJWTConfiguration backendJWTConfiguration = new BackendJWTConfiguration();
 
         EndpointCluster productionEndpoints = Utils.processEndpoints(api.getProductionEndpoints());
         EndpointCluster sandboxEndpoints = Utils.processEndpoints(api.getSandboxEndpoints());
@@ -81,6 +89,10 @@ public class WebSocketAPI implements API {
             endpoints.put(APIConstants.API_KEY_TYPE_SANDBOX, sandboxEndpoints);
         }
 
+        if (api.getEnableBackendJWT() && api.getBackendJWTConfiguration() != null) {
+            backendJWTConfiguration.setAudiences(api.getBackendJWTConfiguration().getAudiencesList());
+        }
+
         for (SecurityScheme securityScheme : api.getSecuritySchemeList()) {
             if (securityScheme.getType() != null) {
                 String schemaType = securityScheme.getType();
@@ -89,16 +101,16 @@ public class WebSocketAPI implements API {
                 securitySchemaConfig.setType(schemaType);
                 securitySchemaConfig.setName(securityScheme.getName());
                 securitySchemaConfig.setIn(securityScheme.getIn());
-                securitySchemes.put(schemaType, securitySchemaConfig);
+                securitySchemeDefinitions.put(schemaType, securitySchemaConfig);
             }
         }
 
         for (SecurityList securityList : api.getSecurityList()) {
             for (Map.Entry<String, Scopes> entry : securityList.getScopeListMap().entrySet()) {
-                apiSecurity.put(entry.getKey(), new ArrayList<>());
+                securityScopesMap.put(entry.getKey(), new ArrayList<>());
                 if (entry.getValue() != null && entry.getValue().getScopesList().size() > 0) {
                     List<String> scopeList = new ArrayList<>(entry.getValue().getScopesList());
-                    apiSecurity.replace(entry.getKey(), scopeList);
+                    securityScopesMap.replace(entry.getKey(), scopeList);
                 }
                 // only supports security scheme OR combinations. Example -
                 // Security:
@@ -108,7 +120,18 @@ public class WebSocketAPI implements API {
             }
         }
 
-        EndpointSecurity endpointSecurity = new EndpointSecurity();
+        for (Resource res : api.getResourcesList()) {
+            Map<String, EndpointCluster> endpointClusterMap = new HashMap();
+            EndpointCluster prodEndpointCluster = Utils.processEndpoints(res.getProductionEndpoints());
+            EndpointCluster sandEndpointCluster = Utils.processEndpoints(res.getSandboxEndpoints());
+            if (prodEndpointCluster != null) {
+                endpointClusterMap.put(APIConstants.API_KEY_TYPE_PRODUCTION, prodEndpointCluster);
+            }
+            if (sandEndpointCluster != null) {
+                endpointClusterMap.put(APIConstants.API_KEY_TYPE_SANDBOX, sandEndpointCluster);
+            }
+        }
+
         if (api.getEndpointSecurity().hasProductionSecurityInfo()) {
             endpointSecurity.setProductionSecurityInfo(
                     APIProcessUtils.convertProtoEndpointSecurity(
@@ -122,11 +145,13 @@ public class WebSocketAPI implements API {
 
         this.apiLifeCycleState = api.getApiLifeCycleState();
         this.apiConfig = new APIConfig.Builder(name).uuid(api.getId()).vhost(vhost).basePath(basePath).version(version)
-                .apiType(apiType).apiLifeCycleState(apiLifeCycleState)
-                .apiSecurity(apiSecurity).tier(api.getTier()).endpointSecurity(endpointSecurity)
-                .authHeader(api.getAuthorizationHeader()).disableSecurity(api.getDisableSecurity())
-                .organizationId(api.getOrganizationId()).endpoints(endpoints).apiProvider(api.getApiProvider())
-                .build();
+        .resources(resources).apiType(apiType).apiLifeCycleState(apiLifeCycleState)
+        .apiSecurity(securityScopesMap).tier(api.getTier()).endpointSecurity(endpointSecurity)
+        .authHeader(api.getAuthorizationHeader()).disableSecurity(api.getDisableSecurity())
+        .organizationId(api.getOrganizationId()).endpoints(endpoints).apiProvider(api.getApiProvider())
+        .securitySchemeDefinitions(securitySchemeDefinitions).enableBackendJWT(api.getEnableBackendJWT())
+        .backendJWTConfiguration(backendJWTConfiguration).deploymentType(api.getDeploymentType())
+        .environmentId(api.getEnvironmentId()).environmentName(api.getEnvironmentName()).build();
         initFilters();
         initUpgradeFilters();
         return basePath;
@@ -135,6 +160,10 @@ public class WebSocketAPI implements API {
     @Override
     public ResponseObject process(RequestContext requestContext) {
         ResponseObject responseObject = new ResponseObject();
+        responseObject.setRequestPath(requestContext.getRequestPath());
+        responseObject.setApiUuid(apiConfig.getUuid());
+        populateRemoveAndProtectedHeaders(requestContext);
+        
         if (executeFilterChain(requestContext)) {
             responseObject.setStatusCode(APIConstants.StatusCodes.OK.getCode());
             if (requestContext.getAddHeaders() != null && requestContext.getAddHeaders().size() > 0) {
@@ -247,5 +276,60 @@ public class WebSocketAPI implements API {
         webSocketThrottleResponse.setThrottlePeriod(
                 (Long) requestContext.getProperties().get(ThrottleConstants.HEADER_RETRY_AFTER));
         return webSocketThrottleResponse;
+    }
+
+    private void populateRemoveAndProtectedHeaders(RequestContext requestContext) {
+        // If the resource has disabled security, then the authorization headers are
+        // passed as it is.
+        // Expectation is that the backend should validate the authorization header if
+        // it is not processed
+        // at the gateway level.
+        // It is required to check if the resource Path is not null, because when CORS
+        // preflight request handling, or
+        // generic OPTIONS method call happens, matchedResourcePath becomes null.
+        if (requestContext.getMatchedResourcePath() != null &&
+                requestContext.getMatchedResourcePath().isDisableSecurity()) {
+            return;
+        }
+
+        Map<String, SecuritySchemaConfig> securitySchemeDefinitions = requestContext.getMatchedAPI()
+                .getSecuritySchemeDefinitions();
+        // API key headers are considered to be protected headers, such that the header
+        // would not be sent
+        // to backend and traffic manager.
+        // This would prevent leaking credentials, even if user is invoking unsecured
+        // resource with some
+        // credentials.
+        for (Map.Entry<String, SecuritySchemaConfig> entry : securitySchemeDefinitions.entrySet()) {
+            SecuritySchemaConfig schema = entry.getValue();
+            if (APIConstants.SWAGGER_API_KEY_AUTH_TYPE_NAME.equalsIgnoreCase(schema.getType())) {
+                if (APIConstants.SWAGGER_API_KEY_IN_HEADER.equals(schema.getIn())) {
+                    requestContext.getProtectedHeaders().add(schema.getName());
+                    requestContext.getRemoveHeaders().add(schema.getName());
+                    continue;
+                }
+                if (APIConstants.SWAGGER_API_KEY_IN_QUERY.equals(schema.getIn())) {
+                    requestContext.getQueryParamsToRemove().add(schema.getName());
+                }
+            }
+        }
+
+        // Internal-Key credential is considered to be protected headers, such that the
+        // header would not be sent
+        // to backend and traffic manager.
+        String internalKeyHeader = ConfigHolder.getInstance().getConfig().getAuthHeader()
+                .getTestConsoleHeaderName().toLowerCase();
+        requestContext.getRemoveHeaders().add(internalKeyHeader);
+        // Avoid internal key being published to the Traffic Manager
+        requestContext.getProtectedHeaders().add(internalKeyHeader);
+
+        // Remove Authorization Header
+        AuthHeaderDto authHeader = ConfigHolder.getInstance().getConfig().getAuthHeader();
+        String authHeaderName = FilterUtils.getAuthHeaderName(requestContext);
+        if (!authHeader.isEnableOutboundAuthHeader()) {
+            requestContext.getRemoveHeaders().add(authHeaderName);
+        }
+        // Authorization Header should not be included in the throttle publishing event.
+        requestContext.getProtectedHeaders().add(authHeaderName);
     }
 }


### PR DESCRIPTION
### Purpose
At invocation, we get the below error log in enforcer. This PR will fix it.
Additionally it fixes the issue of being unable to invoke sandbox deployment using the sandbox internal api key
```
13/05/2024, 22:01:17.851
choreo-connect-deployment-external-p3-68fb7b84f4
at org.wso2.choreo.connect.enforcer.grpc.ExtAuthService.check(ExtAuthService.java:83)
13/05/2024, 22:01:17.851
choreo-connect-deployment-external-p3-68fb7b84f4
at org.wso2.choreo.connect.enforcer.grpc.ExtAuthService.buildResponse(ExtAuthService.java:193)
```
https://github.com/wso2-enterprise/choreo/issues/26743

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes
 - Integration tests added: Yes

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [ ] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
