### PR TITLE
Introduce configuration to enable introspection for all tokens that failed jwt validation

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
@@ -241,6 +241,7 @@ public const string TOKEN_URL = "tokenUrl";
 public const string REFRESH_TOKEN = "refreshToken";
 public const string ACCESS_TOKEN = "accessToken";
 public const string CREDENTIAL_BEARER = "credentialBearer";
+public const string ENABLE_INTROSPECT_FOR_FAILED_JWT = "enableIntrospectForFailedJWT";
 public const string NAME = "name";
 public const string VERSIONS = "versions";
 public const string VERSION = "version";

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/micro_gw_conf_defaults.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/micro_gw_conf_defaults.bal
@@ -37,6 +37,7 @@ public const string DEFAULT_KM_TOKEN_CONTEXT = "oauth2";
 public const int DEFAULT_TIMESTAMP_SKEW = 5000;
 public const boolean DEFAULT_EXTERNAL = false;
 public const string DEFAULT_KM_CONF_ISSUER = "https://localhost:9443/oauth2/token";
+public const boolean DEFAULT_KM_CONF_ENABLE_INTROSPECT_FOR_FAILED_JWT = false;
 
 public const boolean DEFAULT_KM_REMOTE_USER_CLAIM_RETRIEVAL_ENABLED = false;
 

--- a/distribution/resources/conf/default-micro-gw.conf.template
+++ b/distribution/resources/conf/default-micro-gw.conf.template
@@ -52,6 +52,8 @@
   serverUrl = "https://localhost:9443"
   # The token endpoint context of the Key Manager server
   tokenContext = "oauth2"
+  # This enables introspection for all tokens that failed JWT validation
+  enableIntrospectForFailedJWT = false
   # When Microgateway is used with older APIM versions for subscription validation by using KeyValidation service.
   enableLegacyMode = false
   # Remote User Claim Retrieval Enabled


### PR DESCRIPTION
## Purpose
This will introduce the following configuration to enable introspection for all tokens that failed jwt validation and this will allow introspection without considering the token format.
.

```
[keyManager]
  enableIntrospectForFailedJWT = true

```
By default this is set to false.


### Fixes
- https://github.com/wso2/product-microgateway/issues/3533