### PR TITLE
[3.2.x] Revamp schema validation logic to align with APIM 4.x versions

### DIFF
--- a/components/micro-gateway-cli/src/main/resources/templates/ballerinaToml.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/ballerinaToml.mustache
@@ -28,28 +28,84 @@ target = "java8"
         path = "{{toolkitHome}}/lib/dependencies/mgw-jwt-transformer-{{mgwVersion}}.jar"
 
     [[platform.libraries]]
-            module = "jwtGenerator"
-            path = "{{toolkitHome}}/lib/dependencies/mgw-jwt-generator-{{mgwVersion}}.jar"
+        module = "jwtGenerator"
+        path = "{{toolkitHome}}/lib/dependencies/mgw-jwt-generator-{{mgwVersion}}.jar"
 
-     [[platform.libraries]]
+    [[platform.libraries]]
         module = "gateway"
         path = "{{toolkitHome}}/lib/dependencies/org.wso2.carbon.databridge.commons-6.1.45.jar"
 
-     [[platform.libraries]]
+    [[platform.libraries]]
         module = "gateway"
         path = "{{toolkitHome}}/lib/dependencies/org.wso2.carbon.databridge.commons.binary-6.1.45.jar"
 
-     [[platform.libraries]]
+    [[platform.libraries]]
         module = "gateway"
         path = "{{toolkitHome}}/lib/dependencies/disruptor-3.4.2.wso2v1.jar"
 
-     [[platform.libraries]]
+    [[platform.libraries]]
         module = "callhome"
         path = "{{toolkitHome}}/lib/gateway/platform/core-1.0.16.jar"
 
-     [[platform.libraries]]
+    [[platform.libraries]]
         module = "bind-api"
         path = "{{toolkitHome}}/lib/gateway/platform/jaxb-api-2.3.1.jar"
