### PR TITLE
[Choreo] [ws analytics] Fix publishing 101 success requests

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/ChoreoAnalyticsProvider.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/ChoreoAnalyticsProvider.java
@@ -59,6 +59,11 @@ public class ChoreoAnalyticsProvider implements AnalyticsDataProvider {
                 logEntry.getResponse().getResponseCodeDetails())) {
             logger.debug("Is success event");
             return EventCategory.SUCCESS;
+        } else if (logEntry.getResponse() != null && AnalyticsConstants.WEBSOCKET_101_STATUS.equals(
+                String.valueOf(logEntry.getResponse().getResponseCode().getValue()))) {
+            // TODO: (thushani) Need to handle the websocket success event with ChoreoAnalyticsForWSProvider.
+            logger.debug("Is success websocket event");
+            return EventCategory.SUCCESS;
         } else if (logEntry.getResponse() != null
                 && logEntry.getResponse().getResponseCode() != null
                 && logEntry.getResponse().getResponseCode().getValue() != 200
@@ -87,7 +92,10 @@ public class ChoreoAnalyticsProvider implements AnalyticsDataProvider {
 
     @Override
     public FaultCategory getFaultType() {
-        if (isTargetFaultRequest()) {
+        if (AnalyticsConstants.UPSTREAM_OVERFLOW_RESPONSE_DETAIL.
+            equals(logEntry.getResponse().getResponseCodeDetails())) {
+            return  FaultCategory.THROTTLED;
+        } else if (isTargetFaultRequest()) {
             return FaultCategory.TARGET_CONNECTIVITY;
         } else {
             return FaultCategory.OTHER;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/AnalyticsConstants.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/AnalyticsConstants.java
@@ -29,6 +29,8 @@ public class AnalyticsConstants {
     public static final String EXT_AUTH_ERROR_RESPONSE_DETAIL = "ext_authz_error";
     public static final String ROUTE_NOT_FOUND_RESPONSE_DETAIL = "route_not_found";
     public static final String GATEWAY_LABEL = "ENVOY";
+    public static final String WEBSOCKET_101_STATUS = "101";
+    public static final String UPSTREAM_OVERFLOW_RESPONSE_DETAIL = "upstream_reset_before_response_started{overflow}";
 
     public static final String TOKEN_ENDPOINT_PATH = "/testkey";
     public static final String HEALTH_ENDPOINT_PATH = "/health";


### PR DESCRIPTION
### Purpose
Currently the WebSocket Access logs with status code 101 are not published in analytics UI. This PR will fix it by using the current default analytics provider.
Later in the  handleGRPCLogMsg(StreamAccessLogsMessage message) method we need to define a seperate analytics provider for websocket connections. Currently there is no way of identifying this.


Furthermore this can be improved with access logs been flushed for a duration instead of completion

https://www.envoyproxy.io/docs/envoy/v1.26.8/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-hcmaccesslogoptions

access_log_flush_interval
([Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration)) The interval to flush the above access logs. By default, the HCM will flush exactly one access log on stream close, when the HTTP request is complete. If this field is set, the HCM will flush access logs periodically at the specified interval. This is especially useful in the case of long-lived requests, such as CONNECT and Websockets. Final access logs can be detected via the requestComplete() method of StreamInfo in access log filters, or thru the %DURATION% substitution string. The interval must be at least 1 millisecond.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
