### PR TITLE
Bump `ballerina.platform.version`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -574,7 +574,7 @@
     </build>
 
     <properties>
-        <ballerina.platform.version>1.2.55</ballerina.platform.version>
+        <ballerina.platform.version>1.2.56</ballerina.platform.version>
         <broker.version>0.970.5</broker.version>
         <assembly.plugin.version>3.1.1</assembly.plugin.version>
         <compiler.plugin.version>3.7.0</compiler.plugin.version>


### PR DESCRIPTION
## Purpose
Upgrade `ballerina.platform.version` to `1.2.56` to address issue `Docker Image Build Failure in Micro Gateway Toolkit Due to Jersey Library Update`.

## Related to 
Issue: https://github.com/wso2/product-microgateway/issues/3635
Internal issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/8441