### PR TITLE
Add log PR comment analyzer

### DIFF
--- a/.github/workflows/log-pr-comment-analyzer.yml
+++ b/.github/workflows/log-pr-comment-analyzer.yml
@@ -1,0 +1,49 @@
+name: Notify Merged PR to AI Log Agent
+
+on:
+  push:
+    branches:
+      - cc-main
+
+jobs:
+  find-pr-details:
+    runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.pr.outputs.url }}
+    steps:
+      - name: Get merged PR info
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commitSha = context.sha;
+
+            const prs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 10
+            });
+
+            const mergedPr = prs.data.find(pr =>
+              pr.merge_commit_sha === commitSha
+            );
+
+            if (!mergedPr) {
+              core.setFailed("No merged PR found for this commit.");
+              return;
+            }
+
+            core.info(`Found merged PR: ${mergedPr.html_url} (#${mergedPr.number})`);
+            core.setOutput("url", mergedPr.html_url);
+  invoke-ai-log-agent:
+    name: Invoke AI Log Agent
+    needs: find-pr-details
+    uses: wso2/wso2-organization-templates/.github/workflows/log-pr-comment-analyzer.yml@main
+    with:
+      prUrl: ${{ needs.find-pr-details.outputs.url }}
+    secrets:
+      clientId: ${{ secrets.AI_LOG_AGENT_CLIENT_ID }}
+      clientSecret: ${{ secrets.AI_LOG_AGENT_CLIENT_SECRET }}

--- a/.github/workflows/pr-reviewer-for-logs.yml
+++ b/.github/workflows/pr-reviewer-for-logs.yml
@@ -8,8 +8,6 @@ jobs:
   call-template:
     uses: wso2/wso2-organization-templates/.github/workflows/pr-reviewer.yml@main
     with:
-      reviewEndpoint: ${{ vars.AI_LOG_AGENT_REVIEW_ENDPOINT }}
-      tokenUrl: ${{ vars.AI_LOG_AGENT_TOKEN_URL }}
       prUrl: ${{ github.event.pull_request.html_url }}
     secrets:
       clientId: ${{ secrets.AI_LOG_AGENT_CLIENT_ID }}


### PR DESCRIPTION
This will introduce new git action on PR merge to analyze the status of the added comments by AI Log Agent
============================

This pull request introduces a new GitHub Actions workflow to notify an AI Log Agent about merged pull requests and updates an existing workflow to simplify its configuration. Below are the key changes:

### New Workflow Addition:
* Added a new GitHub Actions workflow `.github/workflows/log-pr-comment-analyzer.yml` to notify the AI Log Agent when a pull request is merged into the `cc-main` branch. This workflow retrieves merged pull request details and invokes the AI Log Agent with the pull request URL.

### Workflow Configuration Simplification:
* Updated `.github/workflows/pr-reviewer-for-logs.yml` to remove unnecessary inputs (`reviewEndpoint` and `tokenUrl`) for the `call-template` job, simplifying the workflow configuration.