### PR TITLE
Add environment name to the event properties

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/AnalyticsFilter.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/AnalyticsFilter.java
@@ -231,6 +231,8 @@ public class AnalyticsFilter {
                 requestContext.getMatchedAPI().getBasePath());
         requestContext.addMetadataToMap(MetadataConstants.DEPLOYMENT_TYPE,
                 requestContext.getMatchedAPI().getDeploymentType());
+        requestContext.addMetadataToMap(MetadataConstants.API_ENVIRONMENT_NAME,
+                requestContext.getMatchedAPI().getEnvironmentName());
 
         // Adding Gateway URL
         String gatewayUrl = requestContext.getHeaders().get(GATEWAY_URL);

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/ChoreoAnalyticsProvider.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/ChoreoAnalyticsProvider.java
@@ -238,8 +238,10 @@ public class ChoreoAnalyticsProvider implements AnalyticsDataProvider {
         Map<String, Value> fieldsMap = getFieldsMapFromLogEntry();
         String gwURL = getValueAsString(fieldsMap, MetadataConstants.GATEWAY_URL);
         String deploymentType = getValueAsString(fieldsMap, MetadataConstants.DEPLOYMENT_TYPE);
+        String environmentName = getValueAsString(fieldsMap, MetadataConstants.API_ENVIRONMENT_NAME);
         map.put(AnalyticsConstants.GATEWAY_URL, gwURL);
         map.put(AnalyticsConstants.DEPLOYMENT_TYPE, deploymentType);
+        map.put(AnalyticsConstants.ENVIRONMENT_NAME, environmentName);
         return map;
     }
 

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/ChoreoFaultAnalyticsProvider.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/ChoreoFaultAnalyticsProvider.java
@@ -216,8 +216,10 @@ public class ChoreoFaultAnalyticsProvider implements AnalyticsDataProvider {
         Map map = new HashMap();
         String gwURL = requestContext.getHeaders().get(AnalyticsConstants.GATEWAY_URL);
         String deploymentType = requestContext.getMatchedAPI().getDeploymentType();
+        String environmentName = requestContext.getMatchedAPI().getEnvironmentName();
         map.put(AnalyticsConstants.GATEWAY_URL, gwURL);
         map.put(AnalyticsConstants.DEPLOYMENT_TYPE, deploymentType);
+        map.put(AnalyticsConstants.ENVIRONMENT_NAME, environmentName);
         map.put(AnalyticsConstants.API_METHOD, requestContext.getRequestMethod());
         return map;
     }

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/AnalyticsConstants.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/AnalyticsConstants.java
@@ -42,6 +42,7 @@ public class AnalyticsConstants {
     public static final String GATEWAY_URL = "x-original-gw-url";
     public static final String DEPLOYMENT_TYPE = "deployment-type";
     public static final String API_METHOD = "apiMethod";
+    public static final String ENVIRONMENT_NAME = "environmentName";
 
     public static final int API_THROTTLE_OUT_ERROR_CODE = 900800;
     public static final int HARD_LIMIT_EXCEEDED_ERROR_CODE = 900801;

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/MetadataConstants.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/constants/MetadataConstants.java
@@ -44,6 +44,7 @@ public class MetadataConstants {
     public static final String API_ORGANIZATION_ID = WSO2_METADATA_PREFIX + "api-organization-id";
     public static final String API_ENVIRONMENT_ID = WSO2_METADATA_PREFIX + "api-environment-id";
     public static final String CHOREO_ENVIRONMENT_ID = WSO2_METADATA_PREFIX + "choreo-environment-id";
+    public static final String API_ENVIRONMENT_NAME = WSO2_METADATA_PREFIX + "api-environment-name";
 
     public static final String APP_ID_KEY = WSO2_METADATA_PREFIX + "application-id";
     public static final String APP_UUID_KEY = WSO2_METADATA_PREFIX + "application-uuid";

--- a/pom.xml
+++ b/pom.xml
@@ -680,7 +680,7 @@
         <apictl.version>4.0.0</apictl.version>
         <apim.version>4.0.0</apim.version>
         <grpc.healthProbe.version>0.4.45</grpc.healthProbe.version>
-        <analytics.publisher.client.version>1.2.17.9</analytics.publisher.client.version>
+        <analytics.publisher.client.version>1.2.17.10</analytics.publisher.client.version>
         <awaitility.version>4.2.0</awaitility.version>
         <apache.httpcomponents.version>4.5.14</apache.httpcomponents.version>
         <jackson.databind.version>2.15.0</jackson.databind.version>


### PR DESCRIPTION
This pull request enhances the analytics metadata captured in the enforcer by introducing support for the API environment name. The changes ensure that the environment name is consistently added to analytics logs and metadata, improving traceability and filtering capabilities for API events.

**Addition of API environment name metadata:**

* Added `API_ENVIRONMENT_NAME` constant to `MetadataConstants` and ensured it is included in metadata for each request in `AnalyticsFilter.java`. [[1]](diffhunk://#diff-1acd1f4e775a6eb7ff8e694be1d799c29cd6834f634cd0d377b177e1d7cf15d2R47) [[2]](diffhunk://#diff-2988c4b45aba952a6a37096dfd0bfc304b975ea8b90fcf32f506ed4a63428f9cR234-R235)
* Added `ENVIRONMENT_NAME` constant to `AnalyticsConstants` and ensured it is included in analytics properties for both regular and fault analytics providers (`ChoreoAnalyticsProvider.java`, `ChoreoFaultAnalyticsProvider.java`). [[1]](diffhunk://#diff-785357b19dc66e5e788b49ac284eca9038653c1789ce009bb82e45c014c01a5bR45) [[2]](diffhunk://#diff-3545aa6f67f997f66cf11640b08d85106fae7e94dceae9cf30456f132b671e75R241-R244) [[3]](diffhunk://#diff-c659d4ec3f976671b70af377bff9712fd45de0276924cc60e0992cf3ae834139R219-R222)### Purpose