### PR TITLE
Update SSHKeyFile config in git integration

### DIFF
--- a/integration/test-integration/src/test/resources/configs/cc-with-source-control.toml
+++ b/integration/test-integration/src/test/resources/configs/cc-with-source-control.toml
@@ -26,7 +26,7 @@ artifactsDirectory = "/home/wso2/git-artifacts"
     branch = ""
     username = "username"
     accessToken = "556018e1140708b97d5f3d189055a37e89b9ba82"
-    sshKeyFile = ""
+    SSHKeyFile = ""
 
 [router]
   listenerPort = 9090

--- a/resources/conf/config.toml.template
+++ b/resources/conf/config.toml.template
@@ -89,7 +89,7 @@ soapErrorInXMLEnabled = false
     # Git personal access token or password
     accessToken = $env{git_access_token}
     # Path to the private key used for authentication (Use "" in the case of a public repository (only for GitHub))
-    sshKeyFile = "/home/wso2/ssh-keys/id_ed25519"
+    SSHKeyFile = "/home/wso2/ssh-keys/id_ed25519"
 
 # Configuration to expose adapter metrics
 [adapter.metrics]


### PR DESCRIPTION
## Purpose
> Authenticating the Github repository with SSH key fails when integrating Choreo Connect with Git for version controlling of API artifacts.
Related Issue - https://github.com/wso2-enterprise/wso2-apim-internal/issues/9602

## Goals
> Enable Git for version controlling of API artifacts using SSH by correctly parsing the configuration for the SSH key file.

## Approach
> Change the name of the configuration from sshKeyFile to SSHKeyFile matching the configuration key name to the struct defined in the adapter.