+
+    [[platform.libraries]]
+        module = "bind-api"
+        path = "{{toolkitHome}}/lib/gateway/platform/jaxb-api-2.3.1.jar"
+
+    [[platform.libraries]]
+        module = "gateway"
+        path = "{{toolkitHome}}/lib/dependencies/validation/swagger-parser-2.1.22.wso2v2.jar"
+
+    [[platform.libraries]]
+        module = "gateway"
+        path = "{{toolkitHome}}/lib/dependencies/validation/swagger-request-validator-core-2.12.1.wso2v2.jar"
+
+    [[platform.libraries]]
+        module = "gateway"
+        path = "{{toolkitHome}}/lib/dependencies/validation/jackson-datatype-jsr310-2.16.2.jar"
+
+    [[platform.libraries]]
+        module = "gateway"
+        path = "{{toolkitHome}}/lib/dependencies/validation/jackson-dataformat-yaml-2.16.2.jar"
+
+    [[platform.libraries]]
+        module = "gateway"
+        path = "{{toolkitHome}}/lib/dependencies/validation/swagger-core-1.5.8.jar"
+
+    [[platform.libraries]]
+        module = "gateway"
+        path = "{{toolkitHome}}/lib/dependencies/validation/swagger-models-1.5.16.jar"
+
+    [[platform.libraries]]
+        module = "gateway"
+        path = "{{toolkitHome}}/lib/dependencies/validation/json-schema-validator-all-2.2.7.wso2v2.jar"
+
+    [[platform.libraries]]
+        module = "gateway"
+        path = "{{toolkitHome}}/lib/dependencies/validation/joda-time-2.13.1.jar"
+
+    [[platform.libraries]]
+        module = "gateway"
+        path = "{{toolkitHome}}/lib/dependencies/validation/javax.mail-api-1.6.2.jar"
+
+    [[platform.libraries]]
+        module = "gateway"
+        path = "{{toolkitHome}}/lib/dependencies/validation/libphonenumber-7.4.5.jar"
+
+    [[platform.libraries]]
+        module = "gateway"
+        path = "{{toolkitHome}}/lib/dependencies/validation/guava-32.1.1-jre.jar"
+
+    [[platform.libraries]]
+        module = "gateway"
+        path = "{{toolkitHome}}/lib/dependencies/validation/failureaccess-1.0.1.jar"
+
+    [[platform.libraries]]
+        module = "gateway"
+        path = "{{toolkitHome}}/lib/dependencies/validation/js-1.7.0.R4.wso2v1.jar"
 
 {{#each libs}}
     [[platform.libraries]]

--- a/components/micro-gateway-cli/src/main/resources/templates/ballerinaToml.mustache
+++ b/components/micro-gateway-cli/src/main/resources/templates/ballerinaToml.mustache
@@ -73,11 +73,11 @@ target = "java8"
 
     [[platform.libraries]]
         module = "gateway"
-        path = "{{toolkitHome}}/lib/dependencies/validation/swagger-core-1.5.8.jar"
+        path = "{{toolkitHome}}/lib/dependencies/validation/swagger-core-1.6.11.jar"
 
     [[platform.libraries]]
         module = "gateway"
-        path = "{{toolkitHome}}/lib/dependencies/validation/swagger-models-1.5.16.jar"
+        path = "{{toolkitHome}}/lib/dependencies/validation/swagger-models-1.6.11.jar"
 
     [[platform.libraries]]
         module = "gateway"
@@ -89,7 +89,7 @@ target = "java8"
 
     [[platform.libraries]]
         module = "gateway"
-        path = "{{toolkitHome}}/lib/dependencies/validation/javax.mail-api-1.6.2.jar"
+        path = "{{toolkitHome}}/lib/dependencies/validation/javax.mail-1.6.2.jar"
 
     [[platform.libraries]]
         module = "gateway"

--- a/components/micro-gateway-core/pom.xml
+++ b/components/micro-gateway-core/pom.xml
@@ -99,9 +99,9 @@
             <version>${com.google.guava.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.com.jayway.jsonpath</groupId>
-            <artifactId>json-path</artifactId>
-            <version>${com.jayway.jsonpath.version}</version>
+            <groupId>com.google.guava</groupId>
+            <artifactId>failureaccess</artifactId>
+            <version>${guava.failureaccess.version}</version>
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.org.everit.json</groupId>
@@ -227,6 +227,50 @@
             <groupId>net.minidev</groupId>
             <artifactId>asm</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.io.swagger.v3</groupId>
+            <artifactId>swagger-parser</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.com.atlassian.oai</groupId>
+            <artifactId>swagger-request-validator-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-models</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.com.github.java-json-tools</groupId>
+            <artifactId>json-schema-validator-all</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>javax.mail-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.googlecode.libphonenumber</groupId>
+            <artifactId>libphonenumber</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>rhino.wso2</groupId>
+            <artifactId>js</artifactId>
+        </dependency>
     </dependencies>
 
     <profiles>
@@ -329,18 +373,21 @@
                         </goals>
                         <configuration>
                             <outputDirectory>${project.build.directory}/lib/dependencies/</outputDirectory>
-                            <includeGroupIds>org.wso2.orbit.org.everit.json, org.json.wso2, com.nimbusds,
-                                net.minidev, org.apache.logging.log4j, com.fasterxml.jackson.core,
-                                org.wso2.carbon.apimgt, org.wso2.am.analytics.publisher, ua.parser.wso2,
-                                org.wso2.orbit.com.azure, org.reactivestreams, io.github.openfeign,
-                                org.wso2.orbit.io.projectreactor, org.apache.qpid
+                            <includeGroupIds>
+                                org.wso2.orbit.org.everit.json, org.json.wso2, com.nimbusds, net.minidev,
+                                org.apache.logging.log4j, com.fasterxml.jackson.core, org.wso2.carbon.apimgt,
+                                org.wso2.am.analytics.publisher, ua.parser.wso2, org.wso2.orbit.com.azure,
+                                org.reactivestreams, io.github.openfeign, org.wso2.orbit.io.projectreactor,
+                                org.apache.qpid, org.wso2.orbit.com.atlassian.oai, com.fasterxml.jackson.datatype,
+                                com.google.guava
                             </includeGroupIds>
-                            <includeArtifactIds>org.everit.json.schema, json, nimbus-jose-jwt, json-smart, asm,
-                                log4j-api, log4j-core, jackson-databind, jackson-core,
-                                jackson-annotations, org.wso2.carbon.apimgt.common.analytics,
-                                org.wso2.am.analytics.publisher.client, ua-parser, azure-core, azure-core-amqp,
-                                azure-messaging-eventhubs, reactive-streams, feign-core, feign-slf4j, feign-gson,
-                                reactor-core, proton-j
+                            <includeArtifactIds>
+                                org.everit.json.schema, json, nimbus-jose-jwt, json-smart, asm, log4j-api, log4j-core,
+                                jackson-databind, jackson-core, jackson-annotations,
+                                org.wso2.carbon.apimgt.common.analytics, org.wso2.am.analytics.publisher.client,
+                                ua-parser, azure-core, azure-core-amqp, azure-messaging-eventhubs, reactive-streams,
+                                feign-core, feign-slf4j, feign-gson, reactor-core, proton-j,
+                                swagger-request-validator-core, jackson-datatype-jsr310, guava
                             </includeArtifactIds>
                         </configuration>
                     </execution>

--- a/components/micro-gateway-core/pom.xml
+++ b/components/micro-gateway-core/pom.xml
@@ -260,8 +260,8 @@
             <artifactId>joda-time</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>javax.mail-api</artifactId>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
         </dependency>
         <dependency>
             <groupId>com.googlecode.libphonenumber</groupId>

--- a/components/micro-gateway-core/src/main/ballerina/Ballerina.toml
+++ b/components/micro-gateway-core/src/main/ballerina/Ballerina.toml
@@ -15,10 +15,10 @@ target = "java8"
     path = "../../../target/lib/dependencies/json-3.0.0.wso2v4.jar"
 
     [[platform.libraries]]
-    path = "../../../target/lib/dependencies/log4j-core-2.17.0.jar"
+    path = "../../../target/lib/dependencies/log4j-core-2.17.2.jar"
 
     [[platform.libraries]]
-    path = "../../../target/lib/dependencies/log4j-api-2.17.0.jar"
+    path = "../../../target/lib/dependencies/log4j-api-2.17.2.jar"
 
     [[platform.libraries]]
     path = "../../../target/lib/dependencies/nimbus-jose-jwt-9.40.jar"
@@ -31,13 +31,13 @@ target = "java8"
 
     # jackson libraries are added for the use of default claim retriever implementation
     [[platform.libraries]]
-    path = "../../../target/lib/dependencies/jackson-annotations-2.15.2.jar"
+    path = "../../../target/lib/dependencies/jackson-annotations-2.16.2.jar"
 
     [[platform.libraries]]
-    path = "../../../target/lib/dependencies/jackson-core-2.15.2.jar"
+    path = "../../../target/lib/dependencies/jackson-core-2.16.2.jar"
 
     [[platform.libraries]]
-    path = "../../../target/lib/dependencies/jackson-databind-2.15.2.jar"
+    path = "../../../target/lib/dependencies/jackson-databind-2.16.2.jar"
 
     [[platform.libraries]]
     path = "../../../target/lib/dependencies/org.wso2.carbon.apimgt.common.analytics-9.29.120.jar"
@@ -74,6 +74,15 @@ target = "java8"
 
     [[platform.libraries]]
     path = "../../../target/lib/dependencies/proton-j-0.33.4.jar"
+
+    [[platform.libraries]]
+    path = "../../../target/lib/dependencies/swagger-request-validator-core-2.12.1.wso2v2.jar"
+
+    [[platform.libraries]]
+    path = "../../../target/lib/dependencies/jackson-datatype-jsr310-2.16.2.jar"
+
+    [[platform.libraries]]
+    path = "../../../target/lib/dependencies/guava-32.1.1-jre.jar"
 
 [dependencies]
 "ballerina/java.jms" = "0.8.5"

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/validation_request_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/validation_request_filter.bal
@@ -77,7 +77,19 @@ function doValidationFilterRequest(http:Caller caller, http:Request request, htt
     if (reqPayload is json) {
         payloadVal = reqPayload.toJsonString();
     }
-    var valResult = requestValidate(requestPath, requestMethod, payloadVal, serviceName);
+
+    //getting the headers of the request
+    string[] headerNames = request.getHeaderNames();
+    map<string> headers = {};
+    foreach var header in headerNames {
+        string headerValue = request.getHeader(<@untained> header);
+        headers[header] = headerValue;
+    }
+
+    //getting the query params of the request
+    map<string[]> queryParams = request.getQueryParams();
+
+    var valResult = requestValidate(requestPath, requestMethod, payloadVal, headers, queryParams, serviceName);
     if (valResult is handle && stringutils:equalsIgnoreCase(valResult.toString(), VALIDATION_STATUS)) {
         return true;
     } else {

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/validation_response_filter.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/filters/validation_response_filter.bal
@@ -57,7 +57,7 @@ function doValidationFilterResponse(@tainted http:Response response, http:Filter
 
     //todo: Accept only the content types which are mentioned in the openAPI definition
     //If the content-type is not application/json, validation fiter is not applied.
-    if (!stringutils:equalsIgnoreCase(response.getContentType(), APPLICATION_JSON)) {
+    if (!stringutils:contains(response.getContentType().toLowerAscii(), APPLICATION_JSON)) {
         printDebug(KEY_VALIDATION_FILTER, "Validation Filter is not applied as the response content type is : " + 
             response.getContentType());
         return true;
@@ -70,7 +70,15 @@ function doValidationFilterResponse(@tainted http:Response response, http:Filter
         resPayload = payload.toJsonString();
     }
     string servName = filterContext.getServiceName();
-    var valResult = responseValidate(reqestPath, requestMethod, responseCode, resPayload, servName);
+    //getting the headers of the response
+    string[] headerNames = response.getHeaderNames();
+    map<string> headers = {};
+    foreach var header in headerNames {
+        string headerValue = response.getHeader(<@untained> header);
+        headers[header] = headerValue;
+    }
+
+    var valResult = responseValidate(reqestPath, requestMethod, responseCode, resPayload, headers, servName);
     if (valResult is handle && stringutils:equalsIgnoreCase(valResult.toString(), VALIDATION_STATUS)) {
         return true;
     } else {

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/native/validator.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/native/validator.bal
@@ -21,15 +21,17 @@ import ballerina/java;
 # + reqPath - project Name
 # + requestMethod - Service Name
 # + payload - request payload
+# + transportHeaders - Transport headers
+# + queryParams - Query parameters
 # + serviceName - serviceName
 # +return - status of the validation
-public function requestValidate(string reqPath, string requestMethod,  string payload, string serviceName)
-    returns handle | error {
-     handle requestPath = java:fromString(reqPath);
-     handle reqMethod = java:fromString(requestMethod);
-     handle requestPayload = java:fromString(payload);
-     handle servName = java:fromString(serviceName);
-     return jRequestValidate(requestPath, reqMethod, requestPayload, servName);
+public function requestValidate(string reqPath, string requestMethod, string payload, map<string> transportHeaders,
+    map<string[]> queryParams, string serviceName) returns handle|error {
+    handle requestPath = java:fromString(reqPath);
+    handle reqMethod = java:fromString(requestMethod);
+    handle requestPayload = java:fromString(payload);
+    handle servName = java:fromString(serviceName);
+    return jRequestValidate(requestPath, reqMethod, requestPayload, transportHeaders, queryParams, servName);
 }
 
 # Validate response payload.
@@ -38,41 +40,42 @@ public function requestValidate(string reqPath, string requestMethod,  string pa
 # + requestMethod - Service Name
 # + responseCode - Service Name
 # + response - Service Name
+# + transportHeaders - Transport headers
 # + serviceNme - Service Name
 # + return - Extracted resources map
 public function responseValidate(string reqPath, string requestMethod, string responseCode, string response,
-                                                                           string serviceNme) returns handle | error {
-     handle requestPath = java:fromString(reqPath);
-     handle reqMethod = java:fromString(requestMethod);
-     handle resCode = java:fromString(responseCode);
-     handle responsePayload = java:fromString(response);
-     handle servName = java:fromString(serviceNme);
-     return jResponseValidate(requestPath, reqMethod, resCode, responsePayload, servName);
+    map<string> transportHeaders, string serviceNme) returns handle|error {
+    handle requestPath = java:fromString(reqPath);
+    handle reqMethod = java:fromString(requestMethod);
+    handle resCode = java:fromString(responseCode);
+    handle responsePayload = java:fromString(response);
+    handle servName = java:fromString(serviceNme);
+    return jResponseValidate(requestPath, reqMethod, resCode, responsePayload, transportHeaders, servName);
 }
 
-# Extract Resource artifcats.
+# Extract Resource artifacts.
 #
 # + projectName - project Name
 # + return - Extracted resources map
 public function extractJAR(string projectName) returns error? {
-     handle prjtName = java:fromString(projectName);
-     return extract(prjtName);
+    handle prjtName = java:fromString(projectName);
+    return extract(prjtName);
 }
 
-function extract(handle Name) returns error?  = @java:Method {
-     name: "extractResources",
-     class: "org.wso2.micro.gateway.core.utils.CommonUtils"
+function extract(handle Name) returns error? = @java:Method {
+    name: "extractResources",
+    class: "org.wso2.micro.gateway.core.utils.CommonUtils"
 
 } external;
 
-function jRequestValidate(handle resourcePath, handle reqMethod, handle requestPayload, handle serviceName)
-                                                                            returns handle | error = @java:Method {
-     name: "validateRequest",
-     class: "org.wso2.micro.gateway.core.validation.Validate"
+function jRequestValidate(handle resourcePath, handle reqMethod, handle requestPayload, map<string> transportHeaders,
+    map<string[]> queryParams, handle serviceName) returns handle|error = @java:Method {
+    name: "validateRequest",
+    class: "org.wso2.micro.gateway.core.validation.Validate"
 } external;
 
-function jResponseValidate(handle resourcePath, handle reqMethod, handle resCode, handle res, handle serName)
-                        returns handle | error = @java:Method {
-     name: "validateResponse",
-     class: "org.wso2.micro.gateway.core.validation.Validate"
+function jResponseValidate(handle resourcePath, handle reqMethod, handle resCode, handle res,
+    map<string> transportHeaders, handle serviceName) returns handle|error = @java:Method {
+    name: "validateResponse",
+    class: "org.wso2.micro.gateway.core.validation.Validate"
 } external;

--- a/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/Constants.java
+++ b/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/Constants.java
@@ -41,31 +41,7 @@ public class Constants {
 
     public static final String FILE_NOT_FOUND_ERROR = "{wso2/gateway}FileNotFoundError";
 
-    public static final String SCHEMA_REFERENCE = "$ref";
-    public static final String PATHS = "$..paths..";
-    public static final String BODY_CONTENT = ".requestBody.content.application/json.schema";
-    public static final String JSON_PATH = "$.";
-    public static final String ITEMS = "items";
-    public static final String OPEN_API = ".openapi";
-    public static final char JSONPATH_SEPARATE = '.';
-    public static final String PARAM_SCHEMA = ".parameters..schema";
-    public static final String REQUEST_BODY = "..requestBody";
-    public static final String JSON_RESPONSES = ".responses.";
-    public static final String DEFAULT = "default";
-    public static final String CONTENT = ".content";
-    public static final String JSON_CONTENT = ".application/json.schema.$ref";
-    public static final String SCHEMA = ".schema";
-    public static final String EMPTY_ARRAY = "[]";
-    public static final String DEFINITIONS = "definitions";
-    public static final String COMPONENT_SCHEMA = "components/schemas";
-    public static final char HASH = '#';
-    public static final String EMPTY = "";
-    public static final String BACKWARD_SLASH = "\"";
     public static final char FORWARD_SLASH = '/';
-    public static final String REQUESTBODY_SCHEMA = "components.requestBodies.";
-    public static final String REQUESTBODIES = "requestBodies";
-    public static final String JSONPATH_SCHEMAS = "$..components.schemas.";
-    public static final String JSON_SCHEMA = ".content.application/json.schema";
     public static final String VALIDATED_STATUS = "validated";
     public static final String RUNTIME_HOME_PATH = "mgw-runtime.home";
     public static final String BEGIN_CERTIFICATE_STRING = "-----BEGIN CERTIFICATE-----\n";

--- a/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/validation/OpenAPIRequest.java
+++ b/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/validation/OpenAPIRequest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.micro.gateway.core.validation;
+
+import com.atlassian.oai.validator.model.Request;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * Request Model class for OpenAPI
+ */
+public class OpenAPIRequest implements Request {
+
+    private final Method method;
+    private final Multimap<String, String> headers = ArrayListMultimap.create();
+    private String path;
+    private Map<String, Collection<String>> queryParams;
+    private Optional<String> requestBody;
+
+    /**
+     * Build OAI Request from Message Context.
+     *
+     * @param requestPath      API request resource path
+     * @param reqMethod        API request method
+     * @param requestBody      Request body
+     * @param transportHeaders Transport headers
+     * @param swagger          Swagger definition
+     */
+    public OpenAPIRequest(String requestPath, String reqMethod, String requestBody,
+                          Multimap<String, String> transportHeaders, Map<String, Collection<String>> queryParams,
+                          String swagger) {
+        this.method = Method.valueOf(reqMethod.toUpperCase());
+        this.path = requestPath;
+        this.requestBody = Optional.of(requestBody);
+        if (swagger != null) {
+            OpenAPIParser openAPIParser = new OpenAPIParser();
+            SwaggerParseResult swaggerParseResult = openAPIParser.readContents(swagger, new ArrayList<>(),
+                    new ParseOptions());
+            OpenAPI openAPI = swaggerParseResult.getOpenAPI();
+            validatePath(openAPI);
+        }
+        this.headers.putAll(transportHeaders);
+        this.queryParams = queryParams;
+    }
+
+    @NotNull
+    @Override
+    public String getPath() {
+        return this.path;
+    }
+
+    @NotNull
+    @Override
+    public Method getMethod() {
+        return this.method;
+    }
+
+    @NotNull
+    @Override
+    public Optional<String> getBody() {
+        return this.requestBody;
+    }
+
+    @NotNull
+    @Override
+    public Collection<String> getQueryParameters() {
+        if (this.queryParams == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableCollection(this.queryParams.keySet());
+    }
+
+    @NotNull
+    @Override
+    public Collection<String> getQueryParameterValues(String s) {
+        if (this.queryParams == null) {
+            return Collections.emptyList();
+        }
+        return SchemaValidationUtils.getFromMapOrEmptyList(this.queryParams, s);
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Collection<String>> getHeaders() {
+        if (this.headers == null) {
+            return Collections.emptyMap();
+        }
+        return headers.asMap();
+    }
+
+    @NotNull
+    @Override
+    public Collection<String> getHeaderValues(String s) {
+        if (this.headers == null) {
+            return Collections.emptyList();
+        }
+        return SchemaValidationUtils.getFromMapOrEmptyList(this.headers.asMap(), s);
+    }
+
+    protected void validatePath(OpenAPI openAPI) {
+        Paths paths = openAPI.getPaths();
+        if (path.equals("/") && !paths.containsKey(path)) {
+            if (paths.containsKey("/*")) {
+                path = "/*";
+            }
+        }
+    }
+}

--- a/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/validation/OpenAPIResponse.java
+++ b/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/validation/OpenAPIResponse.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.micro.gateway.core.validation;
+
+import com.atlassian.oai.validator.model.Request.Method;
+import com.atlassian.oai.validator.model.Response;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * Response Model class for OpenAPI
+ */
+public class OpenAPIResponse implements Response {
+
+    private final int status;
+    private final Optional<String> responseBody;
+    private final Multimap<String, String> headers = ArrayListMultimap.create();
+    private final Method method;
+    private final String path;
+
+    /**
+     * Build OAI Response from messageContext.
+     *
+     * @param resourcePath     Resource path
+     * @param reqMethod        Request method
+     * @param responseCode     Response code
+     * @param responseBody     Response body
+     * @param transportHeaders Transport headers
+     */
+    public OpenAPIResponse(String resourcePath, String reqMethod, String responseCode, String responseBody,
+                           Multimap<String, String> transportHeaders) {
+        int statusCode = Integer.parseInt(responseCode);
+        this.status = statusCode;
+        this.method = Method.valueOf(reqMethod.toUpperCase());
+        this.path = resourcePath;
+        this.responseBody = Optional.of(responseBody);
+        this.headers.putAll(transportHeaders);
+    }
+
+    @Override
+    public int getStatus() {
+        return status;
+    }
+
+    /**
+     * @deprecated
+     */
+    @NotNull
+    @Override
+    public Optional<String> getBody() {
+        return responseBody;
+    }
+
+    @NotNull
+    @Override
+    public Collection<String> getHeaderValues(String s) {
+        return SchemaValidationUtils.getFromMapOrEmptyList(headers.asMap(), s);
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+
+    public String getPath() {
+        return path;
+    }
+}

--- a/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/validation/SchemaValidationUtils.java
+++ b/components/micro-gateway-core/src/main/java/org/wso2/micro/gateway/core/validation/SchemaValidationUtils.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.micro.gateway.core.validation;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import org.ballerinalang.jvm.values.ArrayValue;
+import org.ballerinalang.jvm.values.MapValue;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for schema validation.
+ */
+public class SchemaValidationUtils {
+
+    /**
+     * Method to get a Collection map or an empty method
+     *
+     * @param map  Map of String Collection
+     * @param name name of the key
+     * @return Collection of Strings
+     */
+    public static Collection<String> getFromMapOrEmptyList(Map<String, Collection<String>> map, String name) {
+        if (name != null && map.containsKey(name)) {
+            return map.get(name).stream()
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Method to convert MapValue<String, String> to Multimap<String, String>
+     *
+     * @param headersMapValue Ballerina headers MapValue
+     * @return Java Multimap of headers
+     */
+    public static Multimap<String, String> convertToMultimap(MapValue<String, String> headersMapValue) {
+        Multimap<String, String> headersMultimap = ArrayListMultimap.create();
+        for (Map.Entry<String, String> entry : headersMapValue.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            String headerKey = key.equalsIgnoreCase("content-type") ? "Content-Type" : key.toLowerCase(Locale.ROOT);
+            headersMultimap.put(headerKey, value);
+        }
+        return headersMultimap;
+    }
+
+    /**
+     * Method to convert MapValue<String, ArrayValue> to Map<String, Collection<String>>
+     *
+     * @param mapValue Ballerina MapValue
+     * @return Java Map of Strings with Collection of Strings
+     */
+    public static Map<String, Collection<String>> convertMapofArrayValuesToMap(MapValue<String, ArrayValue> mapValue) {
+        return mapValue.entrySet().stream().collect(
+                Collectors.toMap(Map.Entry::getKey, e -> {
+                    ArrayValue arrayValue = e.getValue();
+                    Collection<String> collection = new java.util.ArrayList<>();
+                    for (int i = 0; i < arrayValue.size(); i++) {
+                        collection.add(arrayValue.get(i).toString());
+                    }
+                    return collection;
+                }));
+    }
+}

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -66,11 +66,6 @@
             <version>${org.wso2.securevault.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.com.jayway.jsonpath</groupId>
-            <artifactId>json-path</artifactId>
-            <version>${com.jayway.jsonpath.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${com.google.guava.version}</version>
@@ -227,8 +222,19 @@
                         </goals>
                         <configuration>
                             <outputDirectory>${project.build.directory}/lib/dependencies/validation</outputDirectory>
-                            <includeGroupIds>com.fasterxml.jackson.core,net.minidev,org.wso2.orbit.com.jayway.jsonpath,com.google.guava</includeGroupIds>
-                            <includeArtifactIds>jackson-databind,jackson-core,jackson-annotations,json-smart,json-path,asm,guava</includeArtifactIds>
+                            <includeGroupIds>
+                                com.fasterxml.jackson.core,org.wso2.orbit.io.swagger.v3,
+                                org.wso2.orbit.com.atlassian.oai,com.fasterxml.jackson.datatype,
+                                com.fasterxml.jackson.dataformat,io.swagger,org.wso2.orbit.com.github.java-json-tools,
+                                joda-time,javax.mail,com.googlecode.libphonenumber,com.google.guava,rhino.wso2
+                            </includeGroupIds>
+                            <includeArtifactIds>
+                                jackson-databind,jackson-core,jackson-annotations,swagger-parser,
+                                swagger-request-validator-core,jackson-datatype-jsr310,jackson-dataformat-yaml,
+                                json-schema-core,swagger-core,swagger-models,btf,jackson-coreutils,
+                                json-schema-validator-all,joda-time,javax.mail-api,libphonenumber,guava,
+                                failureaccess,js
+                            </includeArtifactIds>
                         </configuration>
                     </execution>
                 </executions>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -226,13 +226,13 @@
                                 com.fasterxml.jackson.core,org.wso2.orbit.io.swagger.v3,
                                 org.wso2.orbit.com.atlassian.oai,com.fasterxml.jackson.datatype,
                                 com.fasterxml.jackson.dataformat,io.swagger,org.wso2.orbit.com.github.java-json-tools,
-                                joda-time,javax.mail,com.googlecode.libphonenumber,com.google.guava,rhino.wso2
+                                joda-time,com.sun.mail,com.googlecode.libphonenumber,com.google.guava,rhino.wso2
                             </includeGroupIds>
                             <includeArtifactIds>
                                 jackson-databind,jackson-core,jackson-annotations,swagger-parser,
                                 swagger-request-validator-core,jackson-datatype-jsr310,jackson-dataformat-yaml,
                                 json-schema-core,swagger-core,swagger-models,btf,jackson-coreutils,
-                                json-schema-validator-all,joda-time,javax.mail-api,libphonenumber,guava,
+                                json-schema-validator-all,joda-time,javax.mail,libphonenumber,guava,
                                 failureaccess,js
                             </includeArtifactIds>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -450,6 +450,46 @@
                 <artifactId>asm</artifactId>
                 <version>${net.minidev.asm.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.io.swagger.v3</groupId>
+                <artifactId>swagger-parser</artifactId>
+                <version>${swagger.parser.v3.orbit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.com.atlassian.oai</groupId>
+                <artifactId>swagger-request-validator-core</artifactId>
+                <version>${org.wso2.orbit.atlassian.oai.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger</groupId>
+                <artifactId>swagger-core</artifactId>
+                <version>${io.swagger.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.com.github.java-json-tools</groupId>
+                <artifactId>json-schema-validator-all</artifactId>
+                <version>${json.schema.validator.all.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>joda-time</groupId>
+                <artifactId>joda-time</artifactId>
+                <version>${joda.time.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.mail</groupId>
+                <artifactId>javax.mail-api</artifactId>
+                <version>${javax.mail-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.googlecode.libphonenumber</groupId>
+                <artifactId>libphonenumber</artifactId>
+                <version>${libphonenumber.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>rhino.wso2</groupId>
+                <artifactId>js</artifactId>
+                <version>${rhino.js.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <build>
@@ -623,8 +663,8 @@
         <com.google.protobuf.version>3.11.3</com.google.protobuf.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jackson.version>2.15.2</jackson.version>
-        <jackson.databind.version>2.15.2</jackson.databind.version>
+        <jackson.version>2.16.2</jackson.version>
+        <jackson.databind.version>2.16.2</jackson.databind.version>
         <kraal.version>0.0.16</kraal.version>
         <kotlin.stdlib.version>1.3.31</kotlin.stdlib.version>
         <prometheus.jmx.agent.version>0.18.0</prometheus.jmx.agent.version>
@@ -634,13 +674,11 @@
         <org.wso2.securevault.version>1.1.1</org.wso2.securevault.version>
         <apache.commons.version>1.5.6.wso2v1</apache.commons.version>
         <everit.version>1.5.0.wso2.v1</everit.version>
-        <jayway.jsonpath.version>2.4.0</jayway.jsonpath.version>
         <com.google.guava.version>32.1.1-jre</com.google.guava.version>
         <commons-logging.version>1.1.1</commons-logging.version>
-        <org.apache.logging.log4j.version>2.17.0</org.apache.logging.log4j.version>
+        <org.apache.logging.log4j.version>2.17.2</org.apache.logging.log4j.version>
         <commons-io.version>2.14.0</commons-io.version>
         <commons-lang3.version>3.9</commons-lang3.version>
-        <com.jayway.jsonpath.version>2.6.0.wso2v2</com.jayway.jsonpath.version>
         <everit.version>1.5.0.wso2.v1</everit.version>
         <org.wso2.json.version>3.0.0.wso2v4</org.wso2.json.version>
         <carbon.callhome.version>1.0.16</carbon.callhome.version>
@@ -659,6 +697,14 @@
         <io.github.openfeign.version>13.2.1</io.github.openfeign.version>
         <io.projectreactor.reactor-core.version>3.4.31.wso2v1</io.projectreactor.reactor-core.version>
         <org.apache.qpid.proton-j.version>0.33.4</org.apache.qpid.proton-j.version>
+        <swagger.parser.v3.orbit.version>2.1.22.wso2v2</swagger.parser.v3.orbit.version>
+        <org.wso2.orbit.atlassian.oai.version>2.12.1.wso2v2</org.wso2.orbit.atlassian.oai.version>
+        <json.schema.validator.all.version>2.2.7.wso2v2</json.schema.validator.all.version>
+        <joda.time.version>2.13.1</joda.time.version>
+        <javax.mail-api.version>1.6.2</javax.mail-api.version>
+        <libphonenumber.version>7.4.5</libphonenumber.version>
+        <guava.failureaccess.version>1.0.1</guava.failureaccess.version>
+        <rhino.js.version>1.7.0.R4.wso2v1</rhino.js.version>
     </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,7 @@
             <dependency>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-models</artifactId>
-                <version>${swagger.models.version}</version>
+                <version>${io.swagger.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger</groupId>
@@ -476,9 +476,9 @@
                 <version>${joda.time.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.mail</groupId>
-                <artifactId>javax.mail-api</artifactId>
-                <version>${javax.mail-api.version}</version>
+                <groupId>com.sun.mail</groupId>
+                <artifactId>javax.mail</artifactId>
+                <version>${javax.mail.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.googlecode.libphonenumber</groupId>
@@ -626,9 +626,8 @@
         <airline.version>0.7</airline.version>
         <guice.version>4.1.0</guice.version>
         <commons-cli.version>1.3.1</commons-cli.version>
-        <io.swagger.version>1.5.8</io.swagger.version>
+        <io.swagger.version>1.6.11</io.swagger.version>
         <swagger.parser.version>1.0.34</swagger.parser.version>
-        <swagger.models.version>1.5.16</swagger.models.version>
         <swagger.v3.parser.version>2.0.12</swagger.v3.parser.version>
         <swagger.v3.models.version>2.0.8</swagger.v3.models.version>
         <swagger.parser.v2.converter.version>2.0.8</swagger.parser.v2.converter.version>
@@ -701,7 +700,7 @@
         <org.wso2.orbit.atlassian.oai.version>2.12.1.wso2v2</org.wso2.orbit.atlassian.oai.version>
         <json.schema.validator.all.version>2.2.7.wso2v2</json.schema.validator.all.version>
         <joda.time.version>2.13.1</joda.time.version>
-        <javax.mail-api.version>1.6.2</javax.mail-api.version>
+        <javax.mail.version>1.6.2</javax.mail.version>
         <libphonenumber.version>7.4.5</libphonenumber.version>
         <guava.failureaccess.version>1.0.1</guava.failureaccess.version>
         <rhino.js.version>1.7.0.R4.wso2v1</rhino.js.version>

--- a/pom.xml
+++ b/pom.xml
@@ -574,7 +574,7 @@
     </build>
 
     <properties>
-        <ballerina.platform.version>1.2.56</ballerina.platform.version>
+        <ballerina.platform.version>1.2.57</ballerina.platform.version>
         <broker.version>0.970.5</broker.version>
         <assembly.plugin.version>3.1.1</assembly.plugin.version>
         <compiler.plugin.version>3.7.0</compiler.plugin.version>

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/common/ResponseConstants.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/common/ResponseConstants.java
@@ -71,9 +71,10 @@ public class ResponseConstants {
             + ":content-type:Host:Pragma::/petstore/v1/user?test=value1&test2=value2:POST:1.1:"
             + "{test2=value2, test=value1}:value1:<test><msg>hello</msg></test>";
     public static final String VALIDATION_RESPONSE = "{\"fault\":{\"code\":400, \"message\":\"Bad Request\", " +
-            "\"description\":\"#: required key [name] not found, #: required key [photoUrls] not found, \"}}";
+            "\"description\":\"Object has missing required properties ([\\\"name\\\",\\\"photoUrls\\\"])\"}}";
     public static final String  INVALID_RESPONSE = "{\"fault\":{\"code\":500, \"message\":\"Bad Response\", " +
-            "\"description\":\"#/status: hello is not a valid enum value, \"}}";
+            "\"description\":\"[Path '\\/status'] Instance value (\\\"hello\\\") not found in enum " +
+            "(possible values: [\\\"available\\\",\\\"pending\\\",\\\"sold\\\"])\"}}";
 
     public static final String INTERCEPT_JSON_RESPONSE = "\"{\"city\":\"chicago\",\"name\":\"jon doe\",\"age\":\"22\"}\"";
     public static final String ERROR_RESPONSE = "error:true";


### PR DESCRIPTION
### Purpose
This PR revamps the schema validation logic to align with APIM 4.x versions.

Additionally, it includes the changes from PR [1]. Therefore, if a user is using a custom date/time format in the API definition, they must add -Dregister.timeModule=true to register the JavaTimeModule for schema validation to function properly.

Fixes https://github.com/wso2/api-manager/issues/3763

[1] https://github.com/wso2/carbon-apimgt/pull/12432

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [ ] Assigned the project
- [x] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
