### PR TITLE
[choreo] Fix: propely get AmqpOverWebsocketsEnabled flag

### DIFF
--- a/adapter/internal/messaging/azure_listener.go
+++ b/adapter/internal/messaging/azure_listener.go
@@ -65,7 +65,7 @@ func InitiateAndProcessEvents(config *config.Config) {
 			subscription, err := msg.InitiateBrokerConnectionAndValidate(
 				topic.ConnectionString,
 				topic.TopicName,
-				getAmqpClientOptions(config),
+				getAmqpClientOptions(topic.AmqpOverWebsocketsEnabled),
 				componentName,
 				topic.ReconnectRetryCount,
 				topic.ReconnectInterval*time.Millisecond,
@@ -89,7 +89,7 @@ func InitiateAndProcessEvents(config *config.Config) {
 			subscription, err := msg.InitiateBrokerConnectionAndValidate(
 				connectionString,
 				topic,
-				getAmqpClientOptions(config),
+				getAmqpClientOptions(config.ControlPlane.BrokerConnectionParameters.AmqpOverWebsocketsEnabled),
 				componentName,
 				reconnectRetryCount,
 				reconnectInterval*time.Millisecond,
@@ -118,8 +118,8 @@ func startChannelConsumer(consumerType string) {
 	}
 }
 
-func getAmqpClientOptions(config *config.Config) *azservicebus.ClientOptions {
-	if config.ControlPlane.BrokerConnectionParameters.AmqpOverWebsocketsEnabled {
+func getAmqpClientOptions(isAmqpOverWebsocketsEnabled bool) *azservicebus.ClientOptions {
+	if isAmqpOverWebsocketsEnabled {
 		logger.LoggerMgw.Info("AMQP over Websockets is enabled. Initiating brokers with AMQP over Websockets.")
 		newWebSocketConnFn := func(ctx context.Context, args azservicebus.NewWebSocketConnArgs) (net.Conn, error) {
 			opts := &websocket.DialOptions{Subprotocols: []string{"amqp"}}


### PR DESCRIPTION
### Purpose
When multi-tenanted ASB is enabled (i.e. config.ControlPlane.ASBDataplaneTopics are provided) it should get the AmqpOverWebsocketsEnabled flag from each topic wise configuration, rather getting from the global configuration.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
