### PR TITLE
[Choreo] Update envoy cp api version & protobuf.java.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -639,7 +639,7 @@
         <build.helper.plugin.version>3.2.0</build.helper.plugin.version>
         <commons.version>3.12.0</commons.version>
         <commons.io.version>2.7</commons.io.version>
-        <envoy.controlplane.api.version>0.1.28</envoy.controlplane.api.version>
+        <envoy.controlplane.api.version>1.0.45</envoy.controlplane.api.version>
         <geronimo.jms11.spec.version>1.1.1.wso2v1</geronimo.jms11.spec.version>
         <grpc.netty.shaded.version>1.45.1</grpc.netty.shaded.version>
         <grpc.protobuf.version>1.45.1</grpc.protobuf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -639,7 +639,7 @@
         <build.helper.plugin.version>3.2.0</build.helper.plugin.version>
         <commons.version>3.12.0</commons.version>
         <commons.io.version>2.7</commons.io.version>
-        <envoy.controlplane.api.version>1.0.45</envoy.controlplane.api.version>
+        <envoy.controlplane.api.version>0.1.35</envoy.controlplane.api.version>
         <geronimo.jms11.spec.version>1.1.1.wso2v1</geronimo.jms11.spec.version>
         <grpc.netty.shaded.version>1.45.1</grpc.netty.shaded.version>
         <grpc.protobuf.version>1.45.1</grpc.protobuf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -684,7 +684,7 @@
         <jackson.databind.version>2.14.1</jackson.databind.version>
         <exec.maven.plugin.version>3.1.0</exec.maven.plugin.version>
         <googlecode.download.plugin.version>1.6.8</googlecode.download.plugin.version>
-        <protobuf.java.version>3.21.7</protobuf.java.version>
+        <protobuf.java.version>3.25.4</protobuf.java.version>
         <apache.tomcat.dependency.version>10.1.4</apache.tomcat.dependency.version>
         <libthrift.version>0.14.0</libthrift.version>
         <kotlin-stdlib.version>1.6.0</kotlin-stdlib.version>


### PR DESCRIPTION
### Purpose
https://github.com/wso2-enterprise/choreo/issues/26321
<!-- Short description of the issue you are going to solve with this PR. -->
To support implementation to add a header for the response sent from upstream

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Locally tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)


Router logs locally

