### PR TITLE
When applying the APIs to gateway, selectively deploy only the assigned deployments for that partition

### DIFF
--- a/adapter/internal/adapter/adapter.go
+++ b/adapter/internal/adapter/adapter.go
@@ -352,7 +352,7 @@ func fetchAPIsOnStartUp(conf *config.Config, apiUUIDList []string, apiMap map[st
 			isNotFinalChunk := i != len(chunkedAPIUuidsList)-1
 			options := common.XdsOptions{SkipUpdatingXdsCache: isNotFinalChunk}
 			if os.Getenv("FEATURE_ENV_BASED_FILTERING_IN_STARTUP") == "true" {
-				options.ApiIDEnvMap = apiMap
+				options.APIIDEnvMap = apiMap
 			}
 			fetchChunkedAPIsOnStartUp(conf, chunkedAPIUuids, options)
 		}

--- a/adapter/internal/adapter/adapter.go
+++ b/adapter/internal/adapter/adapter.go
@@ -47,6 +47,7 @@ import (
 	sync "github.com/wso2/product-microgateway/adapter/pkg/synchronizer"
 	"github.com/wso2/product-microgateway/adapter/pkg/tlsutils"
 	"github.com/wso2/product-microgateway/adapter/pkg/utils"
+	ga_model "github.com/wso2/product-microgateway/adapter/pkg/discovery/api/wso2/discovery/ga"
 
 	"context"
 	"flag"
@@ -285,7 +286,7 @@ func Run(conf *config.Config) {
 			// Load subscription data when GA is disabled.
 			eventhub.LoadSubscriptionData(conf, nil)
 			// Fetch APIs at start up when GA is disabled.
-			fetchAPIsOnStartUp(conf, nil)
+			fetchAPIsOnStartUp(conf, nil, nil)
 		}
 
 		var connectionURLList = conf.ControlPlane.BrokerConnectionParameters.EventListeningEndpoints
@@ -338,7 +339,7 @@ OUTER:
 
 // fetchAPIsOnStartUp fetches APIs from control plane chunk by chunk during the server start up and push them
 // to the router and enforcer components.
-func fetchAPIsOnStartUp(conf *config.Config, apiUUIDList []string) {
+func fetchAPIsOnStartUp(conf *config.Config, apiUUIDList []string, apiMap map[string]map[string]*ga_model.Api) {
 	if apiUUIDList == nil {
 		logger.LoggerMgw.Info("Fetching APIs at startup...")
 		fetchChunkedAPIsOnStartUp(conf, nil, common.XdsOptions{})
@@ -349,7 +350,11 @@ func fetchAPIsOnStartUp(conf *config.Config, apiUUIDList []string) {
 		for i, chunkedAPIUuids := range chunkedAPIUuidsList {
 			logger.LoggerMgw.Infof("Fetching chunked APIs... [%d/%d]", i+1, len(chunkedAPIUuidsList))
 			isNotFinalChunk := i != len(chunkedAPIUuidsList)-1
-			fetchChunkedAPIsOnStartUp(conf, chunkedAPIUuids, common.XdsOptions{SkipUpdatingXdsCache: isNotFinalChunk})
+			options := common.XdsOptions{SkipUpdatingXdsCache: isNotFinalChunk}
+			if os.Getenv("FEATURE_ENV_BASED_FILTERING_IN_STARTUP") == "true" {
+				options.ApiIDEnvMap = apiMap
+			}
+			fetchChunkedAPIsOnStartUp(conf, chunkedAPIUuids, options)
 		}
 	}
 
@@ -413,7 +418,7 @@ func fetchChunkedAPIsOnStartUp(conf *config.Config, apiUUIDList []string, xdsOpt
 // FetchAPIUUIDsFromGlobalAdapter get the UUIDs of the APIs at the LA startup from GA
 func FetchAPIUUIDsFromGlobalAdapter() {
 	logger.LoggerMgw.Info("Fetching APIs at Local Adapter startup...")
-	apiEventsAtStartup := ga.FetchAPIsFromGA()
+	apiEventsAtStartup, apiEnvDeploymentMapAtStartup := ga.FetchAPIsFromGA()
 	b, _ := json.Marshal(apiEventsAtStartup)
 	logger.LoggerMgw.Debugf("apiEventsAtStartup : %s", string(b))
 	conf, _ := config.ReadConfigs()
@@ -435,7 +440,7 @@ func FetchAPIUUIDsFromGlobalAdapter() {
 		health.SetControlPlaneRestAPIStatus(true)
 		xds.DeployReadinessAPI(envs)
 	} else {
-		fetchAPIsOnStartUp(conf, apiUUIDList)
+		fetchAPIsOnStartUp(conf, apiUUIDList, apiEnvDeploymentMapAtStartup)
 	}
 	ga.StartConsumeGAAPIChannel()
 }

--- a/adapter/internal/common/types.go
+++ b/adapter/internal/common/types.go
@@ -22,5 +22,5 @@ import ga_model "github.com/wso2/product-microgateway/adapter/pkg/discovery/api/
 // XdsOptions represents the options for xDS.
 type XdsOptions struct {
 	SkipUpdatingXdsCache bool
-	ApiIDEnvMap          map[string]map[string]*ga_model.Api
+	APIIDEnvMap          map[string]map[string]*ga_model.Api
 }

--- a/adapter/internal/common/types.go
+++ b/adapter/internal/common/types.go
@@ -17,7 +17,10 @@
 
 package common
 
+import ga_model "github.com/wso2/product-microgateway/adapter/pkg/discovery/api/wso2/discovery/ga"
+
 // XdsOptions represents the options for xDS.
 type XdsOptions struct {
 	SkipUpdatingXdsCache bool
+	ApiIDEnvMap          map[string]map[string]*ga_model.Api
 }

--- a/adapter/internal/ga/client.go
+++ b/adapter/internal/ga/client.go
@@ -62,7 +62,7 @@ var (
 	isFirstResponse bool
 	// gaAPIChannelStart is used to block the GAAPIChannel consuming until the startup is completed.
 	gaAPIChannelStart chan bool
-	// gaAPIChannelInitialMap is used to send the Initial API UUID Map to fetch APIs from controlplane as a bulk.
+	// GAAPIChannelInitialMap is used to send the Initial API UUID Map to fetch APIs from controlplane as a bulk.
 	GAAPIChannelInitialMap chan map[string]map[string]*ga_model.Api
 	// Last Received Response from the global adapter
 	// Last Recieved Response is always is equal to the lastAckedResponse according to current implementation as there is no

--- a/adapter/internal/synchronizer/apis_fetcher.go
+++ b/adapter/internal/synchronizer/apis_fetcher.go
@@ -95,7 +95,7 @@ func PushAPIProjects(payload []byte, environments []string, xdsOptions common.Xd
 			logger.LoggerSync.Errorf("API file not found: %v", err)
 			return err
 		}
-		gaProvidedAPIEnvMap := xdsOptions.ApiIDEnvMap
+		gaProvidedAPIEnvMap := xdsOptions.APIIDEnvMap
 		vhostToEnvsMap := make(map[string][]*synchronizer.GatewayLabel)
 		for index := range deployment.Environments {
 			env := deployment.Environments[index]

--- a/adapter/internal/synchronizer/apis_fetcher.go
+++ b/adapter/internal/synchronizer/apis_fetcher.go
@@ -103,6 +103,8 @@ func PushAPIProjects(payload []byte, environments []string, xdsOptions common.Xd
 				if gaProvidedAPIEnvMap != nil {
 					apiID := strings.Split(file.Name, "-")[0]
 					if gaProvidedAPIEnvMap[apiID] == nil || gaProvidedAPIEnvMap[apiID][env.Name] == nil {
+						logger.LoggerSync.Infof("Skip environment %s for API %s as it is not applicable for the API in the GA provided API map",
+							env.Name, apiID)
 						continue
 					}
 				}
@@ -112,7 +114,6 @@ func PushAPIProjects(payload []byte, environments []string, xdsOptions common.Xd
 
 		// If VhostToEnvsMap is empty, then there is nothing to deploy.
 		if len(vhostToEnvsMap) == 0 {
-			logger.LoggerSync.Infof("Drop api from file (API_ID:REVISION_ID).zip : %v due to not applicable environments", file.Name)
 			continue
 		}
 


### PR DESCRIPTION


For example:
Before fix: API 1 Dev deployment is in partition 1 and Prod Deployment is assigned to partition 2. During startup, development and production both are deployed in gateway partition 1. After fix: only api1 Dev deployment is deployed in partition 1

### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
