### PR TITLE
Fix WebSocket API custom domain invocation returning 403

### DIFF
--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/APIFactory.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/APIFactory.java
@@ -70,8 +70,10 @@ public class APIFactory {
         ConcurrentHashMap<String, API> newApis = new ConcurrentHashMap<>();
 
         for (Api api : apis) {
-            // TODO: Refactor duplicate vhost registration code to avoid code duplication between WebSocket and REST API branches.
+            // TODO: Refactor duplicate vhost registration to a shared method
+            //  to avoid code duplication between WebSocket and REST branches.
             if (APIConstants.ApiType.WEB_SOCKET.equals(api.getApiType())) {
+                logger.info("Processing WebSocket API: {}", api.getId());
                 WebSocketAPI webSocketAPI = new WebSocketAPI();
                 webSocketAPI.init(api);
                 String apiKey = getApiKey(webSocketAPI);
@@ -79,6 +81,8 @@ public class APIFactory {
                 if ((EnvVarConfig.getInstance().isDuplicateVhostEnabled() &&
                         KNOWN_VHOST_PREFIXES.contains(api.getVhost().split("\\.")[0])) ||
                         (EnvVarConfig.getInstance().isDuplicateVhostEnabledPdp())) {
+                    logger.info("Registering duplicate vhost for WebSocket API: {} with vhost: {}",
+                            api.getId(), api.getVhost());
                     newApis.put(getApiKeyWithOrgId(webSocketAPI), webSocketAPI);
                     if (api.getVhost().startsWith("sandbox.")) {
                         String duplicatedVhostProd =

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/APIFactory.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/api/APIFactory.java
@@ -70,11 +70,26 @@ public class APIFactory {
         ConcurrentHashMap<String, API> newApis = new ConcurrentHashMap<>();
 
         for (Api api : apis) {
+            // TODO: Refactor duplicate vhost registration code to avoid code duplication between WebSocket and REST API branches.
             if (APIConstants.ApiType.WEB_SOCKET.equals(api.getApiType())) {
                 WebSocketAPI webSocketAPI = new WebSocketAPI();
                 webSocketAPI.init(api);
                 String apiKey = getApiKey(webSocketAPI);
                 newApis.put(apiKey, webSocketAPI);
+                if ((EnvVarConfig.getInstance().isDuplicateVhostEnabled() &&
+                        KNOWN_VHOST_PREFIXES.contains(api.getVhost().split("\\.")[0])) ||
+                        (EnvVarConfig.getInstance().isDuplicateVhostEnabledPdp())) {
+                    newApis.put(getApiKeyWithOrgId(webSocketAPI), webSocketAPI);
+                    if (api.getVhost().startsWith("sandbox.")) {
+                        String duplicatedVhostProd =
+                                api.getVhost().replaceFirst("sandbox\\.", "prod-sandbox.");
+                        newApis.put(getApiKeyWithOrgId(webSocketAPI, duplicatedVhostProd), webSocketAPI);
+                    } else if (api.getVhost().startsWith("sandbox_dev.")) {
+                        String duplicatedVhostDev =
+                                api.getVhost().replaceFirst("sandbox_dev\\.", "dev-sandbox.");
+                        newApis.put(getApiKeyWithOrgId(webSocketAPI, duplicatedVhostDev), webSocketAPI);
+                    }
+                }
             } else {
                 RestAPI enforcerApi = new RestAPI();
                 enforcerApi.init(api);


### PR DESCRIPTION
### Purpose
  - WebSocket API invocations fail with 403 when custom domains are applied,
    while REST APIs with custom domains work fine
  - Root cause: In `APIFactory.addApis()`, the duplicate vhost key registration
    (needed for custom domain routing) was only inside the REST API branch,
    skipping WebSocket APIs entirely
  - Fix: Add the same duplicate vhost registration to the WebSocket API branch

