### PR TITLE
Add Access-Control-Expose-Headers header to MCP response

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/mcp/McpConstants.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/mcp/McpConstants.java
@@ -90,6 +90,7 @@ public class McpConstants {
     public static final String ASGARDEO_WK_PLACEHOLDER
             = "https://api.asgardeo.io/t/{organization}/oauth2/token/.well-known/openid-configuration";
     public static final String MCP_PROTOCOL_VERSION_HEADER = "MCP-Protocol-Version";
+    public static final String ACCESS_CONTROL_EXPOSE_HEADERS = "Access-Control-Expose-Headers";
 
     /**
      * This class contains constants used for RPC processing

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/mcp/request/McpRequestHandler.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/mcp/request/McpRequestHandler.java
@@ -186,9 +186,11 @@ public class McpRequestHandler extends ChannelInboundHandlerAdapter {
                         .set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON)
                         .setInt(HttpHeaderNames.CONTENT_LENGTH, res.content().readableBytes());
                 if (sessionId != null && !sessionId.isEmpty()) {
+                    res.headers().set(McpConstants.ACCESS_CONTROL_EXPOSE_HEADERS, McpConstants.MCP_SESSION_ID_HEADER);
                     res.headers().set(McpConstants.MCP_SESSION_ID_HEADER, sessionId);
                 }
                 if (mcpResponse.getSessionId() != null && !mcpResponse.getSessionId().isEmpty()) {
+                    res.headers().set(McpConstants.ACCESS_CONTROL_EXPOSE_HEADERS, McpConstants.MCP_SESSION_ID_HEADER);
                     res.headers().set(McpConstants.MCP_SESSION_ID_HEADER, mcpResponse.getSessionId());
                 }
             } else {
@@ -207,6 +209,7 @@ public class McpRequestHandler extends ChannelInboundHandlerAdapter {
                     .set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON)
                     .setInt(HttpHeaderNames.CONTENT_LENGTH, res.content().readableBytes());
             if (sessionId != null && !sessionId.isEmpty()) {
+                res.headers().set(McpConstants.ACCESS_CONTROL_EXPOSE_HEADERS, McpConstants.MCP_SESSION_ID_HEADER);
                 res.headers().set(McpConstants.MCP_SESSION_ID_HEADER, sessionId);
             }
         }


### PR DESCRIPTION
### Purpose
This PR adds the `Access-Control-Expose-Headers` header to the MCP response when the `mcp-session-id` header is available in the response. This is done in order to fix the MCP inspector in the Bijira console not working properly when the MCP server honors the session ID.

### Issues

Related issue: https://github.com/wso2-enterprise/apim-saas/issues/802

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
