### PR TITLE
Bump Go Version from 1.23.0 to 1.23.12

### DIFF
--- a/adapter/go.mod
+++ b/adapter/go.mod
@@ -1,6 +1,6 @@
 module github.com/wso2/product-microgateway/adapter
 
-go 1.23.0
+go 1.23.12
 
 toolchain go1.23.8
 


### PR DESCRIPTION
### Purpose
$subject is to mitigate [CVE-2025-47907](https://avd.aquasec.com/nvd/2025/cve-2025-47907/)

### Issues
N/A

Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
N/A

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
