### PR TITLE
Fix environment ID missing issue in EU

### DIFF
--- a/adapter/internal/discovery/xds/server.go
+++ b/adapter/internal/discovery/xds/server.go
@@ -360,7 +360,11 @@ func UpdateAPI(vHost string, apiProject mgw.ProjectAPI, deployedEnvironments []*
 	// Number of environments will always be 1 in Choreo
 	mgwSwagger.DeploymentType = deployedEnvironments[0].DeploymentType
 	mgwSwagger.APIProvider = apiProject.APIYaml.Data.Provider
-	mgwSwagger.EnvironmentID = deployedEnvironments[0].ID
+	if deployedEnvironments[0].ID != "" {
+		mgwSwagger.EnvironmentID = deployedEnvironments[0].ID
+	} else {
+		mgwSwagger.EnvironmentID = conf.ControlPlane.DynamicEnvironments.DataPlaneID
+	}
 	mgwSwagger.ChoreoEnvironmentID = deployedEnvironments[0].ChoreoEnvironmentID
 	mgwSwagger.EnvironmentName = deployedEnvironments[0].Name
 

--- a/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/ChoreoFaultAnalyticsProvider.java
+++ b/enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/ChoreoFaultAnalyticsProvider.java
@@ -107,7 +107,8 @@ public class ChoreoFaultAnalyticsProvider implements AnalyticsDataProvider {
         api.setApiVersion(requestContext.getMatchedAPI().getVersion());
         api.setApiCreatorTenantDomain(APIConstants.SUPER_TENANT_DOMAIN_NAME);
         api.setOrganizationId(requestContext.getMatchedAPI().getOrganizationId());
-        api.setEnvironmentId(requestContext.getMatchedAPI().getEnvironmentId());
+        String envId = requestContext.getMatchedAPI().getEnvironmentId();
+        api.setEnvironmentId(envId == null ? APIConstants.DEFAULT_ENVIRONMENT_NAME : envId);
         api.setApiContext(requestContext.getMatchedAPI().getBasePath());
         return api;
     }


### PR DESCRIPTION
This pull request introduces improvements to how environment IDs are handled in both the Go backend and Java analytics provider. The changes ensure that the correct environment ID is always set, even when the value is missing, by providing appropriate fallbacks.

**Environment ID Handling Improvements:**

* In `adapter/internal/discovery/xds/server.go`, the `UpdateAPI` function now assigns `mgwSwagger.EnvironmentID` to the environment's ID if present, or falls back to `conf.ControlPlane.DynamicEnvironments.DataPlaneID` if the ID is missing.
* In `enforcer-parent/enforcer/src/main/java/org/wso2/choreo/connect/enforcer/analytics/ChoreoFaultAnalyticsProvider.java`, the `getApi()` method now sets the API's environment ID to the default environment name if the matched API's environment ID is `null`.### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

### Automation tests
 - Unit tests added: Yes/No
 - Integration tests added: Yes/No

### Tested environments
<!-- Specify the environments you used to test this PR. OS, DB, JDK version, etc... -->
Not Tested

---
#### Maintainers: Check before merge
- [ ] Assigned 'Type' label
- [ ] Assigned the project
- [ ] Validated respective github issues
- [ ] Assigned milestone to the github issue(s)
