### PR TITLE
Make Netty content length configurable

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/mcp/request/McpRequestHandler.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/mcp/request/McpRequestHandler.java
@@ -23,6 +23,7 @@ import io.grpc.netty.shaded.io.netty.channel.ChannelFuture;
 import io.grpc.netty.shaded.io.netty.channel.ChannelFutureListener;
 import io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext;
 import io.grpc.netty.shaded.io.netty.channel.ChannelInboundHandlerAdapter;
+import io.grpc.netty.shaded.io.netty.handler.codec.TooLongFrameException;
 import io.grpc.netty.shaded.io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.grpc.netty.shaded.io.netty.handler.codec.http.FullHttpRequest;
 import io.grpc.netty.shaded.io.netty.handler.codec.http.FullHttpResponse;
@@ -33,6 +34,7 @@ import io.grpc.netty.shaded.io.netty.handler.codec.http.HttpHeaders;
 import io.grpc.netty.shaded.io.netty.handler.codec.http.HttpMethod;
 import io.grpc.netty.shaded.io.netty.handler.codec.http.HttpRequest;
 import io.grpc.netty.shaded.io.netty.handler.codec.http.HttpResponseStatus;
+import io.grpc.netty.shaded.io.netty.handler.codec.http.HttpVersion;
 import io.grpc.netty.shaded.io.netty.util.ReferenceCountUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -55,6 +57,18 @@ public class McpRequestHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void channelReadComplete(ChannelHandlerContext ctx) {
         ctx.flush();
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        if (cause instanceof TooLongFrameException) {
+            FullHttpResponse response = new DefaultFullHttpResponse(
+                    HttpVersion.HTTP_1_1,
+                    HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE);
+            ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+        } else {
+            super.exceptionCaught(ctx, cause);
+        }
     }
 
     @Override

--- a/mcp/pkg/mcp/request.go
+++ b/mcp/pkg/mcp/request.go
@@ -53,8 +53,7 @@ func CallUnderlyingAPI(ctx context.Context, payload *MCPRequest) (string, int, e
 	if strings.Contains(resp.Header.Get(ContentType), ContentTypeJSON) {
 		response, err = processJsonResponse(response)
 		if err != nil {
-			logger.ErrorContext(ctx, "Failed to process JSON response", "error", err)
-			return "", http.StatusInternalServerError, err
+			logger.WarnContext(ctx, "Failed to process JSON response", "error", err)
 		}
 	}
 	return response, resp.StatusCode, nil

--- a/mcp/pkg/mcp/utils.go
+++ b/mcp/pkg/mcp/utils.go
@@ -23,7 +23,7 @@ import (
 )
 
 func processJsonResponse(inputString string) (string, error) {
-	var data map[string]any
+	var data any
 
 	err := json.Unmarshal([]byte(inputString), &data)
 	if err != nil {


### PR DESCRIPTION
### Purpose

This PR makes the content length configurable for the Netty REST server

### Issues

Related issue: https://github.com/wso2-enterprise/apim-saas/issues/594

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