```
[2024-08-01 10:33:21.265][9][info][admin] [source/server/admin/admin.cc:67] admin address: 0.0.0.0:9000
[2024-08-01 10:33:21.265][9][info][config] [source/server/configuration_impl.cc:131] loading tracing configuration
[2024-08-01 10:33:21.265][9][info][config] [source/server/configuration_impl.cc:91] loading 0 static secret(s)
[2024-08-01 10:33:21.265][9][info][config] [source/server/configuration_impl.cc:97] loading 4 cluster(s)
[2024-08-01 10:33:21.310][9][info][config] [source/server/configuration_impl.cc:101] loading 0 listener(s)
[2024-08-01 10:33:21.310][9][info][config] [source/server/configuration_impl.cc:113] loading stats configuration
[2024-08-01 10:33:21.311][9][info][main] [source/server/server.cc:894] starting main dispatch loop
[2024-08-01 10:33:21.312][9][info][runtime] [source/common/runtime/runtime_impl.cc:463] RTDS has finished initialization
[2024-08-01 10:33:21.312][9][info][upstream] [source/common/upstream/cluster_manager_impl.cc:222] cm init: initializing cds
[2024-08-01 10:33:21.594][9][info][upstream] [source/common/upstream/cds_api_helper.cc:35] cds: add 10 cluster(s), remove 4 cluster(s)
[2024-08-01 10:33:21.617][9][info][upstream] [source/common/upstream/cds_api_helper.cc:72] cds: added/updated 10 cluster(s), skipped 0 unmodified cluster(s)
[2024-08-01 10:33:26.805][9][info][upstream] [source/common/upstream/cluster_manager_impl.cc:226] cm init: all clusters initialized
[2024-08-01 10:33:26.805][9][info][main] [source/server/server.cc:875] all clusters initialized. initializing init manager
[2024-08-01 10:33:26.825][9][warning][misc] [source/common/protobuf/message_validator_impl.cc:21] Deprecated field: type envoy.config.route.v3.HeaderMatcher Using deprecated option 'envoy.config.route.v3.HeaderMatcher.safe_regex_match' from file route_components.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.
[2024-08-01 10:33:26.825][9][warning][misc] [source/common/protobuf/message_validator_impl.cc:21] Deprecated field: type envoy.config.route.v3.HeaderMatcher Using deprecated option 'envoy.config.route.v3.HeaderMatcher.safe_regex_match' from file route_components.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.
[2024-08-01 10:33:26.825][9][warning][misc] [source/common/protobuf/message_validator_impl.cc:21] Deprecated field: type envoy.config.route.v3.HeaderMatcher Using deprecated option 'envoy.config.route.v3.HeaderMatcher.safe_regex_match' from file route_components.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.
[2024-08-01 10:33:26.825][9][warning][misc] [source/common/protobuf/message_validator_impl.cc:21] Deprecated field: type envoy.config.route.v3.HeaderMatcher Using deprecated option 'envoy.config.route.v3.HeaderMatcher.safe_regex_match' from file route_components.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.
[2024-08-01 10:33:26.827][9][info][upstream] [source/server/lds_api.cc:82] lds: add/update listener 'HTTPSListener'
[2024-08-01 10:33:26.828][9][warning][misc] [source/common/protobuf/message_validator_impl.cc:21] Deprecated field: type envoy.config.route.v3.HeaderMatcher Using deprecated option 'envoy.config.route.v3.HeaderMatcher.safe_regex_match' from file route_components.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.
[2024-08-01 10:33:26.828][9][warning][misc] [source/common/protobuf/message_validator_impl.cc:21] Deprecated field: type envoy.config.route.v3.HeaderMatcher Using deprecated option 'envoy.config.route.v3.HeaderMatcher.safe_regex_match' from file route_components.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.
[2024-08-01 10:33:26.828][9][warning][misc] [source/common/protobuf/message_validator_impl.cc:21] Deprecated field: type envoy.config.route.v3.HeaderMatcher Using deprecated option 'envoy.config.route.v3.HeaderMatcher.safe_regex_match' from file route_components.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.
[2024-08-01 10:33:26.828][9][warning][misc] [source/common/protobuf/message_validator_impl.cc:21] Deprecated field: type envoy.config.route.v3.HeaderMatcher Using deprecated option 'envoy.config.route.v3.HeaderMatcher.safe_regex_match' from file route_components.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.
[2024-08-01 10:33:26.829][9][info][upstream] [source/server/lds_api.cc:82] lds: add/update listener 'HTTPListener'
[2024-08-01 10:33:26.839][9][warning][config] [source/common/protobuf/message_validator_impl.cc:60] Unknown field: type envoy.config.route.v3.RateLimit.Action.MetaData(envoy.config.route.v3.RouteConfiguration::envoy.config.route.v3.VirtualHost::envoy.config.route.v3.Route::envoy.config.route.v3.RouteAction::envoy.config.route.v3.RateLimit::envoy.config.route.v3.RateLimit.Action) with unknown field set {5}
[2024-08-01T10:35:09.542Z]' 'd3a7dfea-fb10-4371-b21d-85d1bc28667b-dev.e1-us-east-azure.preview-dv.choreoapis.dev' 'd3a7dfea-fb10-4371-b21d-85d1bc28667b-dev.e1-us-east-azure.preview-dv.choreoapis.dev' 'GET' '/d3a7dfea-fb10-4371-b21d-85d1bc28667b/websocket/websocket-local/v1.0/chat' '/d3a7dfea-fb10-4371-b21d-85d1bc28667b/websocket/websocket-local/v1.0/chat' 'HTTP/1.1' '401' 'ext_authz_denied' 'UAEX' '-' '2358098b-22f5-4806-99ce-d26211f8ca01' '-' '-' '0' '159' '181' '-' '-' '-' '-' '-' '667d009fff17fc0d6af31cb5' '-' '


[2024-08-01T10:38:43.487Z]' 'd3a7dfea-fb10-4371-b21d-85d1bc28667b-dev.e1-us-east-azure.preview-dv.choreoapis.dev' 'host.docker.internal' 'GET' '/d3a7dfea-fb10-4371-b21d-85d1bc28667b/websocket/websocket-local/v1.0/chat' '/chat' 'HTTP/1.1' '101' 'upstream_reset_after_response_started{connection_termination}' 'UC' '-' 'd61ddf4a-c43f-420c-adbb-ee1199e8306a' '-' '192.168.5.2:8085' '8' '4' '11058' '-' '-' '-' '-' '160' '667d009fff17fc0d6af31cb5' '-' '
```
