### PR TITLE
[3.2.x] Return 401 for malformed basic auth header

### DIFF
--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/api_security_constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/api_security_constants.bal
@@ -99,6 +99,8 @@ public const string INVALID_ENTITY_MESSAGE = "Unprocessable entity";
 public const int INVALID_RESPONSE = 900916;
 public const string INVALID_RESPONSE_MESSAGE = "Unprocessable entity";
 
+public const int API_AUTH_MALFORMED_TOKEN = 900918;
+
 public function getAuthenticationFailureMessage(int errorCode) returns string {
     string errorMessage;
     if (errorCode == API_AUTH_ACCESS_TOKEN_EXPIRED) {
@@ -107,7 +109,7 @@ public function getAuthenticationFailureMessage(int errorCode) returns string {
         errorMessage = API_AUTH_ACCESS_TOKEN_INACTIVE_MESSAGE;
     } else if (errorCode == API_AUTH_GENERAL_ERROR) {
         errorMessage = API_AUTH_GENERAL_ERROR_MESSAGE;
-    } else if (errorCode == API_AUTH_INVALID_CREDENTIALS) {
+    } else if (errorCode == API_AUTH_INVALID_CREDENTIALS || errorCode == API_AUTH_MALFORMED_TOKEN) {
         errorMessage = API_AUTH_INVALID_CREDENTIALS_MESSAGE;
     } else if (errorCode == API_AUTH_MISSING_CREDENTIALS) {
         errorMessage = API_AUTH_MISSING_CREDENTIALS_MESSAGE;
@@ -154,7 +156,7 @@ public function getFailureMessageDetailDescription(int errorCode, string errorMe
         errorDescription += DESCRIPTION_SEPARATOR + API_AUTH_MISSING_CREDENTIALS_DESCRIPTION ;
     } else if (API_AUTH_ACCESS_TOKEN_EXPIRED == errorCode) {
         errorDescription += DESCRIPTION_SEPARATOR + API_AUTH_ACCESS_TOKEN_EXPIRED_DESCRIPTION;
-    } else if (API_AUTH_INVALID_CREDENTIALS == errorCode) {
+    } else if (API_AUTH_INVALID_CREDENTIALS == errorCode || API_AUTH_MALFORMED_TOKEN == errorCode) {
         errorDescription += DESCRIPTION_SEPARATOR + API_AUTH_INVALID_CREDENTIALS_DESCRIPTION;
     } else if (API_AUTH_INVALID_BASICAUTH_CREDENTIALS == errorCode) {
         errorDescription += DESCRIPTION_SEPARATOR + API_AUTH_INVALID_BASICAUTH_CREDENTIALS_DESCRIPTION;

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/constants/constants.bal
@@ -54,6 +54,7 @@ public const string UTF_8 = "UTF-8";
 public const string INVALID_COOKIE = "Cookie is Invalid";
 public const string WWW_AUTHENTICATE = "WWW-Authenticate";
 public const string WWW_AUTHENTICATE_ERROR = ", error=\"invalid token\" , error_description=\"The access token expired\"";
+public const string WWW_INVALID_TOKEN_ERROR = ", error=\"invalid token\" , error_description=\"The access token is invalid\"";
 
 public const string X_FORWARD_FOR_HEADER = "X-FORWARDED-FOR";
 public const string KEY_VALIDATION_RESPONSE = "KEY_VALIDATION_RESPONSE";
@@ -353,6 +354,9 @@ public const string JWKS_URL = "jwksURL";
 public const string TRUST_STORE_PATH = "trustStorePath";
 public const string TRUST_STORE_PASSWORD = "trustStorePassword";
 public const string REMOTE_USER_CLAIM_RETRIEVAL_ENABLED = "remoteUserClaimRetrievalEnabled";
+
+public const string BASIC_AUTH_CONFIG = "basicAuthConfig";
+public const string ENABLE_BASIC_AUTH_STRICT_VALIDATION = "enableBasicAuthStrictValidation";
 
 public const string API_KEY_INSTANCE_ID = "apikey.tokenConfigs";
 public const string API_KEY_ISSUER_ENABLED = "enabled";

--- a/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/utils.bal
+++ b/components/micro-gateway-core/src/main/ballerina/src/gateway/utils/utils.bal
@@ -366,7 +366,11 @@ public function sendErrorResponseFromInvocationContext(http:FilterContext contex
     //set WWW_AUTHENTICATE header to error response
     if (response.statusCode == UNAUTHORIZED) {
         string challengeString = getChallengeString(context);
-        response.setHeader(WWW_AUTHENTICATE, challengeString + WWW_AUTHENTICATE_ERROR);
+        if (errorCode == API_AUTH_MALFORMED_TOKEN){
+            response.setHeader(WWW_AUTHENTICATE, challengeString + WWW_INVALID_TOKEN_ERROR);
+        } else {
+            response.setHeader(WWW_AUTHENTICATE, challengeString + WWW_AUTHENTICATE_ERROR);
+        }
     }
     if (! context.attributes.hasKey(IS_GRPC)) {
         json payload = {

--- a/distribution/resources/conf/default-micro-gw.conf.template
+++ b/distribution/resources/conf/default-micro-gw.conf.template
@@ -549,3 +549,8 @@ password = "admin"
 [security]
   # Enable/ Disable subscription validation for opaque (reference) tokens.
   validateSubscriptions = false
+
+# API level basic auth security configuration
+[basicAuthConfig]
+# For malformed basic auth headers, enabling enableBasicAuthStrictValidation will return 401 instead of the default 500
+enableBasicAuthStrictValidation = false

--- a/tests/src/test/java/org/wso2/micro/gateway/tests/security/APIInvokeWithOAuth2andBasicAuthTestCase.java
+++ b/tests/src/test/java/org/wso2/micro/gateway/tests/security/APIInvokeWithOAuth2andBasicAuthTestCase.java
@@ -85,6 +85,7 @@ public class APIInvokeWithOAuth2andBasicAuthTestCase extends APIInvokeWithBasicA
         //Invalid Credentials
         String invalidInput = "generalUser1:invalidpassword";
         String basicAuthTokenInvalid = Base64.getEncoder().encodeToString(invalidInput.getBytes());
+        String malformedInput = basicAuthTokenInvalid + "1";
 
         //test endpoint
         invokeBasic(basicAuthToken, MockHttpServer.PROD_ENDPOINT_RESPONSE, 200);
@@ -96,6 +97,7 @@ public class APIInvokeWithOAuth2andBasicAuthTestCase extends APIInvokeWithBasicA
         }
         //test invoking with invalid credentials
         invokeBasic(basicAuthTokenInvalid, 401);
+        invokeBasic(malformedInput, 500);
     }
 
     private void invokeBasic(String token, String responseData, int responseCode) throws Exception {
@@ -114,7 +116,7 @@ public class APIInvokeWithOAuth2andBasicAuthTestCase extends APIInvokeWithBasicA
         //test endpoint with token
         headers.put(HttpHeaderNames.AUTHORIZATION.toString(), "Basic " + token);
         org.wso2.micro.gateway.tests.util.HttpResponse response = HttpClientRequest
-                .doGet(getServiceURLHttp("/pizzashack/1.0.0/menu"), headers);
+                .doGet(getServiceURLHttp("/pizzashack/1.0.0/basic-menu"), headers);
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), responseCode, "Response code mismatched");
     }


### PR DESCRIPTION
### Purpose
Introduces a config that returns 401 instead of 500 for malformed basic auth headers.
