### PR TITLE
Fix issues with MCP version negotiation

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/mcp/McpConstants.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/mcp/McpConstants.java
@@ -40,11 +40,13 @@ public class McpConstants {
     public static final String PROTOCOL_VERSION_KEY = "protocolVersion";
     public static final String PROTOCOL_VERSION_2024_NOVEMBER = "2024-11-05";
     public static final String PROTOCOL_VERSION_2025_MARCH = "2025-03-26";
+    public static final String DEFAULT_NEGOTIATED_PROTOCOL_VERSION = PROTOCOL_VERSION_2025_MARCH;
     public static final List<String> SUPPORTED_PROTOCOL_VERSIONS = Arrays.asList(PROTOCOL_VERSION_2025_MARCH);
     public static final String PROTOCOL_VERSION_REQUESTED = "requested";
     public static final String PROTOCOL_VERSION_SUPPORTED = "supported";
     public static final String PROTOCOL_MISMATCH_ERROR = "Unsupported protocol version";
     public static final String MCP_SESSION_ID_HEADER = "mcp-session-id";
+    public static final String MCP_PROTOCOL_VERSION_HEADER = "mcp-protocol-version";
     public static final String PARAMS_KEY = "params";
     public static final String TOOL_NAME_KEY = "name";
     public static final String TOOL_DESC_KEY = "description";
@@ -89,7 +91,6 @@ public class McpConstants {
     public static final String PAYLOAD_BACKEND = "backend";
     public static final String ASGARDEO_WK_PLACEHOLDER
             = "https://api.asgardeo.io/t/{organization}/oauth2/token/.well-known/openid-configuration";
-    public static final String MCP_PROTOCOL_VERSION_HEADER = "MCP-Protocol-Version";
     public static final String ACCESS_CONTROL_EXPOSE_HEADERS = "Access-Control-Expose-Headers";
 
     /**

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/mcp/McpException.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/mcp/McpException.java
@@ -27,12 +27,22 @@ public class McpException extends Exception {
     private final int errorCode;
     private final String errorMessage;
     private final Object data;
+    private final int statusCode;
 
     public McpException(int errorCode, String errorMessage, Object data) {
         super(errorMessage);
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
         this.data = data;
+        this.statusCode = 200;
+    }
+
+    public McpException(int errorCode, String errorMessage, Object data, int statusCode) {
+        super(errorMessage);
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.data = data;
+        this.statusCode = statusCode;
     }
 
     public int getErrorCode() {
@@ -45,6 +55,10 @@ public class McpException extends Exception {
 
     public Object getData() {
         return data;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
     }
 
     public String toJsonRpcErrorPayload() {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/mcp/McpExceptionWithId.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/mcp/McpExceptionWithId.java
@@ -24,10 +24,16 @@ import org.wso2.choreo.connect.enforcer.mcp.response.PayloadGenerator;
  * This class is used to throw MCP related errors with an ID.
  */
 public class McpExceptionWithId extends McpException {
-    private Object id;
+    private final Object id;
+
 
     public McpExceptionWithId(Object id, int errorCode, String errorMessage, Object data) {
         super(errorCode, errorMessage, data);
+        this.id = id;
+    }
+
+    public McpExceptionWithId(Object id, int errorCode, String errorMessage, Object data, int statusCode) {
+        super(errorCode, errorMessage, data, statusCode);
         this.id = id;
     }
 

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/mcp/request/McpRequestHandler.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/mcp/request/McpRequestHandler.java
@@ -174,10 +174,22 @@ public class McpRequestHandler extends ChannelInboundHandlerAdapter {
             }
         }
 
+        String protocolVersion = null;
+        if (headers.contains(McpConstants.MCP_PROTOCOL_VERSION_HEADER)) {
+            protocolVersion = headers.get(McpConstants.MCP_PROTOCOL_VERSION_HEADER);
+        }
+        if (protocolVersion == null || protocolVersion.isEmpty()) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("mcp-protocol-version header is empty for API: {}", apiName);
+            }
+            protocolVersion = McpConstants.DEFAULT_NEGOTIATED_PROTOCOL_VERSION;
+        }
+
         HttpContent requestContent = (HttpContent) msg;
         if (requestContent.content().isReadable()) {
             String body = requestContent.content().toString(StandardCharsets.UTF_8);
-            McpResponseDto mcpResponse = McpRequestProcessor.processRequest(matchedAPI, body, additionalHeaders);
+            McpResponseDto mcpResponse = McpRequestProcessor.processRequest(matchedAPI, body,
+                    additionalHeaders, protocolVersion);
             if (mcpResponse != null) {
                 res = new DefaultFullHttpResponse(req.protocolVersion(),
                         HttpResponseStatus.valueOf(mcpResponse.getStatusCode()),

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/mcp/response/McpResponseDto.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/mcp/response/McpResponseDto.java
@@ -25,6 +25,7 @@ public class McpResponseDto {
     private String response;
     private int statusCode;
     private String sessionId;
+    private String protocolVersion;
 
     public McpResponseDto(String response, int statusCode, String sessionId) {
         this.response = response;
@@ -54,5 +55,13 @@ public class McpResponseDto {
 
     public void setSessionId(String sessionId) {
         this.sessionId = sessionId;
+    }
+
+    public String getProtocolVersion() {
+        return protocolVersion;
+    }
+
+    public void setProtocolVersion(String protocolVersion) {
+        this.protocolVersion = protocolVersion;
     }
 }

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/mcp/response/PayloadGenerator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/mcp/response/PayloadGenerator.java
@@ -48,13 +48,14 @@ public class PayloadGenerator {
     }
 
     public static String getInitializeResponse(Object id, String serverName, String serverVersion,
-                                               String serverDescription, boolean toolListChangeNotified) {
+                                               String serverDescription, boolean toolListChangeNotified,
+                                               String protocolVersion) {
         // Create the response object as specified in
         // https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle#initialization
         McpResponse response = new McpResponse(id);
         JsonObject responseObject = gson.fromJson(gson.toJson(response), JsonObject.class);
         JsonObject result = new JsonObject();
-        result.addProperty(McpConstants.PROTOCOL_VERSION_KEY, McpConstants.PROTOCOL_VERSION_2025_MARCH);
+        result.addProperty(McpConstants.PROTOCOL_VERSION_KEY, protocolVersion);
 
         JsonObject capabilities = new JsonObject();
         JsonObject toolCapabilities = new JsonObject();


### PR DESCRIPTION
### Purpose

This PR fixes an issue where MCP Servers in Bijira does not work with clients built on top of the latest spec.

The issue is fixed by handling the version negotiation in a backward compatible manner.

### Issues

Fixes https://github.com/wso2-enterprise/apim-saas/issues/998

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
