### PR TITLE
Fix GraphQL API traffic showing as REST in Moesif analytics

### DIFF
--- a/adapter/internal/oasparser/model/open_api.go
+++ b/adapter/internal/oasparser/model/open_api.go
@@ -79,10 +79,10 @@ func (swagger *MgwSwagger) SetInfoOpenAPI(swagger3 openapi3.Swagger) error {
 		return err
 	}
 
-	if swagger.apiType != MCP {
+	if swagger.apiType != MCP && swagger.apiType != GRAPHQL {
 		swagger.apiType = HTTP
 	} else {
-		logger.LoggerOasparser.Info("Received swagger for MCP API")
+		logger.LoggerOasparser.Infof("Received swagger for %s API", swagger.apiType)
 	}
 	var productionUrls []Endpoint
 	// For prototyped APIs, the prototype endpoint is only assinged from api.Yaml. Hence,

--- a/adapter/internal/oasparser/model/types.go
+++ b/adapter/internal/oasparser/model/types.go
@@ -290,7 +290,7 @@ func (apiProject *ProjectAPI) ProcessFilesInsideProject(fileContent []byte, file
 			return conversionErr
 		}
 		apiProject.APIDefinition = swaggerJsn
-		if !(apiProject.APIType == MCP) {
+		if !(apiProject.APIType == MCP || apiProject.APIType == GRAPHQL) {
 			apiProject.APIType = HTTP
 			if strings.Contains(fileName, openAPIDir+string(os.PathSeparator)+asyncAPIFilename) {
 				apiProject.APIType = WS


### PR DESCRIPTION
### Purpose
This PR preserves the `GRAPHQL` type through both processing stages, the same way MCP is already handled.

### Issues
https://github.com/wso2-enterprise/apim-saas/issues/2539

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [x] Assigned 'Type' label
- [x] Assigned the project
- [x] Validated respective github issues
- [x] Assigned milestone to the github issue(s)
