### PR TITLE
Add prefixes for every headers and trailers

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/ChoreoAnalyticsProvider.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/ChoreoAnalyticsProvider.java
@@ -41,6 +41,7 @@ import org.wso2.choreo.connect.enforcer.constants.MetadataConstants;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Analytics Data Provider of Microgateway
@@ -258,12 +259,33 @@ public class ChoreoAnalyticsProvider implements AnalyticsDataProvider {
     private void setCustomPropertiesMap(HTTPAccessLogEntry logEntry, Map<String, Object> customProperties) {
         if (logEntry.getRequest().getRequestHeadersMap() != null) {
             customProperties.putAll(logEntry.getRequest().getRequestHeadersMap());
+            customProperties.putAll(
+                    logEntry.getRequest().getRequestHeadersMap().entrySet().stream()
+                            .collect(Collectors.toMap(
+                                    entry -> "REQUEST_HEADER_" + entry.getKey(),
+                                    Map.Entry::getValue
+                            ))
+            );
         }
         if (logEntry.getResponse().getResponseHeadersMap() != null) {
             customProperties.putAll(logEntry.getResponse().getResponseHeadersMap());
+            customProperties.putAll(
+                    logEntry.getResponse().getResponseHeadersMap().entrySet().stream()
+                            .collect(Collectors.toMap(
+                                    entry -> "RESPONSE_HEADER_" + entry.getKey(),
+                                    Map.Entry::getValue
+                            ))
+            );
         }
         if (logEntry.getResponse().getResponseTrailersMap() != null) {
             customProperties.putAll(logEntry.getResponse().getResponseTrailersMap());
+            customProperties.putAll(
+                    logEntry.getResponse().getResponseTrailersMap().entrySet().stream()
+                            .collect(Collectors.toMap(
+                                    entry -> "RESPONSE_TRAILER_" + entry.getKey(),
+                                    Map.Entry::getValue
+                            ))
+            );
         }
     }
 }


### PR DESCRIPTION
## Purpose
This will fix the custom property override issue when the header name is defined in both the request and response arrays. 

From this fix it will add `REQUEST_HEADER_`, `RESPONSE_HEADER_ `and `RESPONSE_TRAILER_` prefixes for particular headers.

```
[analytics.adapter.customProperties]
    enabled = true
    requestHeaders = ["host","content-type","content-length", "authorization","x-forwarded-for","x-original-forwarded-for","x-client-dn", ":path", ":authority"]
    responseHeaders = ["etag", "content-type"]
```


customer property array will be like below.

```
 [REQUEST_HEADER_content-type=text/json, REQUEST_HEADER_:path=/v2/pet/findByStatus?status=available, REQUEST_HEADER_host=petstore.swagger.io, REQUEST_HEADER_:authority=petstore.swagger.io, RESPONSE_HEADER_content-type=application/json, host=petstore.swagger.io, content-type=application/json, :path=/v2/pet/findByStatus?status=available, :authority=petstore.swagger.io]
```

This will not remove the previous headers to keep the backword compatibility.


### Fixes
- https://github.com/wso2/product-microgateway/issues/3524