### PR TITLE
[Choreo] [Bugfix] Adds keepalive pings to enforcer XDS connection

### DIFF
--- a/adapter/internal/adapter/adapter.go
+++ b/adapter/internal/adapter/adapter.go
@@ -82,7 +82,7 @@ var (
 const (
 	ads                        = "ads"
 	amqpProtocol               = "amqp"
-	grpcServerKeepaliveEnabled = "GRPC_KEEPALIVE_ENFORCEMENT_ENABLED"
+	grpcServerKeepaliveEnabled = "GRPC_KEEPALIVE_ENABLED"
 )
 
 func init() {

--- a/adapter/internal/adapter/adapter.go
+++ b/adapter/internal/adapter/adapter.go
@@ -126,6 +126,13 @@ func runManagementServer(conf *config.Config, server xdsv3.Server, rlsServer xds
 			Timeout: time.Duration(20 * time.Second),
 		}),
 	)
+
+	grpcOptions = append(grpcOptions, grpc.KeepaliveEnforcementPolicy(
+		keepalive.EnforcementPolicy{
+			MinTime: time.Duration(30 * time.Second),
+		}),
+	)
+
 	grpcServer := grpc.NewServer(grpcOptions...)
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))

--- a/adapter/internal/adapter/adapter.go
+++ b/adapter/internal/adapter/adapter.go
@@ -80,8 +80,9 @@ var (
 )
 
 const (
-	ads          = "ads"
-	amqpProtocol = "amqp"
+	ads                        = "ads"
+	amqpProtocol               = "amqp"
+	grpcServerKeepaliveEnabled = "GRPC_KEEPALIVE_ENFORCEMENT_ENABLED"
 )
 
 func init() {
@@ -127,11 +128,14 @@ func runManagementServer(conf *config.Config, server xdsv3.Server, rlsServer xds
 		}),
 	)
 
-	grpcOptions = append(grpcOptions, grpc.KeepaliveEnforcementPolicy(
-		keepalive.EnforcementPolicy{
-			MinTime: time.Duration(30 * time.Second),
-		}),
-	)
+	// grpc keep alive feature flag
+	if strings.TrimSpace(os.Getenv(grpcServerKeepaliveEnabled)) == "true" {
+		grpcOptions = append(grpcOptions, grpc.KeepaliveEnforcementPolicy(
+			keepalive.EnforcementPolicy{
+				MinTime: time.Duration(30 * time.Second),
+			}),
+		)
+	}
 
 	grpcServer := grpc.NewServer(grpcOptions...)
 

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/features/FeatureFlags.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/features/FeatureFlags.java
@@ -34,7 +34,7 @@ public class FeatureFlags {
 
     static {
         final String orgEnvVar = System.getenv().getOrDefault("CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ORG", "");
-        final String keepAliveEnvVar = System.getenv().getOrDefault("ENFORCER_GRPC_KEEPALIVE_ENABLED", "");
+        final String keepAliveEnvVar = System.getenv().getOrDefault("GRPC_KEEPALIVE_ENABLED", "");
         ENFORCER_GRPC_CLIENT_KEEPALIVE_ENABLED = keepAliveEnvVar.trim().equals("true");
         CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ORG = new HashSet<>(Arrays.asList(orgEnvVar.split(",")));
         ENABLE_CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ALL_ORG = orgEnvVar.equals("*");

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/features/FeatureFlags.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/features/FeatureFlags.java
@@ -30,9 +30,12 @@ import java.util.Set;
 public class FeatureFlags {
     private static final Set<String> CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ORG;
     private static final boolean ENABLE_CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ALL_ORG;
+    private static final boolean ENFORCER_GRPC_CLIENT_KEEPALIVE_ENABLED;
 
     static {
         final String orgEnvVar = System.getenv().getOrDefault("CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ORG", "");
+        final String keepAliveEnvVar = System.getenv().getOrDefault("ENFORCER_GRPC_KEEPALIVE_ENABLED", "");
+        ENFORCER_GRPC_CLIENT_KEEPALIVE_ENABLED = keepAliveEnvVar.trim().equals("true");
         CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ORG = new HashSet<>(Arrays.asList(orgEnvVar.split(",")));
         ENABLE_CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ALL_ORG = orgEnvVar.equals("*");
     }
@@ -40,6 +43,10 @@ public class FeatureFlags {
     public static boolean isCustomSubscriptionPolicyHandlingEnabled(String orgId) {
         return ENABLE_CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ALL_ORG
                 || CUSTOM_SUBSCRIPTION_POLICY_HANDLING_ORG.contains(orgId);
+    }
+
+    public static boolean isEnforcerGrpcClientKeepaliveEnabled() {
+        return ENFORCER_GRPC_CLIENT_KEEPALIVE_ENABLED;
     }
 
     public static String getCustomSubscriptionPolicyHandlingOrg(String orgId) {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/util/GRPCUtils.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/util/GRPCUtils.java
@@ -28,6 +28,7 @@ import org.wso2.choreo.connect.enforcer.config.ConfigHolder;
 
 import java.io.File;
 import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLException;
 
@@ -50,6 +51,7 @@ public class GRPCUtils {
             logger.error("Error while generating SSL Context.", e);
         }
         return NettyChannelBuilder.forAddress(host, port)
+                .keepAliveTime(2, TimeUnit.MINUTES)
                 .useTransportSecurity()
                 .sslContext(sslContext)
                 .overrideAuthority(ConfigHolder.getInstance().getEnvVarConfig().getAdapterHostName())


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
This PR aims to resolve an issue with the XDS/GRPC connection where the enforcer doesn't know that the connection has failed and doesn't reach out to another replica of the local adapter for new configuration.

This fix works by configuring GRPC client on the enforcer to send HTTP/2 Ping frames every 2 minutes, if the ping isn't returned with an ACK the connection is closed.
This only checks connection health and not the healthiness of the adapter.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->

### Automation tests
 - Unit tests added: No
 - Integration tests added: No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->

This was tested with in a localsetup where the adapter is paused using a debugger after initial discovery and subscription from the enforcer.
- Before this fix the connection to the adapter would remain until the enforcer checks the connection in 2 hours (default keep alive configuration).
- After this fix. The enforcer checks the connection after 2 minutes and disconnects, when the adapter is restarted, the enforcer reconnects to it successfully.

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
