### PR TITLE
Add retry on resets for local endpoints

### DIFF
--- a/adapter/internal/oasparser/envoyconf/envoyconf_internal_test.go
+++ b/adapter/internal/oasparser/envoyconf/envoyconf_internal_test.go
@@ -266,7 +266,7 @@ func TestCreateRoute(t *testing.T) {
 	}
 
 	generatedRouteWithXWso2BasePath := createRoute(generateRouteCreateParamsForUnitTests(title, apiType, vHost, xWso2BasePath, version,
-		endpoint.Basepath, resourceWithGet.GetPath(), resourceWithGet.GetMethodList(), clusterName, nil))
+		endpoint.Basepath, resourceWithGet.GetPath(), resourceWithGet.GetMethodList(), clusterName, nil, false))
 	assert.NotNil(t, generatedRouteWithXWso2BasePath, "Route should not be null.")
 	assert.Equal(t, expectedRouteActionWithXWso2BasePath, generatedRouteWithXWso2BasePath.Action,
 		"Route generation mismatch when xWso2BasePath option is provided.")
@@ -275,7 +275,7 @@ func TestCreateRoute(t *testing.T) {
 		"Assigned HTTP Method Regex is incorrect when single method is available.")
 
 	generatedRouteWithoutXWso2BasePath := createRoute(generateRouteCreateParamsForUnitTests(title, apiType, vHost, "", version,
-		endpoint.Basepath, resourceWithGetPost.GetPath(), resourceWithGetPost.GetMethodList(), clusterName, nil))
+		endpoint.Basepath, resourceWithGetPost.GetPath(), resourceWithGetPost.GetMethodList(), clusterName, nil, false))
 	assert.NotNil(t, generatedRouteWithoutXWso2BasePath, "Route should not be null")
 	assert.NotNil(t, generatedRouteWithoutXWso2BasePath.GetMatch().Headers, "Headers property should not be null")
 	assert.Equal(t, "^(GET|POST|OPTIONS)$", generatedRouteWithoutXWso2BasePath.GetMatch().Headers[0].GetStringMatch().GetSafeRegex().Regex,
@@ -304,21 +304,21 @@ func TestCreateRouteClusterSpecifier(t *testing.T) {
 		"resource_operation_id", []model.Endpoint{}, []model.Endpoint{})
 
 	routeWithProdEp := createRoute(generateRouteCreateParamsForUnitTests(title, apiType, vHost, xWso2BasePath, version, endpointBasePath,
-		resourceWithGet.GetPath(), resourceWithGet.GetMethodList(), prodClusterName, nil))
+		resourceWithGet.GetPath(), resourceWithGet.GetMethodList(), prodClusterName, nil, false))
 	assert.NotNil(t, routeWithProdEp, "Route should not be null")
 	assert.NotNil(t, routeWithProdEp.GetRoute().GetClusterHeader(), "Route Cluster Header should not be null.")
 	assert.Empty(t, routeWithProdEp.GetRoute().GetCluster(), "Route Cluster Name should be empty.")
 	assert.Equal(t, clusterHeaderName, routeWithProdEp.GetRoute().GetClusterHeader(), "Route Cluster Name mismatch.")
 
 	routeWithSandEp := createRoute(generateRouteCreateParamsForUnitTests(title, apiType, vHost, xWso2BasePath, version, endpointBasePath,
-		resourceWithGet.GetPath(), resourceWithGet.GetMethodList(), "", nil))
+		resourceWithGet.GetPath(), resourceWithGet.GetMethodList(), "", nil, false))
 	assert.NotNil(t, routeWithSandEp, "Route should not be null")
 	assert.NotNil(t, routeWithSandEp.GetRoute().GetClusterHeader(), "Route Cluster Header should not be null.")
 	assert.Empty(t, routeWithSandEp.GetRoute().GetCluster(), "Route Cluster Name should be empty.")
 	assert.Equal(t, clusterHeaderName, routeWithSandEp.GetRoute().GetClusterHeader(), "Route Cluster Name mismatch.")
 
 	routeWithProdSandEp := createRoute(generateRouteCreateParamsForUnitTests(title, apiType, vHost, xWso2BasePath, version, endpointBasePath,
-		resourceWithGet.GetPath(), resourceWithGet.GetMethodList(), prodClusterName, nil))
+		resourceWithGet.GetPath(), resourceWithGet.GetMethodList(), prodClusterName, nil, false))
 	assert.NotNil(t, routeWithProdSandEp, "Route should not be null")
 	assert.NotNil(t, routeWithProdSandEp.GetRoute().GetClusterHeader(), "Route Cluster Header should not be null.")
 	assert.Empty(t, routeWithProdSandEp.GetRoute().GetCluster(), "Route Cluster Name should be empty.")
@@ -342,7 +342,7 @@ func TestCreateRouteExtAuthzContext(t *testing.T) {
 		"resource_operation_id", []model.Endpoint{}, []model.Endpoint{})
 
 	routeWithProdEp := createRoute(generateRouteCreateParamsForUnitTests(title, apiType, vHost, xWso2BasePath, version,
-		endpointBasePath, resourceWithGet.GetPath(), resourceWithGet.GetMethodList(), prodClusterName, nil))
+		endpointBasePath, resourceWithGet.GetPath(), resourceWithGet.GetMethodList(), prodClusterName, nil, false))
 	assert.NotNil(t, routeWithProdEp, "Route should not be null")
 	assert.NotNil(t, routeWithProdEp.GetTypedPerFilterConfig(), "TypedPerFilter config should not be null")
 	assert.NotNil(t, routeWithProdEp.GetTypedPerFilterConfig()[wellknown.HTTPExternalAuthorization],
@@ -822,7 +822,7 @@ func TestGetCorsPolicy(t *testing.T) {
 
 	// Route without CORS configuration
 	routeWithoutCors := createRoute(generateRouteCreateParamsForUnitTests("test", "HTTP", "localhost", "/test", "1.0.0", "/test",
-		"/testPath", []string{"GET"}, "test-cluster", nil))
+		"/testPath", []string{"GET"}, "test-cluster", nil, false))
 	corsConfig1 := &cors_filter_v3.CorsPolicy{}
 	err := routeWithoutCors.GetTypedPerFilterConfig()[wellknown.CORS].UnmarshalTo(corsConfig1)
 
