### PR TITLE
Skip Scope Validation for API Keys

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/Authenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/Authenticator.java
@@ -43,6 +43,8 @@ public interface Authenticator {
     /**
      * Name of the authenticator.
      * This is used in authentication context of interceptors.
+     * This name should be unique across all authenticators.
+     * 
      * @return Authenticator name
      */
     String getName();

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyAuthenticator.java
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
  */
 public class APIKeyAuthenticator extends JWTAuthenticator {
 
-    public static final String AUTHENTICATOR_NAME = "Choreo API Key";
+    public static final String API_KEY_AUTHENTICATOR_NAME = "Choreo API Key";
 
     private static final Logger log = LogManager.getLogger(APIKeyAuthenticator.class);
 
@@ -173,7 +173,7 @@ public class APIKeyAuthenticator extends JWTAuthenticator {
 
     @Override
     public String getName() {
-        return AUTHENTICATOR_NAME;
+        return API_KEY_AUTHENTICATOR_NAME;
     }
 
     @Override

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyAuthenticator.java
@@ -47,6 +47,8 @@ import java.util.stream.Collectors;
  */
 public class APIKeyAuthenticator extends JWTAuthenticator {
 
+    public static final String AUTHENTICATOR_NAME = "Choreo API Key";
+
     private static final Logger log = LogManager.getLogger(APIKeyAuthenticator.class);
 
     public APIKeyAuthenticator() {
@@ -171,7 +173,7 @@ public class APIKeyAuthenticator extends JWTAuthenticator {
 
     @Override
     public String getName() {
-        return "Choreo API Key";
+        return AUTHENTICATOR_NAME;
     }
 
     @Override

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyHandler.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/APIKeyHandler.java
@@ -46,6 +46,8 @@ import java.util.List;
  */
 public abstract class APIKeyHandler implements Authenticator {
 
+    public static final String API_KEY_HANDLER_AUTHENTICATOR_NAME = "API Key Handler";
+
     private static final Logger log = LogManager.getLogger(APIKeyHandler.class);
 
     /**
@@ -259,5 +261,10 @@ public abstract class APIKeyHandler implements Authenticator {
             }
         }
         return api;
+    }
+
+    @Override
+    public String getName() {
+        return API_KEY_HANDLER_AUTHENTICATOR_NAME;
     }
 }

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/InternalAPIKeyAuthenticator.java
@@ -60,6 +60,8 @@ import java.util.stream.Collectors;
  */
 public class InternalAPIKeyAuthenticator extends APIKeyHandler {
 
+    public static final String INTERNAL_KEY_TYPE = "Internal Key";
+
     private static final Log log = LogFactory.getLog(InternalAPIKeyAuthenticator.class);
     private static final String DEV_PORTAL_TEST_ISSUER_PREFIX = "/api/am/devportal/v2/apis/test-key";
     private String securityParam;
@@ -335,7 +337,7 @@ public class InternalAPIKeyAuthenticator extends APIKeyHandler {
 
     @Override
     public String getName() {
-        return "Internal Key";
+        return INTERNAL_KEY_TYPE;
     }
 
     private String extractInternalKey(RequestContext requestContext) {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
@@ -82,6 +82,8 @@ import java.util.UUID;
  */
 public class JWTAuthenticator implements Authenticator {
 
+    public static final String JWT_AUTHENTICATOR_NAME = "JWT";
+
     private static final Logger log = LogManager.getLogger(JWTAuthenticator.class);
     private static final String SWAGGER_OAUTH2_SECURITY_SCHEME_NAME = "default";
     private final JWTValidator jwtValidator = new JWTValidator();
@@ -306,7 +308,7 @@ public class JWTAuthenticator implements Authenticator {
                                     ThreadContext.get(APIConstants.LOG_TRACE_ID));
                         }
                         // Skip scope validation for API Keys as scopes are not supported for API Keys.
-                        if(!APIKeyAuthenticator.AUTHENTICATOR_NAME.equals(this.getName())){
+                        if(!APIKeyAuthenticator.API_KEY_AUTHENTICATOR_NAME.equals(this.getName())){
                             validateScopes(context, version, matchingResource, validationInfo, signedJWTInfo);
                         }
 
@@ -504,7 +506,7 @@ public class JWTAuthenticator implements Authenticator {
 
     @Override
     public String getName() {
-        return "JWT";
+        return JWT_AUTHENTICATOR_NAME;
     }
 
     private String retrieveAuthHeaderValue(RequestContext requestContext) {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/JWTAuthenticator.java
@@ -305,7 +305,11 @@ public class JWTAuthenticator implements Authenticator {
                             Utils.setTag(validateScopesSpan, APIConstants.LOG_TRACE_ID,
                                     ThreadContext.get(APIConstants.LOG_TRACE_ID));
                         }
-                        validateScopes(context, version, matchingResource, validationInfo, signedJWTInfo);
+                        // Skip scope validation for API Keys as scopes are not supported for API Keys.
+                        if(!APIKeyAuthenticator.AUTHENTICATOR_NAME.equals(this.getName())){
+                            validateScopes(context, version, matchingResource, validationInfo, signedJWTInfo);
+                        }
+
                     } finally {
                         if (Utils.tracingEnabled()) {
                             validateScopesSpanScope.close();

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/UnsecuredAPIAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/jwt/UnsecuredAPIAuthenticator.java
@@ -40,6 +40,8 @@ import org.wso2.choreo.connect.enforcer.util.FilterUtils;
 
 public class UnsecuredAPIAuthenticator implements Authenticator {
 
+    public static final String UNSECURED_AUTHENTICATOR_NAME = "Unsecured";
+
     @Override
     public boolean canAuthenticate(RequestContext requestContext) {
         // Retrieve the disable security value. If security is disabled, then you can proceed directly with the
@@ -111,7 +113,7 @@ public class UnsecuredAPIAuthenticator implements Authenticator {
 
     @Override
     public String getName() {
-        return "Unsecured";
+        return UNSECURED_AUTHENTICATOR_NAME;
     }
 
     @Override public int getPriority() {

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/oauth/OAuthAuthenticator.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/security/oauth/OAuthAuthenticator.java
@@ -63,6 +63,9 @@ import java.util.Map;
  * //TODO: Complete the implementation.
  */
 public class OAuthAuthenticator implements Authenticator {
+
+    public static final String OAUTH_AUTHENTICATOR_NAME = "OAuth";
+
     private static final Log log = LogFactory.getLog(OAuthAuthenticator.class);
     private List<String> keyManagerList;
 
@@ -213,7 +216,7 @@ public class OAuthAuthenticator implements Authenticator {
 
     @Override
     public String getName() {
-        return "OAuth";
+        return OAUTH_AUTHENTICATOR_NAME;
     }
 
 


### PR DESCRIPTION
### Purpose
$subject

This pull request introduces a standardized approach to naming authenticators by defining and using static constants for authenticator names across the codebase. This change improves code maintainability and reduces the risk of inconsistencies or errors due to hardcoded strings. Additionally, scope validation logic is updated to skip API Key authenticators, ensuring correct authentication behavior.

**Standardization of Authenticator Names:**

* Added static constants for authenticator names in all authenticator classes (`JWTAuthenticator`, `APIKeyAuthenticator`, `APIKeyHandler`, `InternalAPIKeyAuthenticator`, `UnsecuredAPIAuthenticator`, and `OAuthAuthenticator`) and updated the `getName()` methods to use these constants instead of hardcoded strings. [[1]](diffhunk://#diff-de53b714b118fea8cc93f995cefa65d4edbb54dc569e5dbe8038bbfbf4a23ef3R50-R51) [[2]](diffhunk://#diff-de53b714b118fea8cc93f995cefa65d4edbb54dc569e5dbe8038bbfbf4a23ef3L174-R176) [[3]](diffhunk://#diff-661f23bae8b3a65e759fe3a21867c035be53ce938dbf1b653c7596e92d3eb1cbR49-R50) [[4]](diffhunk://#diff-661f23bae8b3a65e759fe3a21867c035be53ce938dbf1b653c7596e92d3eb1cbR265-R269) [[5]](diffhunk://#diff-1bfb6d2e1b0c035cc3b93ba7414bef54d2f2eb91482b577fea3a9a9a61879ff4R63-R64) [[6]](diffhunk://#diff-1bfb6d2e1b0c035cc3b93ba7414bef54d2f2eb91482b577fea3a9a9a61879ff4L338-R340) [[7]](diffhunk://#diff-d4662bee2ab4cf99a9361b828395a4688c016f056b469eb1e00db976792205f1R85-R86) [[8]](diffhunk://#diff-d4662bee2ab4cf99a9361b828395a4688c016f056b469eb1e00db976792205f1L503-R509) [[9]](diffhunk://#diff-5a740f80c0dc60a959657fb393de6484db388fbca6d4858c87db1cf674b5004aR43-R44) [[10]](diffhunk://#diff-5a740f80c0dc60a959657fb393de6484db388fbca6d4858c87db1cf674b5004aL114-R116) [[11]](diffhunk://#diff-03feb5229d00c32b0cc70f585fd129aa5c4ea688cad0c9db4e40bc98559d97bfR66-R68) [[12]](diffhunk://#diff-03feb5229d00c32b0cc70f585fd129aa5c4ea688cad0c9db4e40bc98559d97bfL216-R219)

* Updated the `Authenticator` interface documentation to specify that authenticator names must be unique across all authenticators.

**Authentication Logic Improvement:**

* Modified scope validation in `JWTAuthenticator` to skip scope checks for API Key authenticators, since API Keys do not support scopes.

Related: https://github.com/wso2-enterprise/choreo/issues/37014