### PR TITLE
Add feature flag for port in host header

### DIFF
--- a/adapter/config/default_config.go
+++ b/adapter/config/default_config.go
@@ -71,6 +71,7 @@ var defaultConfig = &Config{
 		SandboxVhost:                "sandbox.host",
 		SandboxEnvName:              "sandbox",
 		IsIntelligentRoutingEnabled: false,
+		IncludePortInHostHeader:     true,
 	},
 	Envoy: envoy{
 		ListenerHost:                     "0.0.0.0",

--- a/adapter/config/types.go
+++ b/adapter/config/types.go
@@ -104,6 +104,8 @@ type adapter struct {
 	SandboxEnvName string
 	// Feature flag to enable semantic version based intelligent routing
 	IsIntelligentRoutingEnabled bool
+	// Feature flag to include port in host header
+	IncludePortInHostHeader bool
 }
 
 // Envoy Listener Component related configurations.

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -515,6 +515,7 @@ func processEndpoints(clusterName string, clusterDetails *model.EndpointCluster,
 	addresses := []*corev3.Address{}
 
 	withinClusterEndpoint := false
+	conf, _ := config.ReadConfigs()
 
 	for i, ep := range clusterDetails.Endpoints {
 
@@ -537,7 +538,7 @@ func processEndpoints(clusterName string, clusterDetails *model.EndpointCluster,
 		addresses = append(addresses, address)
 
 		var lbEndpoint *endpointv3.LbEndpoint
-		if withinClusterEndpoint {
+		if withinClusterEndpoint && conf.Adapter.IncludePortInHostHeader {
 			// If the endpoint is within the cluster, set the address to the hostname.
 			// Hostname is used for the auto host rewrite feature to set the host header.
 			lbEndpoint = &endpointv3.LbEndpoint{
@@ -612,7 +613,6 @@ func processEndpoints(clusterName string, clusterDetails *model.EndpointCluster,
 			priority = priority + 1
 		}
 	}
-	conf, _ := config.ReadConfigs()
 
 	dnsResolverConf, err := getDNSResolverConf()
 	if err != nil {


### PR DESCRIPTION
### Purpose
This PR adds a feature flag for the previous PR https://github.com/wso2/product-microgateway/pull/3655 which adds the port to the host header for keda multiple endpoints routing.

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Related to https://github.com/wso2/product-microgateway/pull/3655

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
