### PR TITLE
Added a env var to control MaxConnectionDuration

### DIFF
--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -625,6 +625,16 @@ func processEndpoints(clusterName string, clusterDetails *model.EndpointCluster,
 		cluster.MaxRequestsPerConnection = wrapperspb.UInt32(1)
 	}
 
+	// If the endpoint is within the cluster, set the set max connection duration for given env variable
+	if withinClusterEndpoint && os.Getenv("ROUTER_MAX_CONNECTION_DURATION_SECONDS") != "" {
+		maxConnectionDuration, err := strconv.Atoi(os.Getenv("ROUTER_MAX_CONNECTION_DURATION_SECONDS"))
+		if err != nil {
+			logger.LoggerOasparser.Error("Error while converting max connection duration to int. ", err)
+		} else {
+			cluster.CommonHttpProtocolOptions.MaxConnectionDuration = durationpb.New(time.Duration(maxConnectionDuration) * time.Second)
+		}
+	}
+
 	if len(clusterDetails.Endpoints) > 1 {
 		cluster.HealthChecks = createHealthCheck()
 	}


### PR DESCRIPTION
### Purpose
The use of connection pooling for intra-cluster communications has led to a few conflicts with Cilium Envoy, resulting in intermittent 503 errors. The goal of this PR is to make sure choreo connect doesn't keep up a connection open for too long resulting in reusing of stale upstream connection. This is a compromise between having connection pooling fully turned of vs having to deal with 503 errors.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
https://github.com/wso2-enterprise/choreo/issues/33447

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
