### PR TITLE
Retrieve subscription policies from SubscriptionDataStore for organizations the feature is enabled

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/features/FeatureFlags.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/features/FeatureFlags.java
@@ -24,18 +24,22 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * Feature flags for Choreo Connect.
+ */
 public class FeatureFlags {
     private static final Set<String> CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ORG;
     private static final boolean ENABLE_CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ALL_ORG;
 
     static {
-        final String ORG_ENV_VAR = System.getenv().getOrDefault("CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ORG", "");
-        CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ORG = new HashSet<>(Arrays.asList(ORG_ENV_VAR.split(",")));
-        ENABLE_CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ALL_ORG = ORG_ENV_VAR.equals("*");
+        final String orgEnvVar = System.getenv().getOrDefault("CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ORG", "");
+        CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ORG = new HashSet<>(Arrays.asList(orgEnvVar.split(",")));
+        ENABLE_CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ALL_ORG = orgEnvVar.equals("*");
     }
 
     public static boolean isCustomSubscriptionPolicyHandlingEnabled(String orgId) {
-        return ENABLE_CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ALL_ORG || CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ORG.contains(orgId);
+        return ENABLE_CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ALL_ORG
+                || CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ORG.contains(orgId);
     }
 
     public static String getCustomSubscriptionPolicyHandlingOrg(String orgId) {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/features/FeatureFlags.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/features/FeatureFlags.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.choreo.connect.enforcer.features;
+
+import org.wso2.choreo.connect.enforcer.constants.APIConstants;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class FeatureFlags {
+    private static final Set<String> CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ORG;
+    private static final boolean ENABLE_CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ALL_ORG;
+
+    static {
+        final String ORG_ENV_VAR = System.getenv().getOrDefault("CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ORG", "");
+        CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ORG = new HashSet<>(Arrays.asList(ORG_ENV_VAR.split(",")));
+        ENABLE_CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ALL_ORG = ORG_ENV_VAR.equals("*");
+    }
+
+    public static boolean isCustomSubscriptionPolicyHandlingEnabled(String orgId) {
+        return ENABLE_CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ALL_ORG || CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ORG.contains(orgId);
+    }
+
+    public static String getCustomSubscriptionPolicyHandlingOrg(String orgId) {
+        if (isCustomSubscriptionPolicyHandlingEnabled(orgId)) {
+            return orgId;
+        }
+        return APIConstants.SUPER_TENANT_DOMAIN_NAME;
+    }
+}

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
@@ -73,8 +73,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Implements the authenticator interface to authenticate request using a JWT token.

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/subscription/SubscriptionDataStoreImpl.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/subscription/SubscriptionDataStoreImpl.java
@@ -22,7 +22,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.wso2.choreo.connect.discovery.subscription.APIs;
-import org.wso2.choreo.connect.enforcer.constants.APIConstants;
 import org.wso2.choreo.connect.enforcer.discovery.ApplicationDiscoveryClient;
 import org.wso2.choreo.connect.enforcer.discovery.ApplicationKeyMappingDiscoveryClient;
 import org.wso2.choreo.connect.enforcer.discovery.ApplicationPolicyDiscoveryClient;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/subscription/SubscriptionDataStoreImpl.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/subscription/SubscriptionDataStoreImpl.java
@@ -28,6 +28,7 @@ import org.wso2.choreo.connect.enforcer.discovery.ApplicationKeyMappingDiscovery
 import org.wso2.choreo.connect.enforcer.discovery.ApplicationPolicyDiscoveryClient;
 import org.wso2.choreo.connect.enforcer.discovery.SubscriptionDiscoveryClient;
 import org.wso2.choreo.connect.enforcer.discovery.SubscriptionPolicyDiscoveryClient;
+import org.wso2.choreo.connect.enforcer.features.FeatureFlags;
 import org.wso2.choreo.connect.enforcer.models.API;
 import org.wso2.choreo.connect.enforcer.models.ApiPolicy;
 import org.wso2.choreo.connect.enforcer.models.Application;
@@ -111,7 +112,7 @@ public class SubscriptionDataStoreImpl implements SubscriptionDataStore {
 
     @Override
     public SubscriptionPolicy getSubscriptionPolicyByOrgIdAndName(String orgId, String policyName) {
-        String organizationId = StringUtils.isEmpty(orgId) ? APIConstants.SUPER_TENANT_DOMAIN_NAME : orgId;
+        String organizationId = FeatureFlags.getCustomSubscriptionPolicyHandlingOrg(orgId);
         String key = PolicyType.SUBSCRIPTION +
                 SubscriptionDataStoreUtil.DELEM_PERIOD + organizationId +
                 SubscriptionDataStoreUtil.DELEM_PERIOD + policyName;


### PR DESCRIPTION
### Purpose

```java
SubscriptionPolicy subPolicy = datastore.getSubscriptionPolicyByOrgIdAndName(apiConfig.getOrganizationId(),
                sub.getPolicyId());
```

We are getting the org ID from API. API always has an org. So let's say org Foo's API is invoked and his org is not in feature flag.

```java
    @Override
    public SubscriptionPolicy getSubscriptionPolicyByOrgIdAndName(String orgId, String policyName) {
        String organizationId = StringUtils.isEmpty(orgId) ? APIConstants.SUPER_TENANT_DOMAIN_NAME : orgId;
        String key = PolicyType.SUBSCRIPTION +
                SubscriptionDataStoreUtil.DELEM_PERIOD + organizationId +
                SubscriptionDataStoreUtil.DELEM_PERIOD + policyName;
        return subscriptionPolicyMap.get(key);
    }
```

But every org still does not have a sub-policy. Hence getting null pointer exception.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #
Related Issue: https://github.com/wso2-enterprise/choreo/issues/26811

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
