### PR TITLE
Fix encoding issue in the mustache file

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/templates/dockerConfig.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/dockerConfig.mustache
@@ -12,6 +12,6 @@
     push:{{containerConfig.docker.dockerConfig.push}}{{/if}}{{#if containerConfig.docker.dockerConfig.username}},
     username:"{{containerConfig.docker.dockerConfig.username}}"{{/if}}{{#if containerConfig.docker.dockerConfig.password}},
     password:"{{containerConfig.docker.dockerConfig.password}}"{{/if}}{{#if containerConfig.docker.dockerConfig.cmd}},
-    cmd: "{{containerConfig.docker.dockerConfig.cmd}}"{{/if}}
+    cmd: "{{&containerConfig.docker.dockerConfig.cmd}}"{{/if}}
 }
 {{/if}}


### PR DESCRIPTION
## Purpose
This will fix mustache encoding of special characters (=), as it's necessary to provide commands including the = character for the Docker CMD command

### Fixes
- https://github.com/wso2/product-microgateway/issues/3513
- https://github.com/wso2/api-manager/issues/2886