### PR TITLE
Add @JsonIgnoreProperties to DTOs for APIM 4.7.0 compatibility

### DIFF
--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/APIInfoAdditionalPropertiesDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/APIInfoAdditionalPropertiesDTO.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.apimgt.gateway.cli.model.rest.apim4x;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -26,6 +27,7 @@ import java.util.Objects;
 /**
  * DTO for API Info additional properties
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class APIInfoAdditionalPropertiesDTO {
   
     private String name = null;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/APIInfoAdditionalPropertiesMapDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/APIInfoAdditionalPropertiesMapDTO.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.apimgt.gateway.cli.model.rest.apim4x;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -26,6 +27,7 @@ import java.util.Objects;
 /**
  * DTO for API Info additional properties map
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class APIInfoAdditionalPropertiesMapDTO {
   
     private String name = null;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/APIMonetizationInfoDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/APIMonetizationInfoDTO.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.apimgt.gateway.cli.model.rest.apim4x;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -29,6 +30,7 @@ import javax.validation.constraints.NotNull;
 /**
  * DTO for Monetization information
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class APIMonetizationInfoDTO {
   
     private Boolean enabled = null;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/APIOperationPoliciesDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/APIOperationPoliciesDTO.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.apimgt.gateway.cli.model.rest.apim4x;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -29,6 +30,7 @@ import javax.validation.Valid;
 /**
  * DTO for API Operation Policies
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class APIOperationPoliciesDTO {
   
     private List<OperationPolicyDTO> request = new ArrayList<OperationPolicyDTO>();

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/APIOperationsDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/APIOperationsDTO.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.apimgt.gateway.cli.model.rest.apim4x;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -30,6 +31,7 @@ import javax.validation.Valid;
  * DTO for API Operations/Resources
  */
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class APIOperationsDTO   {
   
     private String id = null;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/APIScopeDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/APIScopeDTO.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.apimgt.gateway.cli.model.rest.apim4x;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -28,6 +29,7 @@ import javax.validation.constraints.NotNull;
 /**
  * DTO for API bound scopes
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class APIScopeDTO   {
   
     private ScopeDTO scope = null;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/APIServiceInfoDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/APIServiceInfoDTO.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.apimgt.gateway.cli.model.rest.apim4x;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -26,6 +27,7 @@ import java.util.Objects;
 /**
  * DTO for API Service information from service catalog
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class APIServiceInfoDTO {
   
     private String key = null;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/APIThreatProtectionPoliciesDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/APIThreatProtectionPoliciesDTO.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.apimgt.gateway.cli.model.rest.apim4x;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -29,6 +30,7 @@ import javax.validation.Valid;
 /**
  * DTO for API Threat Protection Policies
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class APIThreatProtectionPoliciesDTO {
   
     private List<APIThreatProtectionPoliciesListDTO> list = new ArrayList<APIThreatProtectionPoliciesListDTO>();

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/APIThreatProtectionPoliciesListDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/APIThreatProtectionPoliciesListDTO.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.apimgt.gateway.cli.model.rest.apim4x;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -26,6 +27,7 @@ import java.util.Objects;
 /**
  * DTO for API Threat Protection Policies List
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class APIThreatProtectionPoliciesListDTO {
   
     private String policyId = null;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/AdvertiseInfoDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/AdvertiseInfoDTO.java
@@ -18,6 +18,7 @@
 package org.wso2.apimgt.gateway.cli.model.rest.apim4x;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -29,6 +30,7 @@ import javax.xml.bind.annotation.XmlType;
 /**
  * DTO for Third party API information
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AdvertiseInfoDTO {
   
     private Boolean advertised = null;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/MediationPolicyDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/MediationPolicyDTO.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.apimgt.gateway.cli.model.rest.apim4x;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -27,6 +28,7 @@ import javax.validation.constraints.NotNull;
 /**
  * DTO for Mediation Policy
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class MediationPolicyDTO {
   
     private String id = null;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/OperationPolicyDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/OperationPolicyDTO.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.apimgt.gateway.cli.model.rest.apim4x;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -29,6 +30,7 @@ import javax.validation.constraints.NotNull;
 /**
  * DTO for Operation Policy
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OperationPolicyDTO {
   
     private String policyName = null;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/ScopeDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/ScopeDTO.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.apimgt.gateway.cli.model.rest.apim4x;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -30,6 +31,7 @@ import javax.validation.constraints.Size;
 /**
  * DTO for Scopes
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ScopeDTO {
   
     private String id = null;

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/WSDLInfoDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/WSDLInfoDTO.java
@@ -18,6 +18,7 @@
 package org.wso2.apimgt.gateway.cli.model.rest.apim4x;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -29,6 +30,7 @@ import javax.xml.bind.annotation.XmlType;
 /**
  * DTO for WSDL Information
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class WSDLInfoDTO {
 
     /**

--- a/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/WebsubSubscriptionConfigurationDTO.java
+++ b/components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/WebsubSubscriptionConfigurationDTO.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.apimgt.gateway.cli.model.rest.apim4x;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -26,6 +27,7 @@ import java.util.Objects;
 /**
  * DTO for Web-Sub Subscription Configurations
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class WebsubSubscriptionConfigurationDTO {
   
     private Boolean enable = false;


### PR DESCRIPTION
## Summary
- Fixes https://github.com/wso2/api-manager/issues/4841
- MGW 3.2.0 `micro gw import` fails against APIM 4.7.0 because the Publisher API response contains new fields (`audiences`, `organizationPolicies`, `operationHubPolicies`, `vendor`, `apiOwner`, etc.) that MGW DTO classes don't recognize, causing Jackson `UnrecognizedPropertyException`.
- Added `@JsonIgnoreProperties(ignoreUnknown = true)` to 15 DTO classes in `org.wso2.apimgt.gateway.cli.model.rest.apim4x` package to ensure forward compatibility with newer APIM versions.

## Affected Files
All in `components/micro-gateway-cli/src/main/java/org/wso2/apimgt/gateway/cli/model/rest/apim4x/`:
- `APIOperationsDTO.java`
- `APIOperationPoliciesDTO.java`
- `OperationPolicyDTO.java`
- `APIScopeDTO.java`
- `ScopeDTO.java`
- `MediationPolicyDTO.java`
- `APIServiceInfoDTO.java`
- `APIThreatProtectionPoliciesDTO.java`
- `APIThreatProtectionPoliciesListDTO.java`
- `APIInfoAdditionalPropertiesDTO.java`
- `APIInfoAdditionalPropertiesMapDTO.java`
- `APIMonetizationInfoDTO.java`
- `WSDLInfoDTO.java`
- `WebsubSubscriptionConfigurationDTO.java`
- `AdvertiseInfoDTO.java`

## Test plan
- [x] Module builds successfully (`mvn clean install -Dmaven.test.skip=true`)
- [x] Runtime deserialization test confirms all 15 DTOs handle unknown fields without errors
- [x] Verified `@JsonIgnoreProperties` overrides even global `FAIL_ON_UNKNOWN_PROPERTIES=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)