### PR TITLE
Fix NPE when issuer claim is not available in JWT

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/keymgt/KeyManagerHolder.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/keymgt/KeyManagerHolder.java
@@ -218,6 +218,10 @@ public class KeyManagerHolder {
     }
 
     public ExtendedTokenIssuerDto getTokenIssuerDTO(String organizationUUID, String issuer) {
+        // If the iss claim is not available, this could happen.
+        if (StringUtils.isEmpty(issuer)) {
+            return null;
+        }
         Map<String, Map<String, ExtendedTokenIssuerDto>> tokenIssuerMap = getTokenIssuerMap();
         if (tokenIssuerMap.containsKey(organizationUUID)) {
             Map<String, ExtendedTokenIssuerDto> orgSpecificKMIssuerMap = tokenIssuerMap.get(organizationUUID);

--- a/enforcer-parent/enforcer/src/test/java/org/wso2/choreo/connect/enforcer/keymgt/KeyManagerHolderTest.java
+++ b/enforcer-parent/enforcer/src/test/java/org/wso2/choreo/connect/enforcer/keymgt/KeyManagerHolderTest.java
@@ -136,6 +136,8 @@ public class KeyManagerHolderTest {
         Assert.assertTrue(residentKeyManager.isValidateSubscriptions());
         Assert.assertFalse(residentKeyManager.getJwksConfigurationDTO().isEnabled());
 
+        Assert.assertNull(KeyManagerHolder.getInstance().getTokenIssuerDTO("carbon.super",
+                null));
         Assert.assertEquals(residentKeyManager, KeyManagerHolder.getInstance().getTokenIssuerDTO("carbon.super",
                 "https://localhost:9443/oauth2/token"));
         Assert.assertEquals(publisherIssuer, KeyManagerHolder.getInstance().getTokenIssuerDTO("carbon.super",


### PR DESCRIPTION
## Purpose
Issuer claim can be null, but in choreo context we do not support because the issuer is critical. 

## Approach
This is a bug fix. If token issuer is not present, return 401 error. 

## Documentation
N/A

## Automation tests
 - Unit tests  : added
 - Integration tests: Not required

## Security checks
 - Followed secure coding standards in https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/? yes
 - Ran golangci-lint plugin and verified report? N/A
 - Ran maven-checkstyle-plugin and verified report? Yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes

## Related PRs
> List any other related PRs