### PR TITLE
Add support for disabling in-cluster endpoint connection pooling

### DIFF
--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -622,8 +622,20 @@ func processEndpoints(clusterName string, clusterDetails *model.EndpointCluster,
 	// If the endpoint is within the cluster, set the max requests per connection to 1
 	// This ensure cilium proxy will not reuse the connection
 	if withinClusterEndpoint && os.Getenv("ROUTER_DISABLE_INCLUSTER_CONNECTION_POOLING") == "true" {
-		cluster.CommonHttpProtocolOptions = &corev3.HttpProtocolOptions{
-			MaxRequestsPerConnection: wrapperspb.UInt32(uint32(1)),
+		config := &upstreams.HttpProtocolOptions{
+			CommonHttpProtocolOptions: &corev3.HttpProtocolOptions{
+				MaxRequestsPerConnection: wrapperspb.UInt32(1),
+			},
+		}
+
+		marshalledConfig, err := anypb.New(config)
+		if err != nil {
+			return nil, nil, errors.New("internal Error while marshalling the HTTP Protocol Options")
+		}
+
+		// Add to cluster's TypedExtensionProtocolOptions instead of deprecated fields
+		cluster.TypedExtensionProtocolOptions = map[string]*any.Any{
+			"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": marshalledConfig,
 		}
 	}
 

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -621,7 +621,7 @@ func processEndpoints(clusterName string, clusterDetails *model.EndpointCluster,
 
 	// If the endpoint is within the cluster, set the max requests per connection to 1
 	// This ensure cilium proxy will not reuse the connection
-	if withinClusterEndpoint && os.Getenv("ROUTER_DISABLE_INCLUSTER_CONNECTION_POOLING") == "true" {
+	if withinClusterEndpoint && os.Getenv("ROUTER_DISABLE_IN_CLUSTER_CONNECTION_POOLING") == "true" {
 		config := &upstreams.HttpProtocolOptions{
 			CommonHttpProtocolOptions: &corev3.HttpProtocolOptions{
 				MaxRequestsPerConnection: wrapperspb.UInt32(1),


### PR DESCRIPTION
### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->
The use of connection pooling for intra-cluster communications has led to a few conflicts with Cilium Envoy, resulting in intermittent 503 errors. The goal of this PR is to disable connection pooling within the cluster to mitigate the issue described in https://github.com/cilium/cilium/issues/33880.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