@@ -835,7 +835,7 @@ func TestGetCorsPolicy(t *testing.T) {
 
 	// Route with CORS configuration
 	routeWithCors := createRoute(generateRouteCreateParamsForUnitTests("test", "HTTP", "localhost", "/test", "1.0.0", "/test",
-		"/testPath", []string{"GET"}, "test-cluster", corsConfigModel3))
+		"/testPath", []string{"GET"}, "test-cluster", corsConfigModel3, false))
 	corsConfig2 := &cors_filter_v3.CorsPolicy{}
 	err = routeWithCors.GetTypedPerFilterConfig()[wellknown.CORS].UnmarshalTo(corsConfig2)
 
@@ -846,7 +846,7 @@ func TestGetCorsPolicy(t *testing.T) {
 
 func generateRouteCreateParamsForUnitTests(title string, apiType string, vhost string, xWso2Basepath string, version string, endpointBasepath string,
 	resourcePathParam string, resourceMethods []string, prodClusterName string,
-	corsConfig *model.CorsConfig) *routeCreateParams {
+	corsConfig *model.CorsConfig, enableRSTRetry bool) *routeCreateParams {
 	return &routeCreateParams{
 		title:             title,
 		apiType:           apiType,
@@ -858,5 +858,6 @@ func generateRouteCreateParamsForUnitTests(title string, apiType string, vhost s
 		corsPolicy:        corsConfig,
 		resourcePathParam: resourcePathParam,
 		resourceMethods:   resourceMethods,
+		enableRSTRetry:    enableRSTRetry,
 	}
 }

--- a/adapter/internal/oasparser/envoyconf/internal_dtos.go
+++ b/adapter/internal/oasparser/envoyconf/internal_dtos.go
@@ -42,4 +42,5 @@ type routeCreateParams struct {
 	corsPolicy          *model.CorsConfig
 	rateLimitLevel      string
 	isRLPolicyAvailable bool
+	enableRSTRetry      bool
 }

--- a/adapter/internal/oasparser/envoyconf/listener_test.go
+++ b/adapter/internal/oasparser/envoyconf/listener_test.go
@@ -110,11 +110,11 @@ func testCreateRoutesForUnitTests(t *testing.T) []*routev3.Route {
 	}
 
 	route1 := createRoute(generateRouteCreateParamsForUnitTests("test", "HTTP", "localhost", "/test", "1.0.0", "/test",
-		"/testPath", []string{"GET"}, "test-cluster", corsConfigModel3))
+		"/testPath", []string{"GET"}, "test-cluster", corsConfigModel3, false))
 	route2 := createRoute(generateRouteCreateParamsForUnitTests("test", "HTTP", "localhost", "/test", "1.0.0", "/test",
-		"/testPath", []string{"POST"}, "test-cluster", corsConfigModel3))
+		"/testPath", []string{"POST"}, "test-cluster", corsConfigModel3, false))
 	route3 := createRoute(generateRouteCreateParamsForUnitTests("test", "HTTP", "localhost", "/test", "1.0.0", "/test",
-		"/testPath", []string{"PUT"}, "test-cluster", corsConfigModel3))
+		"/testPath", []string{"PUT"}, "test-cluster", corsConfigModel3, false))
 
 	routes := []*routev3.Route{route1, route2, route3}
 

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -522,7 +522,6 @@ func processEndpoints(clusterName string, clusterDetails *model.EndpointCluster,
 			return nil, nil, errors.New("endpoint basepath mismatched for " + ep.RawURL + ". expected : " + basePath + " but found : " + ep.Basepath)
 		}
 		// create addresses for endpoints
-		// TODO: Get endpoint from here
 		address := createAddress(ep.Host, ep.Port)
 		if enableRouterConfigValidation {
 			err := address.Validate()

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"regexp"
 	"slices"
 	"strconv"
@@ -1028,7 +1029,7 @@ func createRoute(params *routeCreateParams) *routev3.Route {
 		}
 	}
 
-	if params.enableRSTRetry {
+	if params.enableRSTRetry && os.Getenv("ROUTER_CONNECTION_FAILURE_RETRY_ON_RST_ENABLED") == "true" {
 		// Retry configs are always added via headers. This is to update the
 		// default retry back-off base interval, which cannot be updated via headers.
 		retryConfig := config.Envoy.Upstream.Retry

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
@@ -19,6 +19,7 @@ package envoyconf_test
 import (
 	"encoding/json"
 	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -490,6 +491,8 @@ func TestCreateRoutesWithClusters(t *testing.T) {
 }
 
 func TestCreateRoutesWithClustersWithRstRetry(t *testing.T) {
+	os.Setenv("ROUTER_CONNECTION_FAILURE_RETRY_ON_RST_ENABLED", "true")
+
 	envProps := synchronizer.APIEnvProps{
 		EnvID: "some id",
 		APIConfigs: synchronizer.APIConfigs{


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
Configure Envoy to retry connections when upstream Kubernetes endpoints, proxied by Cilium Envoy, send RST packets. This change aims to mitigate https://github.com/cilium/cilium/issues/33880 which cause unexpected 503 responses for requests.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/~No~
 - Integration tests added: ~Yes~/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
