### PR TITLE
[Choreo] Limit WS connection duration to 1h

### DIFF
--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -1513,7 +1513,7 @@ func getMaxStreamDuration(apiType string) *routev3.RouteAction_MaxStreamDuration
 	if apiType == model.WS {
 		maxStreamDuration = &routev3.RouteAction_MaxStreamDuration{
 			MaxStreamDuration: &durationpb.Duration{
-				Seconds: 60 * 60 * 24,
+				Seconds: 60 * 60 * 1,
 			},
 		}
 	}


### PR DESCRIPTION
### Purpose
Limit the maximum connection duration of a webSocket connection to 1hour
### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes https://github.com/wso2-enterprise/choreo/issues/26361

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Tested locally.
After one hour the connection is terminated with the below router log - "max_duration_timeout"
`[2024-07-27T15:30:04.962Z]' 'd3a7dfea-fb10-4371-b21d-85d1bc28667b-dev.e1-us-east-azure.preview-dv.choreoapis.dev' 'host.docker.internal' 'GET' '/d3a7dfea-fb10-4371-b21d-85d1bc28667b/websocket/websocket-local/v1.0/chat' '/chat' 'HTTP/1.1' '101' 'max_duration_timeout' '-' '-' 'debb007e-c902-40e8-8acf-e38f35c29b02' '-' '192.168.5.2:8085' '7173' '4315' '3600011' '-' '-' '-' '-' '107' '667d009fff17fc0d6af31cb5' '-' '`

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [ ] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
